### PR TITLE
Move where(scheduled_at: Time.current) into dynamic part of GoodJob::Job::Performer

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -36,11 +36,11 @@ module GoodJob
         ENV['GOOD_JOB_POLL_INTERVAL']
       ).to_i
 
-      job_query = GoodJob::Job.all
+      job_query = GoodJob::Job.all.priority_ordered
       queue_names_without_all = queue_names.reject { |q| q == '*' }
       job_query = job_query.where(queue_name: queue_names_without_all) unless queue_names_without_all.size.zero?
 
-      job_performer = job_query.only_scheduled.priority_ordered.to_performer
+      job_performer = job_query.to_performer
 
       $stdout.puts "GoodJob worker starting with max_threads=#{max_threads} on queues=#{queue_names.join(',')}"
 

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -19,7 +19,7 @@ module GoodJob
       def next
         good_job = nil
 
-        @query.limit(1).with_advisory_lock do |good_jobs|
+        @query.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
           good_job = good_jobs.first
           break unless good_job
 

--- a/spec/good_job/job_spec.rb
+++ b/spec/good_job/job_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe GoodJob::Job do
       expect { job_1.reload }.to raise_error ActiveRecord::RecordNotFound
       expect { job_2.reload }.to raise_error ActiveRecord::RecordNotFound
     end
+
+    it 'sets scheduled_at condition dynamically' do
+      allow_any_instance_of(described_class).to receive(:perform), &:destroy!
+      job = described_class.create!(scheduled_at: 12.hours.from_now)
+      performer = described_class.to_performer
+
+      performer.next
+      expect { job.reload }.not_to raise_error
+
+      travel 1.day do
+        performer.next
+        expect { job.reload }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe 'lockable' do


### PR DESCRIPTION
Fixes a bug with jobs created after the scheduler instantiation not being performed because Time.current is cached