### PR TITLE
Change threadpool idletime default to 60 seconds from 0

### DIFF
--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -15,7 +15,7 @@ module GoodJob
       min_threads: 0,
       max_threads: Concurrent.processor_count,
       auto_terminate: true,
-      idletime: 0,
+      idletime: 60,
       max_queue: 0,
       fallback_policy: :abort, # shouldn't matter -- 0 max queue
     }.freeze


### PR DESCRIPTION
60 seconds is the same default as [AsyncAdapter](https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activejob/lib/active_job/queue_adapters/async_adapter.rb#L79). Originally my goal was to try to get every job to run on a fresh thread, but that didn't seem to actually be the case. 

I hope also that this will reduce the incidence of `ThreadError: can't create Thread: Resource temporarily unavailable`.