### PR TITLE
Update the setup documentation to use correct bin setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To run tests:
 $ git clone git@github.com:bensheldon/good_job.git
 
 # Set up the local environment
-$ bin/setup_test
+$ bin/setup
 
 # Run the tests
 $ bin/rspec


### PR DESCRIPTION
## Feature
_(Short summary of changes)_
Small update to the readme so advise running `bin/setup` as opposed to `bin/setup_test`. If it's preferred we could keep the documentation the same and add the `bin/setup_test` script to handle just setting up the test env.

### Checklist
- [x] All existing tests passing