### PR TITLE
Explicitly require thread_mattr_accessor from ActiveSupport

### DIFF
--- a/lib/good_job/current_execution.rb
+++ b/lib/good_job/current_execution.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/attribute_accessors_per_thread'
+
 module GoodJob
   # Thread-local attributes for passing values from Instrumentation.
   # (Cannot use ActiveSupport::CurrentAttributes because ActiveJob resets it)


### PR DESCRIPTION
Closes #85 