### PR TITLE
Name the thread pools

### DIFF
--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -7,6 +7,7 @@ module GoodJob # :nodoc:
   class Notifier
     CHANNEL = 'good_job'.freeze
     POOL_OPTIONS = {
+      name: name,
       min_threads: 0,
       max_threads: 1,
       auto_terminate: true,

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -21,6 +21,7 @@ module GoodJob # :nodoc:
 
     # Defaults for instance of Concurrent::ThreadPoolExecutor
     DEFAULT_POOL_OPTIONS = {
+      name: name,
       min_threads: 0,
       max_threads: Concurrent.processor_count,
       auto_terminate: true,


### PR DESCRIPTION
Before, threads had names like "worker-1" in `Thread.list` and friends, and `Notifier` could not be differentiated from `Scheduler`, or other concurrent-ruby `ThreadPoolExecutor` instances:

```
  Thread #<Thread:0x00007fee3fc4d418@worker-1 /usr/local/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/concurrent-ruby-1.1.7/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:332 sleep> status=sleep priority=0
      /usr/local/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/good_job-1.2.1/lib/good_job/notifier.rb:93:in `wait_for_notify'
```

Now, the class name is used as a default thread pool name, which is prefixes to worker names:

```
  Thread #<Thread:0x00007fee3fc4d418@GoodJob::Notifier-worker-1 /usr/local/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/concurrent-ruby-1.1.7/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:332 sleep> status=sleep priority=0
      /usr/local/rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/good_job-1.2.1/lib/good_job/notifier.rb:93:in `wait_for_notify'
```