### PR TITLE
Remove executor/reloader for less interlocking

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -56,11 +56,13 @@ module GoodJob
       result = nil
       error = nil
 
-      unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
-        good_job = good_jobs.first
-        break unless good_job
+      Rails.application.executor.wrap do
+        unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
+          good_job = good_jobs.first
+          break unless good_job
 
-        result, error = good_job.perform
+          result, error = good_job.perform
+        end
       end
 
       [good_job, result, error] if good_job

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -56,7 +56,7 @@ module GoodJob
       result = nil
       error = nil
 
-      Rails.application.executor.wrap do
+      connection_pool.with_connection do
         unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
           good_job = good_jobs.first
           break unless good_job

--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -70,36 +70,37 @@ module GoodJob # :nodoc:
     def listen
       future = Concurrent::Future.new(args: [@recipients, @pool, @listening], executor: @pool) do |recipients, pool, listening|
         Rails.application.reloader.wrap do
-          conn = ActiveRecord::Base.connection.raw_connection
-          ActiveSupport::Notifications.instrument("notifier_listen.good_job") do
-            conn.async_exec "LISTEN #{CHANNEL}"
-          end
-
-          begin
-            ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              while pool.running?
-                listening.make_true
-                conn.wait_for_notify(WAIT_INTERVAL) do |channel, _pid, payload|
-                  listening.make_false
-                  next unless channel == CHANNEL
-
-                  ActiveSupport::Notifications.instrument("notifier_notified.good_job", { payload: payload })
-                  parsed_payload = JSON.parse(payload, symbolize_names: true)
-                  recipients.each do |recipient|
-                    target, method_name = recipient.is_a?(Array) ? recipient : [recipient, :call]
-                    target.send(method_name, parsed_payload)
-                  end
-                end
-                listening.make_false
-              end
+          with_listen_connection do |conn|
+            ActiveSupport::Notifications.instrument("notifier_listen.good_job") do
+              conn.async_exec "LISTEN #{CHANNEL}"
             end
-          rescue StandardError => e
-            ActiveSupport::Notifications.instrument("notifier_notify_error.good_job", { error: e })
-            raise
-          ensure
-            @listening.make_false
-            ActiveSupport::Notifications.instrument("notifier_unlisten.good_job") do
-              conn.async_exec "UNLISTEN *"
+
+            begin
+              ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
+                while pool.running?
+                  listening.make_true
+                  conn.wait_for_notify(WAIT_INTERVAL) do |channel, _pid, payload|
+                    listening.make_false
+                    next unless channel == CHANNEL
+
+                    ActiveSupport::Notifications.instrument("notifier_notified.good_job", { payload: payload })
+                    parsed_payload = JSON.parse(payload, symbolize_names: true)
+                    recipients.each do |recipient|
+                      target, method_name = recipient.is_a?(Array) ? recipient : [recipient, :call]
+                      target.send(method_name, parsed_payload)
+                    end
+                  end
+                  listening.make_false
+                end
+              end
+            rescue StandardError => e
+              ActiveSupport::Notifications.instrument("notifier_notify_error.good_job", { error: e })
+              raise
+            ensure
+              @listening.make_false
+              ActiveSupport::Notifications.instrument("notifier_unlisten.good_job") do
+                conn.async_exec "UNLISTEN *"
+              end
             end
           end
         end
@@ -111,6 +112,17 @@ module GoodJob # :nodoc:
 
     def listen_observer(_time, _result, _thread_error)
       listen unless shutdown?
+    end
+
+    def with_listen_connection
+      ar_conn = ActiveRecord::Base.connection_pool.checkout.tap do |conn|
+        ActiveRecord::Base.connection_pool.remove(conn)
+      end
+      pg_conn = ar_conn.raw_connection
+      pg_conn.exec("SET application_name = #{pg_conn.escape_identifier(self.class.name)}")
+      yield pg_conn
+    ensure
+      ar_conn.disconnect!
     end
   end
 end

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -137,7 +137,7 @@ module GoodJob # :nodoc:
         return false unless @performer.next?(state)
       end
 
-      future = Concurrent::Future.new(args: [@performer], executor: @pool, &:next)
+      future = Concurrent::Future.new(executor: @pool, &@performer.method(:next))
       future.add_observer(self, :task_observer)
       future.execute
 

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -137,9 +137,7 @@ module GoodJob # :nodoc:
         return false unless @performer.next?(state)
       end
 
-      future = Concurrent::Future.new(args: [@performer], executor: @pool) do |performer|
-        performer.next
-      end
+      future = Concurrent::Future.new(args: [@performer], executor: @pool, &:next)
       future.add_observer(self, :task_observer)
       future.execute
 

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -138,9 +138,7 @@ module GoodJob # :nodoc:
       end
 
       future = Concurrent::Future.new(args: [@performer], executor: @pool) do |performer|
-        output = nil
-        Rails.application.executor.wrap { output = performer.next }
-        output
+        performer.next
       end
       future.add_observer(self, :task_observer)
       future.execute


### PR DESCRIPTION
I believe this will fix a bunch of dependency interlocking issues. The only thing good_job needs from the executor and/or reloader is activerecord connection management, and considering how tightly intertwined with activerecord it is, it's very reasonable to own the connection management in the same way [actioncable does](https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/subscription_adapter/postgresql.rb).

ActiveJob takes care of the interface to user rails code which requires reloading, and makes sure the executor wraps user code in the right places:
https://github.com/rails/rails/blob/acaa546026471354ae1ff15e96c6bf5d39b0e34a/activejob/lib/active_job/railtie.rb#L39-L47

The only reason Sidekiq etc have to get involved with the executor is because they execute user code outside of ActiveJob.

Fixes #95