### PR TITLE
Fix Ruby 2.7 keyword arguments warning

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -9,10 +9,12 @@ module GoodJob
       end
 
       configuration = GoodJob::Configuration.new(
-        execution_mode: execution_mode,
-        queues: queues,
-        max_threads: max_threads,
-        poll_interval: poll_interval
+        {
+          execution_mode: execution_mode,
+          queues: queues,
+          max_threads: max_threads,
+          poll_interval: poll_interval,
+        }
       )
 
       @execution_mode = configuration.execution_mode


### PR DESCRIPTION
Fixes https://github.com/bensheldon/good_job/issues/93