### PR TITLE
Return to using executor.wrap around Scheduler execution task

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -56,20 +56,12 @@ module GoodJob
       result = nil
       error = nil
 
-      connection_pool.with_connection do
-        unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
-          good_job = good_jobs.first
-          break unless good_job
+      unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
+        good_job = good_jobs.first
+        # TODO: Determine why some records are fetched without an advisory lock at all
+        break unless good_job&.owns_advisory_lock?
 
-          # TODO: Determine why some records are fetched without an advisory lock at all
-          if good_job.advisory_locked? && !good_job.owns_advisory_lock?
-            puts "LOCKED BUT DOES NOT OWN LOCK"
-          elsif !good_job.advisory_locked?
-            puts "TOTALLY UNLOCKED"
-          end
-
-          result, error = good_job.perform
-        end
+        result, error = good_job.perform
       end
 
       [good_job, result, error] if good_job

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -61,6 +61,13 @@ module GoodJob
           good_job = good_jobs.first
           break unless good_job
 
+          # TODO: Determine why some records are fetched without an advisory lock at all
+          if good_job.advisory_locked? && !good_job.owns_advisory_lock?
+            puts "LOCKED BUT DOES NOT OWN LOCK"
+          elsif !good_job.advisory_locked?
+            puts "TOTALLY UNLOCKED"
+          end
+
           result, error = good_job.perform
         end
       end

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -138,7 +138,11 @@ module GoodJob # :nodoc:
         return false unless @performer.next?(state)
       end
 
-      future = Concurrent::Future.new(executor: @pool, &@performer.method(:next))
+      future = Concurrent::Future.new(args: [@performer], executor: @pool) do |performer|
+        output = nil
+        Rails.application.executor.wrap { output = performer.next }
+        output
+      end
       future.add_observer(self, :task_observer)
       future.execute
 

--- a/spec/integration/scheduler_spec.rb
+++ b/spec/integration/scheduler_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Schedule Integration' do
   let(:adapter) { GoodJob::Adapter.new }
 
   context 'when there are a large number of jobs' do
-    let(:number_of_jobs) { 250 }
+    let(:number_of_jobs) { 500 }
 
     let!(:good_jobs) do
       number_of_jobs.times do |i|
@@ -53,7 +53,7 @@ RSpec.describe 'Schedule Integration' do
       performer = GoodJob::Performer.new(GoodJob::Job.all, :perform_with_advisory_lock)
       scheduler = GoodJob::Scheduler.new(performer)
 
-      sleep_until(max: 5, increments_of: 0.5) { GoodJob::Job.count == 0 }
+      sleep_until(max: 10, increments_of: 0.5) { GoodJob::Job.count == 0 }
 
       rerun_jobs = {}
 

--- a/spec/integration/scheduler_spec.rb
+++ b/spec/integration/scheduler_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Schedule Integration' do
   let(:adapter) { GoodJob::Adapter.new }
 
   context 'when there are a large number of jobs' do
-    let(:number_of_jobs) { 500 }
+    let(:number_of_jobs) { 1000 }
 
     let!(:good_jobs) do
       number_of_jobs.times do |i|
@@ -53,7 +53,7 @@ RSpec.describe 'Schedule Integration' do
       performer = GoodJob::Performer.new(GoodJob::Job.all, :perform_with_advisory_lock)
       scheduler = GoodJob::Scheduler.new(performer)
 
-      sleep_until(max: 10, increments_of: 0.5) { GoodJob::Job.count == 0 }
+      sleep_until(max: 20, increments_of: 0.5) { GoodJob::Job.count == 0 }
 
       rerun_jobs = {}
 

--- a/spec/support/sleep_helper.rb
+++ b/spec/support/sleep_helper.rb
@@ -1,12 +1,19 @@
 module SleepHelper
+  TooSlowError = Class.new(StandardError)
+
   def sleep_until(max: 5, increments_of: 0.1)
     so_many = (max.to_f / increments_of).ceil.to_i
 
-    so_many.times do
-      break if yield
+    finished = catch(:finished) do
+      so_many.times do
+        throw(:finished, true) if yield
 
-      sleep increments_of
+        sleep increments_of
+      end
+      false
     end
+
+    raise TooSlowError unless finished
   end
 end
 

--- a/spec/test_app/config/puma.rb
+++ b/spec/test_app/config/puma.rb
@@ -35,20 +35,20 @@ workers ENV.fetch("WEB_CONCURRENCY") { 0 }
 preload_app! if ENV["PRELOAD_APP"]
 
 before_fork do
-  GoodJob::Scheduler.instances.each { |s| s.shutdown }
+  GoodJob.shutdown
 end
 
 on_worker_boot do
-  GoodJob::Scheduler.instances.each { |s| s.restart }
+  GoodJob.restart
 end
 
 on_worker_shutdown do
-  GoodJob::Scheduler.instances.each { |s| s.shutdown }
+  GoodJob.shutdown
 end
 
 MAIN_PID = Process.pid
 at_exit do
-  GoodJob::Scheduler.instances.each { |s| s.shutdown } if Process.pid == MAIN_PID
+  GoodJob.shutdown if Process.pid == MAIN_PID
 end
 
 # Allow puma to be restarted by `rails restart` command.


### PR DESCRIPTION
@sj26 I'm seeing some behavior indicating that #97 is losing advisory locks. Would you be able to take a look? 

It looks similar to what's described here: https://github.com/rails/rails/issues/26956#issuecomment-258059971

> Off the top of my head, the most potentially-surprising outcome I'd anticipate is that `executor.wrap` inside `with_connection` would cause the connection to be returned early

...at least, that's my hypothesis given that the Advisory Locks are connection-based, implying that the connection taking the advisory lock is a different connection than the one trying to release it (the `WARNING:  you don't own a lock of type ExclusiveLock`).

```bash
$ bin/rspec spec/integration/scheduler_spec.rb

Randomized with seed 533
.WARNING:  you don't own a lock of type ExclusiveLock
WARNING:  you don't own a lock of type ExclusiveLock
WARNING:  you don't own a lock of type ExclusiveLock
WARNING:  you don't own a lock of type ExclusiveLock
F

Failures:

  1) Schedule Integration when there are a large number of jobs pops items off of the queue and runs them
     Failure/Error: expect(RUN_JOBS.size).to eq number_of_jobs

       expected: 500
            got: 501

       (compared using ==)
     # ./spec/integration/scheduler_spec.rb:80:in `block (3 levels) in <top (required)>'
     # ./spec/support/reset_rails_queue_adapter.rb:4:in `block (2 levels) in <top (required)>'
     # ./spec/support/database_cleaner.rb:13:in `block (3 levels) in <top (required)>'
     # ./spec/support/database_cleaner.rb:12:in `block (2 levels) in <top (required)>'

Finished in 7.81 seconds (files took 3.96 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/integration/scheduler_spec.rb:52 # Schedule Integration when there are a large number of jobs pops items off of the queue and runs them

Randomized with seed 533

```

