### PR TITLE
Document the rest of the code

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,2 @@
+--plugin activesupport-concern
 --load .yard_support.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
     yard (0.9.25)
+    yard-activesupport-concern (0.0.1)
+      yard (>= 0.8)
     zeitwerk (2.3.1)
 
 PLATFORMS
@@ -214,6 +216,7 @@ DEPENDENCIES
   rubocop-rspec
   sigdump
   yard
+  yard-activesupport-concern
 
 BUNDLED WITH
    2.1.4

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -63,4 +63,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec"
   spec.add_development_dependency "sigdump"
   spec.add_development_dependency "yard"
+  spec.add_development_dependency "yard-activesupport-concern"
 end

--- a/lib/generators/good_job/install_generator.rb
+++ b/lib/generators/good_job/install_generator.rb
@@ -2,6 +2,13 @@ require 'rails/generators'
 require 'rails/generators/active_record'
 
 module GoodJob
+  #
+  # Implements the Rails generator used for setting up GoodJob in a Rails
+  # application. Run it with +bin/rails g good_job:install+ in your console.
+  #
+  # This generator is primarily dedicated to stubbing out a migration that adds
+  # a table to hold GoodJob's queued jobs in your database.
+  #
   class InstallGenerator < Rails::Generators::Base
     include Rails::Generators::Migration
 
@@ -11,6 +18,7 @@ module GoodJob
 
     source_paths << File.join(File.dirname(__FILE__), "templates")
 
+    # Generates the actual migration file and places it on disk.
     def create_migration_file
       migration_template 'migration.rb.erb', 'db/migrate/create_good_jobs.rb', migration_version: migration_version
     end

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -1,17 +1,33 @@
 require 'thor'
 
 module GoodJob
+  #
+  # Implements the +good_job+ command-line tool, which executes jobs and
+  # provides other utilities. The actual entry point is in +exe/good_job+, but
+  # it just sets up and calls this class.
+  #
+  # The +good_job+ command-line tool is based on Thor, a CLI framework for
+  # Ruby. For more on general usage, see http://whatisthor.com/ and
+  # https://github.com/erikhuda/thor/wiki.
+  #
   class CLI < Thor
+    # Path to the local Rails application's environment configuration.
+    # Requiring this loads the application's configuration and classes.
     RAILS_ENVIRONMENT_RB = File.expand_path("config/environment.rb")
 
-    desc :start, <<~DESCRIPTION
+    # @!macro thor.desc
+    #   @!method $1
+    #   @return [void]
+    #   The +good_job $1+ command. $2
+    desc :start, "Executes queued jobs."
+    long_desc <<~DESCRIPTION
       Executes queued jobs.
 
-      All options can be configured with environment variables. 
+      All options can be configured with environment variables.
       See option descriptions for the matching environment variable name.
 
       == Configuring queues
-      Separate multiple queues with commas; exclude queues with a leading minus; 
+      \x5Separate multiple queues with commas; exclude queues with a leading minus;
       separate isolated execution pools with semicolons and threads with colons.
 
     DESCRIPTION
@@ -51,8 +67,10 @@ module GoodJob
 
     default_task :start
 
-    desc :cleanup_preserved_jobs, <<~DESCRIPTION
-      Deletes preserved job records. 
+    # @!macro thor.desc
+    desc :cleanup_preserved_jobs, "Deletes preserved job records."
+    long_desc <<~DESCRIPTION
+      Deletes preserved job records.
 
       By default, GoodJob deletes job records when the job is performed and this
       command is not necessary.
@@ -82,6 +100,11 @@ module GoodJob
     end
 
     no_commands do
+      # Load the current Rails application and configuration that the good_job
+      # command-line tool should be working within.
+      #
+      # GoodJob components that need access to constants, classes, etc. from
+      # Rails or from the application can be set up here.
       def set_up_application!
         require RAILS_ENVIRONMENT_RB
         return unless defined?(GOOD_JOB_LOG_TO_STDOUT) && GOOD_JOB_LOG_TO_STDOUT && !ActiveSupport::Logger.logger_outputs_to?(GoodJob.logger, STDOUT)

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -1,12 +1,40 @@
 module GoodJob
+  #
+  # +GoodJob::Configuration+ provides normalized configuration information to
+  # the rest of GoodJob. It combines environment information with explicitly
+  # set options to get the final values for each option.
+  #
   class Configuration
+    # @!attribute [r] options
+    #   The options that were explicitly set when initializing +Configuration+.
+    #   @return [Hash]
+    #
+    # @!attribute [r] env
+    #   The environment from which to read GoodJob's environment variables. By
+    #   default, this is the current process's environment, but it can be set
+    #   to something else in {#initialize}.
+    #   @return [Hash]
     attr_reader :options, :env
 
+    # @param options [Hash] Any explicitly specified configuration options to
+    #   use. Keys are symbols that match the various methods on this class.
+    # @param env [Hash] A +Hash+ from which to read environment variables that
+    #   might specify additional configuration values.
     def initialize(options, env: ENV)
       @options = options
       @env = env
     end
 
+    # Specifies how and where jobs should be executed. See {Adapter#initialize}
+    # for more details on possible values.
+    #
+    # When running inside a Rails app, you may want to use
+    # {#rails_execution_mode}, which takes the current Rails environment into
+    # account when determining the final value.
+    #
+    # @param default [Symbol]
+    #   Value to use if none was specified in the configuration.
+    # @return [Symbol]
     def execution_mode(default: :external)
       if options[:execution_mode]
         options[:execution_mode]
@@ -17,6 +45,9 @@ module GoodJob
       end
     end
 
+    # Like {#execution_mode}, but takes the current Rails environment into
+    # account (e.g. in the +test+ environment, it falls back to +:inline+).
+    # @return [Symbol]
     def rails_execution_mode
       if execution_mode(default: nil)
         execution_mode
@@ -29,6 +60,10 @@ module GoodJob
       end
     end
 
+    # Indicates the number of threads to use per {Scheduler}. Note that
+    # {#queue_string} may provide more specific thread counts to use with
+    # individual schedulers.
+    # @return [Integer]
     def max_threads
       (
         options[:max_threads] ||
@@ -38,12 +73,21 @@ module GoodJob
       ).to_i
     end
 
+    # Describes which queues to execute jobs from and how those queues should
+    # be grouped into {Scheduler} instances. See
+    # {file:README.md#optimize-queues-threads-and-processes} for more details
+    # on the format of this string.
+    # @return [String]
     def queue_string
       options[:queues] ||
         env['GOOD_JOB_QUEUES'] ||
         '*'
     end
 
+    # The number of seconds between polls for jobs. GoodJob will execute jobs
+    # on queues continuously until a queue is empty, at which point it will
+    # poll (using this interval) for new queued jobs to execute.
+    # @return [Integer]
     def poll_interval
       (
         options[:poll_interval] ||

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -108,7 +108,7 @@ module GoodJob
 
     # Finds the next eligible Job, acquire an advisory lock related to it, and
     # executes the job.
-    # @return [Array<GoodJob::Job, Object, Exception>, nil]
+    # @return [Array<(GoodJob::Job, Object, Exception)>, nil]
     #   If a job was executed, returns an array with the {Job} record, the
     #   return value for the job's +#perform+ method, and the exception the job
     #   raised, if any (if the job raised, then the second array entry will be
@@ -167,7 +167,7 @@ module GoodJob
     #   Whether to re-queue the job to execute again if it raised an instance
     #   of +StandardError+. Defaults to the value of
     #   {GoodJob.reperform_jobs_on_standard_error}.
-    # @return [Array<Object, Exception>]
+    # @return [Array<(Object, Exception)>]
     #   An array of the return value of the job's +#perform+ method and the
     #   exception raised by the job, if any. If the job completed successfully,
     #   the second array entry (the exception) will be +nil+ and vice versa.

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -1,14 +1,32 @@
 module GoodJob
+  #
+  # Represents a request to perform an +ActiveJob+ job.
+  #
   class Job < ActiveRecord::Base
     include Lockable
 
+    # Raised if something attempts to execute a previously completed Job again.
     PreviouslyPerformedError = Class.new(StandardError)
 
+    # ActiveJob jobs without a +queue_name+ attribute are placed on this queue.
     DEFAULT_QUEUE_NAME = 'default'.freeze
+    # ActiveJob jobs without a +priority+ attribute are given this priority.
     DEFAULT_PRIORITY = 0
 
     self.table_name = 'good_jobs'.freeze
 
+    # Parse a string representing a group of queues into a more readable data
+    # structure.
+    # @return [Hash]
+    #   How to match a given queue. It can have the following keys and values:
+    #   - +{ all: true }+ indicates that all queues match.
+    #   - +{ exclude: Array<String> }+ indicates the listed queue names should
+    #     not match.
+    #   - +{ include: Array<String> }+ indicates the listed queue names should
+    #     match.
+    # @example
+    #   GoodJob::Job.queue_parser('-queue1,queue2')
+    #   => { exclude: [ 'queue1', 'queue2' ] }
     def self.queue_parser(string)
       string = string.presence || '*'
 
@@ -28,6 +46,10 @@ module GoodJob
       end
     end
 
+    # Get Jobs that have not yet been completed.
+    # @!method unfinished
+    # @!scope class
+    # @return [ActiveRecord::Relation]
     scope :unfinished, (lambda do
       if column_names.include?('finished_at')
         where(finished_at: nil)
@@ -36,9 +58,42 @@ module GoodJob
         nil
       end
     end)
+
+    # Get Jobs that are not scheduled for a later time than now (i.e. jobs that
+    # are not scheduled or scheduled for earlier than the current time).
+    # @!method only_scheduled
+    # @!scope class
+    # @return [ActiveRecord::Relation]
     scope :only_scheduled, -> { where(arel_table['scheduled_at'].lteq(Time.current)).or(where(scheduled_at: nil)) }
+
+    # Order jobs by priority (highest priority first).
+    # @!method priority_ordered
+    # @!scope class
+    # @return [ActiveRecord::Relation]
     scope :priority_ordered, -> { order('priority DESC NULLS LAST') }
+
+    # Get Jobs were completed before the given timestamp. If no timestamp is
+    # provided, get all jobs that have been completed. By default, GoodJob
+    # deletes jobs after they are completed and this will find no jobs.
+    # However, if you have changed {GoodJob.preserve_job_records}, this may
+    # find completed Jobs.
+    # @!method finished(timestamp = nil)
+    # @!scope class
+    # @param timestamp (Float)
+    #   Get jobs that finished before this time (in epoch time).
+    # @return [ActiveRecord::Relation]
     scope :finished, ->(timestamp = nil) { timestamp ? where(arel_table['finished_at'].lteq(timestamp)) : where.not(finished_at: nil) }
+
+    # Get Jobs on queues that match the given queue string.
+    # @!method queue_string(string)
+    # @!scope class
+    # @param string [String]
+    #   A string expression describing what queues to select. See
+    #   {Job.queue_parser} or
+    #   {file:README.md#optimize-queues-threads-and-processes} for more details
+    #   on the format of the string. Note this only handles individual
+    #   semicolon-separated segments of that string format.
+    # @return [ActiveRecord::Relation]
     scope :queue_string, (lambda do |string|
       parsed = queue_parser(string)
 
@@ -51,6 +106,13 @@ module GoodJob
       end
     end)
 
+    # Finds the next eligible Job, acquire an advisory lock related to it, and
+    # executes the job.
+    # @return [Array<GoodJob::Job, Object, Exception>, nil]
+    #   If a job was executed, returns an array with the {Job} record, the
+    #   return value for the job's +#perform+ method, and the exception the job
+    #   raised, if any (if the job raised, then the second array entry will be
+    #   +nil+). If there were no jobs to execute, returns +nil+.
     def self.perform_with_advisory_lock
       good_job = nil
       result = nil
@@ -67,6 +129,15 @@ module GoodJob
       [good_job, result, error] if good_job
     end
 
+    # Places an ActiveJob job on a queue by creating a new {Job} record.
+    # @param active_job [ActiveJob::Base]
+    #   The job to enqueue.
+    # @param scheduled_at [Float]
+    #   Epoch timestamp when the job should be executed.
+    # @param create_with_advisory_lock [Boolean]
+    #   Whether to establish a lock on the {Job} record after it is created.
+    # @return [Job]
+    #   The new {Job} instance representing the queued ActiveJob job.
     def self.enqueue(active_job, scheduled_at: nil, create_with_advisory_lock: false)
       good_job = nil
       ActiveSupport::Notifications.instrument("enqueue_job.good_job", { active_job: active_job, scheduled_at: scheduled_at, create_with_advisory_lock: create_with_advisory_lock }) do |instrument_payload|
@@ -87,6 +158,19 @@ module GoodJob
       good_job
     end
 
+    # Execute the ActiveJob job this {Job} represents.
+    # @param destroy_after [Boolean]
+    #   Whether to destroy the {Job} record after executing it if the job did
+    #   not need to be reperformed. Defaults to the value of
+    #   {GoodJob.preserve_job_records}.
+    # @param reperform_on_standard_error [Boolean]
+    #   Whether to re-queue the job to execute again if it raised an instance
+    #   of +StandardError+. Defaults to the value of
+    #   {GoodJob.reperform_jobs_on_standard_error}.
+    # @return [Array<Object, Exception>]
+    #   An array of the return value of the job's +#perform+ method and the
+    #   exception raised by the job, if any. If the job completed successfully,
+    #   the second array entry (the exception) will be +nil+ and vice versa.
     def perform(destroy_after: !GoodJob.preserve_job_records, reperform_on_standard_error: GoodJob.reperform_jobs_on_standard_error)
       raise PreviouslyPerformedError, 'Cannot perform a job that has already been performed' if finished_at
 

--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -195,7 +195,7 @@ module GoodJob
 
     # Releases all advisory locks on the record that are held by the current
     # database session.
-    # @return [nil]
+    # @return [void]
     def advisory_unlock!
       advisory_unlock while advisory_locked?
     end

--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -87,8 +87,15 @@ module GoodJob
 
       # @!attribute [r] create_with_advisory_lock
       # @return [Boolean]
-      # Whether an advisory lock should be acquired immediately after creating
-      # the record.
+      # Whether an advisory lock should be acquired in the same transaction
+      # that created the record.
+      #
+      # This helps prevent another thread or database session from acquiring a
+      # lock on the record between the time you create it and the time you
+      # request a lock, since other sessions will not be able to see the new
+      # record until the transaction that creates it is completed (at which
+      # point you have already acquired the lock).
+      #
       # @example
       #   record = MyLockableRecord.create(create_with_advisory_lock: true)
       #   record.advisory_locked?

--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -1,10 +1,33 @@
 module GoodJob
+  #
+  # Adds Postgres advisory locking capabilities to an ActiveRecord record.
+  # For details on advisory locks, see the Postgres documentation:
+  # - {https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS Advisory Locks Overview}
+  # - {https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS Advisory Locks Functions}
+  #
+  # @example Add this concern to a +MyRecord+ class:
+  #   class MyRecord < ActiveRecord::Base
+  #     include Lockable
+  #
+  #     def my_method
+  #       ...
+  #     end
+  #   end
+  #
   module Lockable
     extend ActiveSupport::Concern
 
+    # Indicates an advisory lock is already held on a record by another
+    # database session.
     RecordAlreadyAdvisoryLockedError = Class.new(StandardError)
 
     included do
+      # Attempt to acquire an advisory lock on the selected records and
+      # return only those records for which a lock could be acquired.
+      # @!method advisory_lock
+      # @!scope class
+      # @return [ActiveRecord::Relation]
+      #   A relation selecting only the records that were locked.
       scope :advisory_lock, (lambda do
         original_query = self
 
@@ -21,6 +44,17 @@ module GoodJob
         unscoped.where(arel_table[:id].in(query)).merge(original_query.only(:order))
       end)
 
+      # Joins the current query with Postgres's +pg_locks+ table (it provides
+      # data about existing locks) such that each row in the main query joins
+      # to all the advisory locks associated with that row.
+      #
+      # For details on +pg_locks+, see
+      # {https://www.postgresql.org/docs/current/view-pg-locks.html}.
+      # @!method joins_advisory_locks
+      # @!scope class
+      # @return [ActiveRecord::Relation]
+      # @example Get the records that have a session awaiting a lock:
+      #   MyLockableRecord.joins_advisory_locks.where("pg_locks.granted = ?", false)
       scope :joins_advisory_locks, (lambda do
         join_sql = <<~SQL
           LEFT JOIN pg_locks ON pg_locks.locktype = 'advisory'
@@ -32,16 +66,55 @@ module GoodJob
         joins(sanitize_sql_for_conditions([join_sql, { table_name: table_name }]))
       end)
 
+      # Find records that do not have an advisory lock on them.
+      # @!method advisory_unlocked
+      # @!scope class
+      # @return [ActiveRecord::Relation]
       scope :advisory_unlocked, -> { joins_advisory_locks.where(pg_locks: { locktype: nil }) }
+
+      # Find records that have an advisory lock on them.
+      # @!method advisory_locked
+      # @!scope class
+      # @return [ActiveRecord::Relation]
       scope :advisory_locked, -> { joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
+
+      # Find records with advisory locks owned by the current Postgres
+      # session/connection.
+      # @!method advisory_locked
+      # @!scope class
+      # @return [ActiveRecord::Relation]
       scope :owns_advisory_locked, -> { joins_advisory_locks.where('"pg_locks"."pid" = pg_backend_pid()') }
 
+      # @!attribute [r] create_with_advisory_lock
+      # @return [Boolean]
+      # Whether an advisory lock should be acquired immediately after creating
+      # the record.
+      # @example
+      #   record = MyLockableRecord.create(create_with_advisory_lock: true)
+      #   record.advisory_locked?
+      #   => true
       attr_accessor :create_with_advisory_lock
 
       after_create -> { advisory_lock }, if: :create_with_advisory_lock
     end
 
     class_methods do
+      # Acquires an advisory lock on the selected record(s) and safely releases
+      # it after the passed block is completed. The block will be passed an
+      # array of the locked records as its first argument.
+      #
+      # Note that this will not block and wait for locks to be acquired.
+      # Instead, it will acquire a lock on all the selected records that it
+      # can (as in {Lockable.advisory_lock}) and only pass those that could be
+      # locked to the block.
+      #
+      # @yield [Array<Lockable>] the records that were successfully locked.
+      # @return [Object] the result of the block.
+      #
+      # @example Work on the first two +MyLockableRecord+ objects that could be locked:
+      #   MyLockableRecord.order(created_at: :asc).limit(2).with_advisory_lock do |record|
+      #     do_something_with record
+      #   end
       def with_advisory_lock
         raise ArgumentError, "Must provide a block" unless block_given?
 
@@ -54,6 +127,11 @@ module GoodJob
       end
     end
 
+    # Acquires an advisory lock on this record if it is not already locked by
+    # another database session. Be careful to ensure you release the lock when
+    # you are done with {#advisory_unlock} (or {#advisory_unlock!} to release
+    # all remaining locks).
+    # @return [Boolean] whether the lock was acquired.
     def advisory_lock
       where_sql = <<~SQL
         pg_try_advisory_lock(('x'||substr(md5(:table_name || :id::text), 1, 16))::bit(64)::bigint)
@@ -61,6 +139,10 @@ module GoodJob
       self.class.unscoped.where(where_sql, { table_name: self.class.table_name, id: send(self.class.primary_key) }).exists?
     end
 
+    # Releases an advisory lock on this record if it is locked by this database
+    # session. Note that advisory locks stack, so you must call
+    # {#advisory_unlock} and {#advisory_lock} the same number of times.
+    # @return [Boolean] whether the lock was released.
     def advisory_unlock
       where_sql = <<~SQL
         pg_advisory_unlock(('x'||substr(md5(:table_name || :id::text), 1, 16))::bit(64)::bigint)
@@ -68,11 +150,28 @@ module GoodJob
       self.class.unscoped.where(where_sql, { table_name: self.class.table_name, id: send(self.class.primary_key) }).exists?
     end
 
+    # Acquires an advisory lock on this record or raises
+    # {RecordAlreadyAdvisoryLockedError} if it is already locked by another
+    # database session.
+    # @raise [RecordAlreadyAdvisoryLockedError]
+    # @return [Boolean] +true+
     def advisory_lock!
       result = advisory_lock
       result || raise(RecordAlreadyAdvisoryLockedError)
     end
 
+    # Acquires an advisory lock on this record and safely releases it after the
+    # passed block is completed. If the record is locked by another database
+    # session, this raises {RecordAlreadyAdvisoryLockedError}.
+    #
+    # @yield Nothing
+    # @return [Object] The result of the block.
+    #
+    # @example
+    #   record = MyLockableRecord.first
+    #   record.with_advisory_lock do
+    #     do_something_with record
+    #   end
     def with_advisory_lock
       raise ArgumentError, "Must provide a block" unless block_given?
 
@@ -82,14 +181,21 @@ module GoodJob
       advisory_unlock unless $ERROR_INFO.is_a? RecordAlreadyAdvisoryLockedError
     end
 
+    # Tests whether this record has an advisory lock on it.
+    # @return [Boolean]
     def advisory_locked?
       self.class.unscoped.advisory_locked.where(id: send(self.class.primary_key)).exists?
     end
 
+    # Tests whether this record is locked by the current database session.
+    # @return [Boolean]
     def owns_advisory_lock?
       self.class.unscoped.owns_advisory_locked.where(id: send(self.class.primary_key)).exists?
     end
 
+    # Releases all advisory locks on the record that are held by the current
+    # database session.
+    # @return [nil]
     def advisory_unlock!
       advisory_unlock while advisory_locked?
     end

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -16,6 +16,7 @@ module GoodJob
     #   Responds to the +$0.good_job+ notification.
     #   @return [void]
     def create(event)
+      # FIXME: This method does not match any good_job notifications.
       good_job = event.payload[:good_job]
 
       debug do
@@ -25,6 +26,7 @@ module GoodJob
 
     # @macro notification_responder
     def timer_task_finished(event)
+      # FIXME: This method does not match any good_job notifications.
       exception = event.payload[:error]
       return unless exception
 
@@ -35,6 +37,7 @@ module GoodJob
 
     # @macro notification_responder
     def job_finished(event)
+      # FIXME: This method does not match any good_job notifications.
       exception = event.payload[:error]
       return unless exception
 

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -10,7 +10,7 @@ module GoodJob
   # documentation for more.
   #
   class LogSubscriber < ActiveSupport::LogSubscriber
-    # @group Notifications
+    # @!group Notifications
 
     # @!macro notification_responder
     #   Responds to the +$0.good_job+ notification.
@@ -138,9 +138,13 @@ module GoodJob
       end
     end
 
-    # @endgroup
-    # NOTE: the double-blank line below is required to actually end the group.
+    # @!endgroup
 
+    # Get the logger associated with this {LogSubscriber} instance.
+    # @return [Logger]
+    def logger
+      GoodJob::LogSubscriber.logger
+    end
 
     class << self
       # Tracks all loggers that {LogSubscriber} is writing to. You can write to
@@ -179,12 +183,6 @@ module GoodJob
       def reset_logger
         @_logger = nil
       end
-    end
-
-    # Get the logger associated with this {LogSubscriber} instance.
-    # @return [Logger]
-    def logger
-      GoodJob::LogSubscriber.logger
     end
 
     private

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -10,6 +10,9 @@ module GoodJob
   # documentation for more.
   #
   class LogSubscriber < ActiveSupport::LogSubscriber
+    # @!macro notification_responder
+    #   Responds to the +$0.good_job+ notification.
+    #   @return [void]
     def create(event)
       good_job = event.payload[:good_job]
 
@@ -18,6 +21,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def timer_task_finished(event)
       exception = event.payload[:error]
       return unless exception
@@ -27,6 +31,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def job_finished(event)
       exception = event.payload[:error]
       return unless exception
@@ -36,6 +41,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def scheduler_create_pools(event)
       max_threads = event.payload[:max_threads]
       poll_interval = event.payload[:poll_interval]
@@ -47,6 +53,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def scheduler_shutdown_start(event)
       process_id = event.payload[:process_id]
 
@@ -55,6 +62,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def scheduler_shutdown(event)
       process_id = event.payload[:process_id]
 
@@ -63,6 +71,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def scheduler_restart_pools(event)
       process_id = event.payload[:process_id]
 
@@ -71,6 +80,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def perform_job(event)
       good_job = event.payload[:good_job]
       process_id = event.payload[:process_id]
@@ -81,12 +91,14 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def notifier_listen(_event)
       info do
         "Notifier subscribed with LISTEN"
       end
     end
 
+    # @macro notification_responder
     def notifier_notified(event)
       payload = event.payload[:payload]
 
@@ -95,6 +107,7 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def notifier_notify_error(event)
       error = event.payload[:error]
 
@@ -103,12 +116,14 @@ module GoodJob
       end
     end
 
+    # @macro notification_responder
     def notifier_unlisten(_event)
       info do
         "Notifier unsubscribed with UNLISTEN"
       end
     end
 
+    # @macro notification_responder
     def cleanup_preserved_jobs(event)
       timestamp = event.payload[:timestamp]
       deleted_records_count = event.payload[:deleted_records_count]

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -10,6 +10,8 @@ module GoodJob
   # documentation for more.
   #
   class LogSubscriber < ActiveSupport::LogSubscriber
+    # @group Notifications
+
     # @!macro notification_responder
     #   Responds to the +$0.good_job+ notification.
     #   @return [void]
@@ -132,6 +134,10 @@ module GoodJob
         "GoodJob deleted #{deleted_records_count} preserved #{'job'.pluralize(deleted_records_count)} finished before #{timestamp}."
       end
     end
+
+    # @endgroup
+    # NOTE: the double-blank line below is required to actually end the group.
+
 
     class << self
       # Tracks all loggers that {LogSubscriber} is writing to. You can write to


### PR DESCRIPTION
**This is meant to merge into #111 rather than the `main` branch.**

This brings GoodJob to 89% documented — the remaining bits are the methods on `LogSubscriber`, which didn't seem worth documenting since they merely mirror the names of notifications they respond to, so I feel like they're pretty self documenting. These can probably be handled with one of:
- `:nodoc:` comments (which unfortunately show up in the resulting docs).
- A macro that makes a pretty simplistic comment.
- `@api nodoc` comments combined with `--hide-api nodoc` in the `.yardopts` file. (This will hide them completely.)

Additionally, I didn’t really want to mess with it too much since it looks like some of the methods are for non-existent notifications. Not sure if things have changed since you last touched it or if you were anticipating notifications that haven’t yet been created. These are all the ones that I could see GoodJob sending:

- `scheduler_shutdown_start`
- `scheduler_shutdown`
- `scheduler_restart_pools`
- `finished_timer_task`
- `finished_job_task`
- `scheduler_create_pools`
- `cleanup_preserved_jobs`
- `enqueue_job`
- `perform_job`
- `notifier_listen`
- `notifier_notified`
- `notifier_notify_error`
- `notifier_unlisten`

Don’t know if you want to document them somewhere or not.

This also adds the `yard-activesupport-concern` gem, which is pretty helpful for documenting methods inside `included` and `class_methods` blocks, which are Rails features that are wind up hiding their contents from Yard.

I spent an unfortunate amount of time attempting to make macros work nicely for ActiveRecord’s `scope`, but never found a solution that didn’t cause strange warnings from Yard, odd behavior with duplicated methods every time you reloaded the docs, or other problems, so I wound up with pretty verbose syntax for those. There might be a nice Yard plugin that solves this better. ¯\\\_(ツ)\_/¯

Finally, I changed the CLI description setup slightly. It turns out we were putting long descriptions where the short, summary descriptions were meant to go, leaving us with this:

```sh
$ bundle exec good_job help
Commands:
  good_job cleanup_preserved_jobs  # Deletes preserved job records. By default, GoodJob deletes job records when the job is performed and this command is not necessary. However, ...
  good_job help [COMMAND]          # Describe available commands or one specific command
  good_job start                   # Executes queued jobs. All options can be configured with environment variables. See option descriptions for the matching environment variable...
```

Now we have the more readable:

```sh
$ bundle exec good_job help
Commands:
  good_job cleanup_preserved_jobs  # Deletes preserved job records.
  good_job help [COMMAND]          # Describe available commands or one specific command
  good_job start                   # Executes queued jobs.
```

As a bonus, it let me make a nice little macro for the doc comments. 😉 