### PR TITLE
Use `connection.quote_table_name` and add spacing for SQL concatenation

### DIFF
--- a/spec/support/shared_examples/lockable.rb
+++ b/spec/support/shared_examples/lockable.rb
@@ -28,7 +28,7 @@ RSpec.shared_examples 'lockable' do
           )
           SELECT "rows"."id"
           FROM "rows"
-          WHERE pg_try_advisory_lock(('x'||substr(md5('good_jobs' || "rows"."id"::text), 1, 16))::bit(64)::bigint)
+          WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || "rows"."id"::text), 1, 16))::bit(64)::bigint)
           LIMIT 2
         )
         ORDER BY "good_jobs"."priority" DESC


### PR DESCRIPTION
Follow-up to learnings from #119 and #117 