### PR TITLE
Only allow Scheduler to be initialized with max_threads and poll_interval; remove full access to pool and timer_task options

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -5,6 +5,13 @@ module GoodJob
   # set options to get the final values for each option.
   #
   class Configuration
+    # Default number of threads to use per {Scheduler}
+    DEFAULT_MAX_THREADS = 5
+    # Default number of seconds between polls for jobs
+    DEFAULT_POLL_INTERVAL = 1
+    # Default number of seconds to preserve jobs for {CLI#cleanup_preserved_jobs}
+    DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO = 24 * 60 * 60
+
     # @!attribute [r] options
     #   The options that were explicitly set when initializing +Configuration+.
     #   @return [Hash]
@@ -69,7 +76,7 @@ module GoodJob
         options[:max_threads] ||
         env['GOOD_JOB_MAX_THREADS'] ||
         env['RAILS_MAX_THREADS'] ||
-        ActiveRecord::Base.connection_pool.size
+        DEFAULT_MAX_THREADS
       ).to_i
     end
 
@@ -92,7 +99,7 @@ module GoodJob
       (
         options[:poll_interval] ||
         env['GOOD_JOB_POLL_INTERVAL'] ||
-        1
+        DEFAULT_POLL_INTERVAL
       ).to_i
     end
 
@@ -100,7 +107,7 @@ module GoodJob
       (
         options[:before_seconds_ago] ||
         env['GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO'] ||
-        24 * 60 * 60
+        DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO
       ).to_i
     end
   end

--- a/spec/lib/good_job/cli_spec.rb
+++ b/spec/lib/good_job/cli_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GoodJob::CLI do
         allow(ActiveRecord::Base.connection_pool).to receive(:size).and_return(1)
 
         cli.start
-        expect(GoodJob::Scheduler).to have_received(:new).with(a_kind_of(GoodJob::Performer), pool_options: { max_threads: 4 }, timer_options: { execution_interval: 1 })
+        expect(GoodJob::Scheduler).to have_received(:new).with(a_kind_of(GoodJob::Performer), max_threads: 4, poll_interval: 1)
       end
     end
 


### PR DESCRIPTION
Provides clearer configuration options and interface. Moves defaults to Configuration constants.

This also removes the reference to `ActiveRecord::Base.connection_pool.size` which I think should address #89.