### PR TITLE
Add `GoodJob.preserve_job_records = :on_unhandled_error` option to only preserve jobs that errored

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -32,7 +32,7 @@ module GoodJob
   #   Whether to preserve job records in the database after they have finished (default: +false+).
   #   By default, GoodJob deletes job records after the job is completed successfully.
   #   If you want to preserve jobs for latter inspection, set this to +true+.
-  #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_error+.
+  #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_unhandled_error+.
   #   If +true+, you will need to clean out jobs using the +good_job cleanup_preserved_jobs+ CLI command.
   #   @return [Boolean]
   mattr_accessor :preserve_job_records, default: false

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -32,6 +32,7 @@ module GoodJob
   #   Whether to preserve job records in the database after they have finished (default: +false+).
   #   By default, GoodJob deletes job records after the job is completed successfully.
   #   If you want to preserve jobs for latter inspection, set this to +true+.
+  #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_error+.
   #   If +true+, you will need to clean out jobs using the +good_job cleanup_preserved_jobs+ CLI command.
   #   @return [Boolean]
   mattr_accessor :preserve_job_records, default: false

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -209,10 +209,12 @@ module GoodJob
 
       if rescued_error && GoodJob.reperform_jobs_on_standard_error
         save!
+      elsif rescued_error && GoodJob.preserve_job_records == :on_error
+        update!(finished_at: Time.current)
       else
         self.finished_at = Time.current
 
-        if GoodJob.preserve_job_records
+        if GoodJob.preserve_job_records == true
           save!
         else
           destroy!

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -191,37 +191,25 @@ module GoodJob
 
       result, rescued_error = execute
 
-      retry_or_discard_error = GoodJob::CurrentExecution.error_on_retry ||
-                               GoodJob::CurrentExecution.error_on_discard
+      result_error = nil
+      result, result_error = nil, result if result.is_a?(Exception) # rubocop:disable Style/ParallelAssignment
 
-      error = nil
-      if rescued_error
-        error = rescued_error
-      elsif result.is_a?(Exception)
-        error = result
-        result = nil
-      elsif retry_or_discard_error
-        error = retry_or_discard_error
-      end
+      job_error = rescued_error ||
+                  result_error ||
+                  GoodJob::CurrentExecution.error_on_retry ||
+                  GoodJob::CurrentExecution.error_on_discard
 
-      error_message = "#{error.class}: #{error.message}" if error
-      self.error = error_message
+      self.error = "#{job_error.class}: #{job_error.message}" if job_error
 
       if rescued_error && GoodJob.reperform_jobs_on_standard_error
         save!
-      elsif rescued_error && GoodJob.preserve_job_records == :on_error
+      elsif GoodJob.preserve_job_records == true || (GoodJob.preserve_job_records == :on_error && rescued_error)
         update!(finished_at: Time.current)
       else
-        self.finished_at = Time.current
-
-        if GoodJob.preserve_job_records == true
-          save!
-        else
-          destroy!
-        end
+        destroy!
       end
 
-      [result, error]
+      [result, job_error]
     end
 
     private

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -201,6 +201,12 @@ RSpec.describe GoodJob::Job do
       expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
     end
 
+    it 'destroys the job when preserving record only on error' do
+      allow(GoodJob).to receive(:preserve_job_records).and_return(:on_error)
+      good_job.perform
+      expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+
     it 'can preserve the job' do
       allow(GoodJob).to receive(:preserve_job_records).and_return(true)
 
@@ -300,6 +306,17 @@ RSpec.describe GoodJob::Job do
           it 'can preserve the job' do
             allow(GoodJob).to receive(:preserve_job_records).and_return(true)
 
+            good_job.perform
+
+            expect(good_job.reload).to have_attributes(
+              error: "ExpectedError: Raised expected error",
+              performed_at: within(1.second).of(Time.current),
+              finished_at: within(1.second).of(Time.current)
+            )
+          end
+
+          it 'preserves the job when preserving record only on error' do
+            allow(GoodJob).to receive(:preserve_job_records).and_return(:on_error)
             good_job.perform
 
             expect(good_job.reload).to have_attributes(

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe GoodJob::Job do
     end
 
     it 'destroys the job when preserving record only on error' do
-      allow(GoodJob).to receive(:preserve_job_records).and_return(:on_error)
+      allow(GoodJob).to receive(:preserve_job_records).and_return(:on_unhandled_error)
       good_job.perform
       expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
     end
@@ -316,7 +316,7 @@ RSpec.describe GoodJob::Job do
           end
 
           it 'preserves the job when preserving record only on error' do
-            allow(GoodJob).to receive(:preserve_job_records).and_return(:on_error)
+            allow(GoodJob).to receive(:preserve_job_records).and_return(:on_unhandled_error)
             good_job.perform
 
             expect(good_job.reload).to have_attributes(


### PR DESCRIPTION
Adds option :on_error to preserve jobs in database only on final error and delete otherwise.

This is done in 2 commits. First one just introduces the functionality, the second one changes options to :never, :always, :on_error with backward compatibility.

closes #136 