### PR TITLE
Rename reperform_jobs_on_standard_error to retry_on_unhandled_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Good Job’s general behavior can also be configured via several attributes dire
 
 - **`GoodJob.logger`** ([Rails Logger](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html)) lets you set a custom logger for GoodJob. It should be an instance of a Rails `Logger`.
 - **`GoodJob.preserve_job_records`** (boolean) keeps job records in your database even after jobs are completed. (Default: `false`)
-- **`GoodJob.reperform_jobs_on_standard_error`** (boolean) causes jobs to be re-queued and retried if they raise an instance of `StandardError`. Instances of `Exception`, like SIGINT, will *always* be retried, regardless of this attribute’s value. (Default: `true`)
+- **`GoodJob.retry_on_unhandled_error`** (boolean) causes jobs to be re-queued and retried if they raise an instance of `StandardError`. Instances of `Exception`, like SIGINT, will *always* be retried, regardless of this attribute’s value. (Default: `true`)
 - **`GoodJob.on_thread_error`** (proc, lambda, or callable) will be called when an Exception. It can be useful for logging errors to bug tracking services, like Sentry or Airbrake.
 
 You’ll generally want to configure these in `config/initializers/good_job.rb`, like so:
@@ -221,7 +221,7 @@ You’ll generally want to configure these in `config/initializers/good_job.rb`,
 ```ruby
 # config/initializers/good_job.rb
 GoodJob.preserve_job_records = true
-GoodJob.reperform_jobs_on_standard_error = false
+GoodJob.retry_on_unhandled_error = false
 GoodJob.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
 ```
 
@@ -304,7 +304,7 @@ When using `retry_on` with _a limited number of retries_, the final exception wi
 
 ```ruby
 # config/initializers/good_job.rb
-GoodJob.reperform_jobs_on_standard_error = false
+GoodJob.retry_on_unhandled_error = false
 ```
 
 Alternatively, pass a block to `retry_on` to handle the final exception instead of raising it to GoodJob:

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -37,14 +37,30 @@ module GoodJob
   #   @return [Boolean]
   mattr_accessor :preserve_job_records, default: false
 
-  # @!attribute [rw] reperform_jobs_on_standard_error
+  # @!attribute [rw] retry_on_unhandled_error
   #   @!scope class
   #   Whether to re-perform a job when a type of +StandardError+ is raised to GoodJob (default: +true+).
   #   If +true+, causes jobs to be re-queued and retried if they raise an instance of +StandardError+.
   #   If +false+, jobs will be discarded or marked as finished if they raise an instance of +StandardError+.
   #   Instances of +Exception+, like +SIGINT+, will *always* be retried, regardless of this attribute's value.
   #   @return [Boolean]
-  mattr_accessor :reperform_jobs_on_standard_error, default: true
+  mattr_accessor :retry_on_unhandled_error, default: true
+
+  # @deprecated Use {GoodJob#retry_on_unhandled_error} instead.
+  def self.reperform_jobs_on_standard_error
+    ActiveSupport::Deprecation.warn(
+      "Calling 'GoodJob.reperform_jobs_on_standard_error' is deprecated. Please use 'retry_on_unhandled_error'"
+    )
+    retry_on_unhandled_error
+  end
+
+  # @deprecated Use {GoodJob#retry_on_unhandled_error=} instead.
+  def self.reperform_jobs_on_standard_error=(value)
+    ActiveSupport::Deprecation.warn(
+      "Setting 'GoodJob.reperform_jobs_on_standard_error=' is deprecated. Please use 'retry_on_unhandled_error='"
+    )
+    self.retry_on_unhandled_error = value
+  end
 
   # @!attribute [rw] on_thread_error
   #   @!scope class

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -204,7 +204,7 @@ module GoodJob
 
       self.error = "#{job_error.class}: #{job_error.message}" if job_error
 
-      if unhandled_error && GoodJob.reperform_jobs_on_standard_error
+      if unhandled_error && GoodJob.retry_on_unhandled_error
         save!
       elsif GoodJob.preserve_job_records == true || (unhandled_error && GoodJob.preserve_job_records == :on_unhandled_error)
         self.finished_at = Time.current

--- a/spec/good_job_spec.rb
+++ b/spec/good_job_spec.rb
@@ -31,4 +31,27 @@ describe GoodJob do
       end.to change(described_class, :shutdown?).from(true).to(false)
     end
   end
+
+  describe '.reperform_jobs_on_standard_error' do
+    around do |example|
+      original_retry_on_unhandled_error = described_class.retry_on_unhandled_error
+      example.run
+      described_class.retry_on_unhandled_error = original_retry_on_unhandled_error
+    end
+
+    it 'is deprecated and replaced with .retry_on_unhandled_error' do
+      allow(ActiveSupport::Deprecation).to receive(:warn)
+      described_class.retry_on_unhandled_error = true
+
+      expect do
+        described_class.reperform_jobs_on_standard_error = false
+      end.to(
+        change(described_class, :retry_on_unhandled_error).from(true).to(false).and(
+          change(described_class, :reperform_jobs_on_standard_error).from(true).to(false)
+        )
+      )
+
+      expect(ActiveSupport::Deprecation).to have_received(:warn).exactly(3).times
+    end
+  end
 end

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe GoodJob::Job do
       describe 'GoodJob.reperform_jobs_on_standard_error behavior' do
         context 'when true' do
           before do
-            allow(GoodJob).to receive(:reperform_jobs_on_standard_error).and_return(true)
+            allow(GoodJob).to receive(:retry_on_unhandled_error).and_return(true)
           end
 
           it 'leaves the job record unfinished' do
@@ -293,7 +293,7 @@ RSpec.describe GoodJob::Job do
 
         context 'when false' do
           before do
-            allow(GoodJob).to receive(:reperform_jobs_on_standard_error).and_return(false)
+            allow(GoodJob).to receive(:retry_on_unhandled_error).and_return(false)
           end
 
           it 'destroys the job' do


### PR DESCRIPTION
Preserves backward compatibility.

Follow up to https://github.com/bensheldon/good_job/pull/145#discussion_r492069976