### PR TITLE
Create a Timer object that will wake up the Scheduler at specific times

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -82,6 +82,7 @@ module GoodJob
   def self.shutdown(wait: true)
     Notifier.instances.each { |notifier| notifier.shutdown(wait: wait) }
     Scheduler.instances.each { |scheduler| scheduler.shutdown(wait: wait) }
+    Timer.instances.each { |timer| timer.shutdown(wait: wait) }
   end
 
   # Tests whether jobs have stopped executing.

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -78,8 +78,12 @@ module GoodJob
         end
       end
 
-      executed_locally = execute_async? && @scheduler.create_thread(queue_name: good_job.queue_name)
-      Notifier.notify(queue_name: good_job.queue_name) unless executed_locally
+      job_state = {
+        queue_name: good_job.queue_name,
+        scheduled_at: good_job.scheduled_at&.to_i,
+      }
+      executed_locally = execute_async? && @scheduler.create_thread(job_state)
+      Notifier.notify(job_state) unless executed_locally
 
       good_job
     end

--- a/lib/good_job/performer.rb
+++ b/lib/good_job/performer.rb
@@ -28,11 +28,15 @@ module GoodJob
     #   Used to determine whether the performer should be used in GoodJob's
     #   current state. GoodJob state is a +Hash+ that will be passed as the
     #   first argument to +filter+ and includes info like the current queue.
-    def initialize(target, method_name, name: nil, filter: nil)
+    # @param next_at_method [Symbol]
+    #   The name of a method on +target+ that returns timestamps of when next
+    #   tasks may be available.
+    def initialize(target, method_name, name: nil, filter: nil, next_at_method: nil)
       @target = target
       @method_name = method_name
       @name = name
       @filter = filter
+      @next_at_method_name = next_at_method
     end
 
     # Find and perform any eligible jobs.
@@ -55,6 +59,15 @@ module GoodJob
       return true unless @filter.respond_to?(:call)
 
       @filter.call(state)
+    end
+
+    # The Returns timestamps of when next tasks may be available.
+    # @param count [Integer] number of timestamps to return.
+    # @return [Array<(Time, Timestamp)>, nil]
+    def next_at(count = 1)
+      return unless @next_at_method_name
+
+      @target.public_send(@next_at_method_name, count)
     end
   end
 end

--- a/lib/good_job/timer.rb
+++ b/lib/good_job/timer.rb
@@ -1,0 +1,114 @@
+module GoodJob
+  #
+  # Timers will wake at the provided times to check for new work.
+  #
+  # Timers manage a discrete set of wake up times, sorted by soonest.
+  # New times can be pushed onto a Timer, and they will added if they are
+  # sooner than existing tracked times, or discarded if they are later than
+  # existing tracked times and the Timer's queue of tracked times is full.
+  #
+  # @todo Allow Timer to track an unbounded number of wake times.
+  #
+  # Timers are intended to be used with a {GoodJob::Scheduler} to provide
+  # reduced execution scheduling latency compared to a {GoodJob::Poller}.
+  #
+  class Timer
+    # Default number of wake times to track
+    DEFAULT_MAX_QUEUE = 5
+
+    # Defaults for instance of +Concurrent::ThreadPoolExecutor+.
+    EXECUTOR_OPTIONS = {
+      name: 'timer',
+      min_threads: 0,
+      max_threads: 1,
+      auto_terminate: true,
+      idletime: 60,
+      max_queue: 0,
+      fallback_policy: :discard, # shouldn't matter -- 0 max queue
+    }.freeze
+
+    # @!attribute [r] instances
+    #   @!scope class
+    #   List of all instantiated Timers in the current process.
+    #   @return [array<GoodJob:Timer>]
+    cattr_reader :instances, default: [], instance_reader: false
+
+    # @!attribute [r] queue
+    #   List of scheduled wakeups.
+    #   @return [GoodJob::Timer::ScheduleTask]
+    attr_reader :queue
+
+    # @!attribute [r] queue
+    #   Number of wake times to track.
+    #   @return [Integer]
+    attr_reader :max_queue
+
+    # List of recipients that will receive wakeups.
+    # @return [Array<#call, Array(Object, Symbol)>]
+    attr_reader :recipients
+
+    # @param recipients [Array<#call, Array(Object, Symbol)>]
+    # @param max_queue [nil, Integer] Maximum number of times to track
+    def initialize(*recipients, max_queue: nil)
+      @recipients = Concurrent::Array.new(recipients)
+      @max_queue = max_queue || DEFAULT_MAX_QUEUE
+      @queue = Concurrent::Array.new
+      @mutex = Mutex.new
+
+      self.class.instances << self
+
+      create_executor
+    end
+
+    # Add a wake time to be tracked.
+    # The timestamp value be be discarded it is not sooner than the
+    # @param timestamp [Time, DateTime] the wake time
+    def push(timestamp)
+      @mutex.synchronize do
+        queue.select!(&:pending?)
+        return if queue.size == max_queue && timestamp > queue.last.scheduled_at
+
+        task = ScheduledTask.new(timestamp, args: [@recipients], executor: @executor) do |recipients|
+          recipients.each do |recipient|
+            target, method_name = recipient.is_a?(Array) ? recipient : [recipient, :call]
+            target.send(method_name)
+          end
+        end
+        task.execute
+
+        queue.unshift(task)
+        queue.sort_by!(&:scheduled_at)
+
+        removed_items = queue.slice!(max_queue..-1)
+        removed_items&.each(&:cancel)
+
+        task
+      end
+    end
+
+    # Shut down the timer.
+    def shutdown(wait: true)
+      return unless @executor&.running?
+
+      @executor.shutdown
+      @executor.wait_for_termination if wait
+    end
+
+    private
+
+    def create_executor
+      @executor = Concurrent::ThreadPoolExecutor.new(EXECUTOR_OPTIONS)
+    end
+
+    class ScheduledTask < Concurrent::ScheduledTask
+      attr_reader :scheduled_at
+
+      def initialize(timestamp, **args, &block)
+        @scheduled_at = timestamp
+
+        delay = [(timestamp - Time.current).to_f, 0].max
+        super(delay, **args, &block)
+      end
+    end
+  end
+end

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe GoodJob::Adapter do
   let(:adapter) { described_class.new }
   let(:active_job) { instance_double(ApplicationJob) }
-  let(:good_job) { instance_double(GoodJob::Job, queue_name: 'default') }
+  let(:good_job) { instance_double(GoodJob::Job, queue_name: 'default', scheduled_at: nil) }
 
   describe '#initialize' do
     it 'guards against improper execution modes' do

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -84,6 +84,15 @@ RSpec.describe GoodJob::Job do
     end
   end
 
+  describe '.next_at' do
+    let(:active_job) { ExampleJob.new }
+    let!(:good_job) { described_class.enqueue(active_job) }
+
+    it 'returns an array of timestamps' do
+      expect(described_class.next_at).to eq [good_job.created_at]
+    end
+  end
+
   describe '.queue_parser' do
     it 'creates an intermediary hash' do
       result = described_class.queue_parser('first,second')

--- a/spec/lib/good_job/timer_spec.rb
+++ b/spec/lib/good_job/timer_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe GoodJob::Timer do
+  describe '#initialize' do
+    it 'succeeds' do
+      described_class.new
+    end
+  end
+
+  describe '#push' do
+    let(:timer) { described_class.new(max_queue: 2) }
+
+    it 'adds a future to the queue' do
+      run_at = 1.minute.from_now
+      timer.push(run_at)
+
+      task = timer.queue.first
+      expect(task).to be_a Concurrent::ScheduledTask
+      expect(task.scheduled_at).to eq(run_at)
+    end
+
+    it 'maintains the appropriate queue size' do
+      one_minute = 1.minute.from_now
+      two_minutes = 2.minutes.from_now
+
+      timer.push(one_minute)
+      timer.push(two_minutes)
+
+      (3..5).to_a.each { |i| timer.push(i.minutes.from_now) }
+
+      expect(timer.queue.map(&:scheduled_at)).to eq [one_minute, two_minutes]
+    end
+  end
+
+  describe '#recipients' do
+    let(:recipient) { -> { RUNS << Time.current } }
+    let(:timer) { described_class.new(recipient, max_queue: 2) }
+
+    before do
+      stub_const "RUNS", Concurrent::Array.new
+    end
+
+    it 'triggers the recipient at the appropriate time' do
+      scheduled_at = 0.1.seconds.from_now
+      timer.push(scheduled_at)
+      sleep_until(max: 5) { RUNS.any? }
+
+      expect(RUNS.size).to eq(1)
+      expect(RUNS.first).to be_within(0.01.seconds).of(scheduled_at)
+    end
+
+    it 'only triggers scheduled items' do
+      one_tenth = 0.1.seconds.from_now
+      two_tenths = 0.2.seconds.from_now
+
+      timer.push(one_tenth)
+      timer.push(two_tenths)
+      (3..5).to_a.each { |i| timer.push((i * 0.1).minutes.from_now) }
+
+      sleep(1)
+
+      expect(RUNS.size).to eq 2
+    end
+  end
+end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -7,5 +7,6 @@ RSpec.configure do |config|
     GoodJob.shutdown
     GoodJob::Notifier.instances.clear
     GoodJob::Scheduler.instances.clear
+    GoodJob::Timer.instances.clear
   end
 end


### PR DESCRIPTION
The intention is to allow a Scheduler to store the times of future scheduled tasks and trigger a wake at those times. 

My goal is to allow polling to be significantly dialed back (~1 minute), if not done away with entirely and allow the `:async` execution mode to be non-noisily set as the default in the Rails development environment. (#139 and #90)

Current concerns:
- What is the appropriate number of future times to store? I'm a little worried that an unbounded queue is unsafe in production (uses a lot of memory and overlaps with the database's responsibility). But I do think it would make sense in the development environment and match Rails's own [AsyncAdapter](https://github.com/rails/rails/blob/166b63eb674b56faf4f75dfe300b14f00fb79dae/activejob/lib/active_job/queue_adapters/async_adapter.rb#L75-L82).
- Complexity and yet another `Concurent::ThreadPoolExecutor`. The `Timer` object has its own threadpool to execute `Concurrent::ScheduledTasks` that then wake up the `GoodJob::Scheduler` to fetch and perform the actual job. The `GoodJob::Timer` is currently entangled with both the `Scheduler` and the `Performer` because the Timer needs to refresh its queue of future tasks. I'm struggling with whether the `Timer` is an implementation detail of the `Scheduler`, or whether it can be non-complexly extracted like the Poller in #152. 