### PR TITLE
Lengthen default poll interval from 1 to 5 seconds

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -42,7 +42,7 @@ module GoodJob
     method_option :poll_interval,
                   type: :numeric,
                   banner: 'SECONDS',
-                  desc: "Interval between polls for available jobs in seconds (env var: GOOD_JOB_POLL_INTERVAL, default: 1)"
+                  desc: "Interval between polls for available jobs in seconds (env var: GOOD_JOB_POLL_INTERVAL, default: 5)"
     def start
       set_up_application!
 

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -8,7 +8,7 @@ module GoodJob
     # Default number of threads to use per {Scheduler}
     DEFAULT_MAX_THREADS = 5
     # Default number of seconds between polls for jobs
-    DEFAULT_POLL_INTERVAL = 1
+    DEFAULT_POLL_INTERVAL = 5
     # Default number of seconds to preserve jobs for {CLI#cleanup_preserved_jobs}
     DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO = 24 * 60 * 60
 

--- a/spec/lib/good_job/cli_spec.rb
+++ b/spec/lib/good_job/cli_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GoodJob::CLI do
         allow(ActiveRecord::Base.connection_pool).to receive(:size).and_return(1)
 
         cli.start
-        expect(GoodJob::Scheduler).to have_received(:new).with(a_kind_of(GoodJob::Performer), max_threads: 4, poll_interval: 1)
+        expect(GoodJob::Scheduler).to have_received(:new).with(a_kind_of(GoodJob::Performer), max_threads: 4, poll_interval: 5)
       end
     end
 


### PR DESCRIPTION
1 second seems fairly rapid (#90). Lengthens to 5 seconds which is the same default as other backends:

- Delayed Job sleep delay: [5 seconds](https://github.com/collectiveidea/delayed_job/blob/5ac5adea8d18325d0470eeebfa81227b1f5961e3/lib/delayed/worker.rb#L13)
- Que poll interval: [5 seconds](https://github.com/que-rb/que/blob/1736d3a30612f90a6839c5f98f622c9585e51784/lib/que/locker.rb#L46)