### PR TITLE
Don't disconnect a nil activerecord connection

### DIFF
--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -147,7 +147,7 @@ module GoodJob # :nodoc:
       pg_conn.exec("SET application_name = #{pg_conn.escape_identifier(self.class.name)}")
       yield pg_conn
     ensure
-      ar_conn.disconnect!
+      ar_conn&.disconnect!
     end
   end
 end


### PR DESCRIPTION
Related to #89.

Being seen on Heroku when precompiling assets and (assumed) the database is not available.