### PR TITLE
Create a ScheduledTaskQueue to manage future scheduled tasks stored in memory

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -76,10 +76,15 @@ module GoodJob
         ensure
           good_job.advisory_unlock
         end
-      end
+      else
+        job_state = {
+          queue_name: good_job.queue_name,
+          scheduled_at: good_job.scheduled_at,
+        }
 
-      executed_locally = execute_async? && @scheduler.create_thread(queue_name: good_job.queue_name)
-      Notifier.notify(queue_name: good_job.queue_name) unless executed_locally
+        executed_locally = execute_async? && @scheduler.create_thread(job_state)
+        Notifier.notify(job_state) unless executed_locally
+      end
 
       good_job
     end

--- a/lib/good_job/custom_concurrent/scheduled_task.rb
+++ b/lib/good_job/custom_concurrent/scheduled_task.rb
@@ -1,0 +1,14 @@
+module GoodJob
+  module CustomConcurrent
+    class ScheduledTask < Concurrent::ScheduledTask
+      attr_reader :scheduled_at
+
+      def initialize(timestamp, **args, &block)
+        @scheduled_at = timestamp
+
+        delay = [(timestamp - Time.current).to_f, 0].max
+        super(delay, **args, &block)
+      end
+    end
+  end
+end

--- a/lib/good_job/custom_concurrent/thread_pool_executor.rb
+++ b/lib/good_job/custom_concurrent/thread_pool_executor.rb
@@ -1,0 +1,21 @@
+require "concurrent/executor/thread_pool_executor"
+
+module GoodJob
+  module CustomConcurrent
+    # Custom sub-class of +Concurrent::ThreadPoolExecutor+ to add additional worker status.
+    # @private
+    class ThreadPoolExecutor < Concurrent::ThreadPoolExecutor
+      # Number of inactive threads available to execute tasks.
+      # https://github.com/ruby-concurrency/concurrent-ruby/issues/684#issuecomment-427594437
+      # @return [Integer]
+      def ready_worker_count
+        synchronize do
+          workers_still_to_be_created = @max_length - @pool.length
+          workers_created_but_waiting = @ready.length
+
+          workers_still_to_be_created + workers_created_but_waiting
+        end
+      end
+    end
+  end
+end

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -72,6 +72,12 @@ module GoodJob
     # @return [ActiveRecord::Relation]
     scope :priority_ordered, -> { order('priority DESC NULLS LAST') }
 
+    # Order jobs by scheduled (unscheduled or soonest first).
+    # @!method schedule_ordered
+    # @!scope class
+    # @return [ActiveRecord::Relation]
+    scope :schedule_ordered, -> { order('scheduled_at ASC NULLS FIRST, created_at ASC') }
+
     # Get Jobs were completed before the given timestamp. If no timestamp is
     # provided, get all jobs that have been completed. By default, GoodJob
     # deletes jobs after they are completed and this will find no jobs.
@@ -145,6 +151,16 @@ module GoodJob
       end
 
       [good_job, result, error] if good_job
+    end
+
+    # Fetches the scheduled execution time of the next eligible Job(s).
+    # @return [Array<(DateTime)>]
+    def self.next_scheduled_at(count = 1, after: nil)
+      query = advisory_unlocked.unfinished.schedule_ordered.limit(count)
+      if after
+        query = query.where('scheduled_at > ?', after).or query.where(scheduled_at: nil).where('created_at > ?', after)
+      end
+      query.pluck(:created_at, :scheduled_at).map { |timestamps| timestamps.compact.max }
     end
 
     # Places an ActiveJob job on a queue by creating a new {Job} record.

--- a/lib/good_job/performer.rb
+++ b/lib/good_job/performer.rb
@@ -28,11 +28,15 @@ module GoodJob
     #   Used to determine whether the performer should be used in GoodJob's
     #   current state. GoodJob state is a +Hash+ that will be passed as the
     #   first argument to +filter+ and includes info like the current queue.
-    def initialize(target, method_name, name: nil, filter: nil)
+    # @param next_at_method [Symbol]
+    #   The name of a method on +target+ that returns timestamps of when next
+    #   tasks may be available.
+    def initialize(target, method_name, name: nil, filter: nil, next_at_method: nil)
       @target = target
       @method_name = method_name
       @name = name
       @filter = filter
+      @next_at_method = next_at_method
     end
 
     # Find and perform any eligible jobs.
@@ -55,6 +59,16 @@ module GoodJob
       return true unless @filter.respond_to?(:call)
 
       @filter.call(state)
+    end
+
+    # The Returns timestamps of when next tasks may be available.
+    # @param count [Integer] number of timestamps to return
+    # @param count [DateTime, Time, nil] jobs scheduled after this time
+    # @return [Array<(Time, Timestamp)>, nil]
+    def next_at(count = 1, after: nil)
+      return unless @next_at_method_name
+
+      @target.public_send(@next_at_method_name, count, after: after)
     end
   end
 end

--- a/lib/good_job/scheduled_task_queue.rb
+++ b/lib/good_job/scheduled_task_queue.rb
@@ -1,0 +1,43 @@
+module GoodJob
+  class ScheduledTaskQueue
+    DEFAULT_MAX_SIZE = 5
+
+    attr_reader :max_size
+
+    def initialize(max_size: nil)
+      @max_size = max_size || DEFAULT_MAX_SIZE
+      @queue = Concurrent::Array.new
+      @mutex = Mutex.new
+    end
+
+    def push(scheduled_task)
+      @mutex.synchronize do
+        queue.select!(&:pending?)
+
+        if max_size.size == 0 || queue.size == max_size && scheduled_task.scheduled_at > queue.last.scheduled_at
+          scheduled_task.cancel
+          return false
+        end
+
+        queue.unshift(scheduled_task)
+        queue.sort_by!(&:scheduled_at)
+
+        removed_items = queue.slice!(max_size..-1)
+        removed_items&.each(&:cancel)
+
+        true
+      end
+    end
+
+    def size
+      @mutex.synchronize do
+        queue.select!(&:pending?)
+        queue.size
+      end
+    end
+
+    private
+
+    attr_reader :queue
+  end
+end

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe GoodJob::Adapter do
   let(:adapter) { described_class.new }
   let(:active_job) { instance_double(ApplicationJob) }
-  let(:good_job) { instance_double(GoodJob::Job, queue_name: 'default') }
+  let(:good_job) { instance_double(GoodJob::Job, queue_name: 'default', scheduled_at: nil) }
 
   describe '#initialize' do
     it 'guards against improper execution modes' do

--- a/spec/lib/good_job/scheduler_spec.rb
+++ b/spec/lib/good_job/scheduler_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe GoodJob::Scheduler do
 
       expect(scheduler.create_thread(queue_name: 'elephant')).to eq false
     end
+
+    it 'will schedule in the future' do
+      configuration = GoodJob::Configuration.new({ queues: 'mice:2' })
+      scheduler = described_class.from_configuration(configuration)
+      expect(scheduler.create_thread(queue_name: 'mice', scheduled_at: 1.second.from_now)).to eq true
+    end
   end
 
   describe '.from_configuration' do


### PR DESCRIPTION
_This is another take at #155._ 

The intention is to allow a Scheduler to store the times of future scheduled tasks and trigger a wake at those times.

My goal is to allow polling to be significantly dialed back (~1 minute), if not done away with entirely and allow the :async execution mode to be non-noisily set as the default in the Rails development environment. (#139 and #90)

**_This is given as an example, but with further research I believe that the `ScheduledTaskQueue` is not necessary because a `ScheduledTask` can be provided an explicit `TimerSet` that functions similarly to what I invented here._**