### PR TITLE
Fix job ordering.

### DIFF
--- a/engine/app/controllers/good_job/active_jobs_controller.rb
+++ b/engine/app/controllers/good_job/active_jobs_controller.rb
@@ -2,7 +2,7 @@ module GoodJob
   class ActiveJobsController < GoodJob::BaseController
     def show
       @jobs = GoodJob::Job.where("serialized_params ->> 'job_id' = ?", params[:id])
-                          .order('COALESCE(scheduled_at, created_at) DESC')
+                          .order(Arel.sql("COALESCE(scheduled_at, created_at) DESC"))
     end
   end
 end


### PR DESCRIPTION
In Rails 6.1 it throws error:
`Query method called with non-attribute argument(s): "COALESCE(scheduled_at, created_at) DESC"`
It was printing a warning about it in Rails 6.0.

Sorry for not including spec - I had issues with setting up system specs.

BTW, Rails 6.1 is around the corner https://weblog.rubyonrails.org/2020/12/1/Rails-6-1-rc2-release/ so I guess we could extend appraisal to 6.1