### PR TITLE
 Ensure advisory lock CTE is MATERIALIZED on Postgres v12+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.5, 2.6, 2.7]
+        pg: [12.5, 10.8]
     env:
       PGHOST: localhost
       PGUSER: test_app
@@ -63,11 +64,12 @@ jobs:
       DISABLE_SPRING: 1
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:${{ matrix.pg }}
         env:
           POSTGRES_USER: test_app
           POSTGRES_DB: test_app_test
           POSTGRES_PASSWORD: ""
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 

--- a/spec/lib/good_job/lockable_spec.rb
+++ b/spec/lib/good_job/lockable_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GoodJob::Lockable do
         SELECT "good_jobs".*
         FROM "good_jobs"
         WHERE "good_jobs"."id" IN (
-          WITH "rows" AS (
+          WITH "rows" AS #{'MATERIALIZED' if model_class.supports_cte_materialization_specifiers?} (
             SELECT "good_jobs"."id"
             FROM "good_jobs"
             WHERE "good_jobs"."priority" = 99


### PR DESCRIPTION
The advisory lock strategy uses a nested CTE that relies on the CTE being materialized to prevent the higher-level `pg_try_advisory_lock` condition from being pushed down.

Before Postgres 12, the materialized CTE was implicit; Postgres 12+ makes materialization explicit and disabled by default.

Connects to #177 