### PR TITLE
Run tests with Rails default configuration to enable Zeitwerk

### DIFF
--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -9,7 +9,7 @@ require "good_job"
 module TestApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    # config.load_defaults 6.0
+    config.load_defaults Gem::Version.new(Rails.version).segments.slice(0..1).join('.').to_f
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/spec/test_app/config/initializers/good_job.rb
+++ b/spec/test_app/config/initializers/good_job.rb
@@ -1,12 +1,3 @@
-if ENV['RBTRACE']
-  require 'sigdump/setup'
-  require 'rbtrace'
-  sleep 1
-  $stdout.puts "Run $ bundle exec rbtrace --pid #{Process.pid} --firehose"
-  $stdout.puts 'Press Enter to continue'
-  $stdin.gets
-end
-
 if ENV['GOOD_JOB_EXECUTION_MODE'].present?
   ActiveJob::Base.queue_adapter = :good_job
 end

--- a/spec/test_app/config/initializers/rbtrace.rb
+++ b/spec/test_app/config/initializers/rbtrace.rb
@@ -1,0 +1,10 @@
+if ENV['RBTRACE']
+  require 'sigdump/setup'
+  require 'rbtrace'
+  sleep 1
+  $stdout.puts "Enabled rbtrace. Example commands:"
+  $stdout.puts "  Show all method calls: $ bundle exec rbtrace --pid #{Process.pid} --firehose"
+  $stdout.puts "  Debug Rails deadlock: $ bundle exec rbtrace --pid #{Process.pid} --eval \"puts output = ActionDispatch::DebugLocks.new(nil).send(:render_details, nil); output\""
+  $stdout.puts 'Press Enter to continue...'
+  $stdin.gets
+end


### PR DESCRIPTION
**GoodJob requires Rails use the Zeitwerk autoloader (not Classic) for Rails 6.0+.** 

This PR ensures that that the test environment defaults to the configuration defaults for the version of Rails the test suit is being run against.

This was discovered because of a deadlock caused by isolating a single test that loads up a bunch of Scheduler threads at once. I think it's the same deadlock that causes CI tests to flakily time-out: 

`$ RBTRACE=1 bin/rspec spec/integration/scheduler_spec.rb:52`

https://github.com/bensheldon/good_job/blob/bed770d66ee4c7b702639310e3e41cf8034f8779/spec/integration/scheduler_spec.rb#L52-L57

 