### PR TITLE
Do not add lib/generators to Zeitwerk autoloader

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -1,16 +1,15 @@
 require "rails"
-
 require "active_job"
 require "active_job/queue_adapters"
 
 require "zeitwerk"
-
-loader = Zeitwerk::Loader.for_gem
-loader.inflector.inflect(
-  'cli' => "CLI"
-)
-loader.push_dir(File.join(__dir__, ["generators"]))
-loader.setup
+Zeitwerk::Loader.for_gem.tap do |loader|
+  loader.inflector.inflect({
+                             "cli" => "CLI",
+                           })
+  loader.ignore(File.join(File.dirname(__FILE__), "generators"))
+  loader.setup
+end
 
 require "good_job/railtie"
 


### PR DESCRIPTION
I _think_ (and experimentally believe) that the `rails generator` command does an implicit lookup and the generator does not have to be explicitly loaded. 

Many other gems appear to explicitly ignore `lib/generators` too: https://github.com/search?l=Ruby&q=Zeitwerk%3A%3ALoader.for_gem+generators&type=Code

Addresses this issue of the Zeitwerk autoloader complaining that it expects `lib/generators/good_job/templates` to contain a matching class. https://github.com/bensheldon/good_job/issues/160#issuecomment-755126674