### PR TITLE
Fix start-up issue with Rails 6.1 & async mode

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -30,7 +30,7 @@ module GoodJob
     def self.queue_parser(string)
       string = string.presence || '*'
 
-      if string.first == '-'
+      if string[0] == '-'
         exclude_queues = true
         string = string[1..-1]
       end


### PR DESCRIPTION
I'm not sure this is an acceptable fix for https://github.com/bensheldon/good_job/issues/195, but this would not raise `queue_parser': undefined method `first' for "*":String (NoMethodError) anymore.

I also notice the start-up time for async mode is significantly slower than other modes. (It took more than 5 minutes to start-up).

I'm not sure it is related to this fix or any other factor of rails 6.1.