### PR TITLE
Update bundler version to 2.2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,4 +280,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.4
+   2.2.5

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -328,4 +328,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.4
+   2.2.5

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -343,4 +343,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.4
+   2.2.5

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -345,4 +345,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.4
+   2.2.5

--- a/gemfiles/rails_head.gemfile.lock
+++ b/gemfiles/rails_head.gemfile.lock
@@ -351,4 +351,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.2.4
+   2.2.5


### PR DESCRIPTION
Should fix problem with #197.

I'm not sure why the GH Action is using a different version of bundler than is installed explicitly in the action.