### PR TITLE
Fix equality typo in development.rb of test_app

### DIFF
--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
     config.good_job.execution_mode = :external
   end
 
-  if config.good_job.execution_mode = :async
+  if config.good_job.execution_mode == :async
     config.good_job.poll_interval = 30
   end
 end


### PR DESCRIPTION
I came across this typo when trying to run ```bin/setup``` on the latest version of good_job.

For the sake of completeness, the error I received was:
```
rails aborted!
ActiveRecord::NoDatabaseError: FATAL:  database "test_app_development" does not exist


Caused by:
PG::ConnectionBad: FATAL:  database "test_app_development" does not exist

Tasks: TOP => db:setup => db:create => db:load_config
(See full trace by running task with --trace)

== Command ["bundle exec bin/rails db:setup"] failed ==
```

```bin/setup``` worked fine for me after making the change.