### PR TITLE
Ensure Job#serialized_params are immutable

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -15,6 +15,8 @@ module GoodJob
 
     self.table_name = 'good_jobs'.freeze
 
+    attr_readonly :serialized_params
+
     # Parse a string representing a group of queues into a more readable data
     # structure.
     # @return [Hash]


### PR DESCRIPTION
The ActiveJob data within an individual `GoodJob::Job` record should be immutable. 

Within #215, there is evidence that `serialized_params['exception_executions']` was being modified because the object-within-an-object was being mutated from within the the ActiveJob::Base job instance. (Alternative would be to `deep_dup` the object, but that seems more heavy-handed).