### PR TITLE
Fix appraisal and bundler version CI conflicts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,31 +19,12 @@ jobs:
         uses: actions/checkout@v2
 
       # Dependencies
-      - name: Install missing libs (This is slated to be added to the base image soon!)
-        run: sudo apt-get -yqq install libpq-dev
-      - name: "Set Ruby version"
-        id: ruby_version
-        run: echo "::set-output name=value::$(cat .ruby-version)"
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ steps.ruby_version.outputs.value }}
-          bundler: none
-      - name: Ruby gem cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: v1-bundler-${{ runner.os }}-${{ steps.ruby_version.outputs.value }}-${{ hashFiles('**/good_job.gemspec') }}-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Appraisals') }}
-          restore-keys: |
-            v1-bundler-${{ runner.os }}-${{ steps.ruby_version.outputs.value }}-
-      - name: Install bundler
-        run: gem update --system && gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -1 | tr -d " ")
-      - name: Install Gemfile gems
-        run: bundle install
-      - name: Install Appraisal gems
-        run: bundle exec appraisal install --path $BUNDLE_PATH
-      # /Dependencies
+          bundler-cache: true
 
+      # Lint
       - name: Run linter
         run: bin/lint --nofix
 
@@ -54,7 +35,10 @@ jobs:
     strategy:
       matrix:
         ruby: [2.5, 2.6, 2.7, 3.0, jruby-9.2.13.0, jruby-9.2.14.0]
-        pg: [12.5, 10.8]
+        pg: [12.5]
+        include:
+          - ruby: 2.7
+            pg: 10.8
     env:
       PGHOST: localhost
       PGUSER: test_app
@@ -62,6 +46,7 @@ jobs:
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
       BUNDLE_PATH: vendor/bundle
+      BUNDLE_WITHOUT: "lint"
       DISABLE_SPRING: 1
     services:
       postgres:
@@ -77,35 +62,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Update .ruby-version with matrix value
+        run: echo "${{ matrix.ruby }}" >| .ruby-version
 
       # Dependencies
-      - name: Install missing libs (This is slated to be added to the base image soon!)
-        run: sudo apt-get -yqq install libpq-dev
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler: none
-      - name: Ruby gem cache
-        uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: v1-bundler-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('**/good_job.gemspec') }}-${{ hashFiles('**/Gemfile.lock') }}-${{ hashFiles('**/Appraisals') }}
-          restore-keys: |
-            v1-bundler-${{ runner.os }}-${{ matrix.ruby }}-
-      - name: Install bundler
-        run: gem update --system && gem install bundler --default -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -1 | tr -d " ")
-      - name: Install Gemfile gems
-        run: bundle install --without lint
+          bundler-cache: true
       - name: Install Appraisal gems
-        run: bundle exec appraisal install --without lint --path $BUNDLE_PATH
-      # /Dependencies
+        run: bundle exec appraisal install
 
+      # Test
       - name: Set up test database
         run: bin/rails db:test:prepare
         working-directory: spec/test_app
       - name: Run tests
-        run: bundle exec appraisal bin/rspec
+        run: bundle exec appraisal rspec
+
+      # Archive
       - name: Archive system spec screenshots
         uses: actions/upload-artifact@v2
         if: failure()

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gemspec
 # your gem to rubygems.org.
 
 gem 'activerecord-jdbcpostgresql-adapter', platforms: [:jruby]
+gem 'appraisal', github: "excid3/appraisal", branch: "fix-bundle-env" # https://github.com/thoughtbot/appraisal/pull/174
 gem 'pg', platforms: [:mri, :mingw, :x64_mingw]
 gem 'rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/excid3/appraisal.git
+  revision: 8bb003b273ae074356dc67b59ecc67c8ae2f3a27
+  branch: fix-bundle-env
+  specs:
+    appraisal (2.3.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: .
   specs:
@@ -78,10 +88,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    appraisal (2.4.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.2)
     better_html (1.0.16)
       actionview (>= 4.0)
@@ -177,6 +183,7 @@ GEM
     mixlib-shellout (3.2.5)
       chef-utils
     msgpack (1.4.2)
+    msgpack (1.4.2-java)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.5)
@@ -333,7 +340,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-jdbcpostgresql-adapter
-  appraisal
+  appraisal!
   capybara
   database_cleaner
   dotenv

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -54,7 +54,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", ">= 0.14.1"
   spec.add_dependency "zeitwerk", ">= 2.0"
 
-  spec.add_development_dependency "appraisal"
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "dotenv"


### PR DESCRIPTION
Fixes problem by pinning https://github.com/thoughtbot/appraisal/pull/174

Also took opportunity to simplify the Github Actions:
- Fully use `ruby/setup-ruby` action's bundler version and gem caching
- Simplify the ruby/pg matrix
- `libpg-dev` has been added to the base image: https://github.com/actions/virtual-environments/issues/12 and the line about "Install missing libs" can be removed.

Response to seeing errors like:

-    ```
      Run bundle exec appraisal install --without lint --path $BUNDLE_PATH
      bundler: failed to load command: appraisal (/home/runner/work/good_job/good_job/vendor/bundle/ruby/2.7.0/bin/appraisal)
      /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/site_ruby/2.7.0/bundler/runtime.rb:302:in `check_for_activated_spec!': You have already activated bundler 2.2.11, but your Gemfile requires bundler 2.2.13. Since bundler is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports bundler as a default gem. (Gem::LoadError)
      ```
- ` Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered`