### PR TITLE
Add GoodJob::BaseRecord as base for all ActiveRecord queries to support multiple databases

### DIFF
--- a/lib/good_job/base_record.rb
+++ b/lib/good_job/base_record.rb
@@ -1,0 +1,5 @@
+module GoodJob
+  class BaseRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -2,7 +2,7 @@ module GoodJob
   #
   # Represents a request to perform an +ActiveJob+ job.
   #
-  class Job < ActiveRecord::Base
+  class Job < BaseRecord
     include Lockable
 
     # Raised if something attempts to execute a previously completed Job again.

--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -36,7 +36,7 @@ module GoodJob # :nodoc:
     # Send a message via Postgres NOTIFY
     # @param message [#to_json]
     def self.notify(message)
-      connection = ActiveRecord::Base.connection
+      connection = BaseRecord.connection
       connection.exec_query <<~SQL.squish
         NOTIFY #{CHANNEL}, #{connection.quote(message.to_json)}
       SQL
@@ -159,8 +159,8 @@ module GoodJob # :nodoc:
     end
 
     def with_listen_connection
-      ar_conn = ActiveRecord::Base.connection_pool.checkout.tap do |conn|
-        ActiveRecord::Base.connection_pool.remove(conn)
+      ar_conn = BaseRecord.connection_pool.checkout.tap do |conn|
+        BaseRecord.connection_pool.remove(conn)
       end
       pg_conn = ar_conn.raw_connection
       raise AdapterCannotListenError unless pg_conn.respond_to? :wait_for_notify


### PR DESCRIPTION
The intention is to improve support for [Rails Multiple Databases](https://guides.rubyonrails.org/active_record_multiple_databases.html).

This is experimental. 

To use with Multiple Databases, add to `config/initializers/good_job.rb`:

```
GoodJob::BaseRecord.connects_to database: { writing: :your_database }
```

Fixes #236. Possible solution to https://github.com/bensheldon/good_job/issues/52#issuecomment-796789483 too.