### PR TITLE
Add async_server detection for extensions of rack handler

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -150,6 +150,7 @@ module GoodJob
 
       @_in_server_process = Rails.const_defined?('Server') ||
                             caller.grep(%r{config.ru}).any? || # EXAMPLE: config.ru:3:in `block in <main>' OR config.ru:3:in `new_from_string'
+                            caller.grep(%{/rack/handler/}).any? || # EXAMPLE: iodine-0.7.44/lib/rack/handler/iodine.rb:13:in `start'
                             (Concurrent.on_jruby? && caller.grep(%r{jruby/rack/rails_booter}).any?) # EXAMPLE: uri:classloader:/jruby/rack/rails_booter.rb:83:in `load_environment'
     end
   end


### PR DESCRIPTION
Closes #244.

Directly intended to give support for Iodine, but also is the same interface for Thin, Webrick, etc.