### PR TITLE
Fix dashboard jobs endless pagination with timezone handling

### DIFF
--- a/engine/app/controllers/good_job/dashboards_controller.rb
+++ b/engine/app/controllers/good_job/dashboards_controller.rb
@@ -12,7 +12,8 @@ module GoodJob
       end
 
       def jobs
-        sql = GoodJob::Job.display_all(after_scheduled_at: params[:after_scheduled_at], after_id: params[:after_id])
+        after_scheduled_at = params[:after_scheduled_at].present? ? Time.zone.parse(params[:after_scheduled_at]) : nil
+        sql = GoodJob::Job.display_all(after_scheduled_at: after_scheduled_at, after_id: params[:after_id])
                           .limit(params.fetch(:limit, 10))
         if params[:job_class] # rubocop:disable Style/IfUnlessModifier
           sql = sql.where("serialized_params->>'job_class' = ?", params[:job_class])

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -160,6 +160,25 @@ RSpec.describe GoodJob::Job do
     end
   end
 
+  describe '.display_all' do
+    let(:active_job) { ExampleJob.new }
+
+    it 'does not return jobs after last scheduled at' do
+      described_class.enqueue(active_job, scheduled_at: '2021-05-14 09:33:16 +0200')
+
+      expect(described_class.display_all(after_scheduled_at: Time.zone.parse('2021-05-14 09:33:16 +0200')).count).to eq(0)
+    end
+
+    it 'does not return jobs after last scheduled at and job id' do
+      described_class.enqueue(active_job, scheduled_at: '2021-05-14 09:33:16 +0200')
+      job_id = described_class.last!.id
+
+      expect(
+        described_class.display_all(after_scheduled_at: Time.zone.parse('2021-05-14 09:33:16 +0200'), after_id: job_id).count
+      ).to eq(0)
+    end
+  end
+
   describe '#executable?' do
     it 'is true when locked' do
       job.with_advisory_lock do


### PR DESCRIPTION
Having `config.time_zone = "Europe/Berlin"` in the app, to properly handle time zone, we need to parse timestamp.
The difference before the patch:

```
irb(main):033:0> GoodJob::Job.display_all(after_scheduled_at: '2021-04-21 10:36:12 +0200').count
   (1.3ms)  SELECT COUNT(*) FROM "good_jobs" WHERE ((COALESCE(scheduled_at, created_at)) < ('2021-04-21 10:36:12 +0200'))
=> 1
irb(main):034:0> GoodJob::Job.display_all(after_scheduled_at: Time.zone.parse('2021-04-21 10:36:12 +0200')).count
   (1.2ms)  SELECT COUNT(*) FROM "good_jobs" WHERE ((COALESCE(scheduled_at, created_at)) < ('2021-04-21 08:36:12'))
=> 0
```