### PR TITLE
Collapse Dashboard params by default

### DIFF
--- a/engine/app/controllers/good_job/dashboards_controller.rb
+++ b/engine/app/controllers/good_job/dashboards_controller.rb
@@ -14,7 +14,7 @@ module GoodJob
       def jobs
         after_scheduled_at = params[:after_scheduled_at].present? ? Time.zone.parse(params[:after_scheduled_at]) : nil
         sql = GoodJob::Job.display_all(after_scheduled_at: after_scheduled_at, after_id: params[:after_id])
-                          .limit(params.fetch(:limit, 10))
+                          .limit(params.fetch(:limit, 25))
         sql = sql.with_job_class(params[:job_class]) if params[:job_class]
         if params[:state]
           case params[:state]

--- a/engine/app/views/shared/_jobs_table.erb
+++ b/engine/app/views/shared/_jobs_table.erb
@@ -19,7 +19,13 @@
             <td><%= job.queue_name %></td>
             <td><%= job.scheduled_at || job.created_at %></td>
             <td><%= job.error %></td>
-            <td><pre><%= JSON.pretty_generate(job.serialized_params) %></pre></td>
+            <td>
+              <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                data: {bs_toggle: "collapse", bs_target: "##{dom_id(job, 'params')}"},
+                aria: {expanded: false, controls: dom_id(job, "params")}
+              %>
+              <%= tag.pre JSON.pretty_generate(job.serialized_params), id: dom_id(job, "params"), class: "collapse" %>
+            </td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
Having expanded all of the params is very noisy. With this change we can also pack more jobs on page

![image](https://user-images.githubusercontent.com/10766/119619379-37c90680-be04-11eb-89a0-dd7a360dbf9c.png)

