### PR TITLE
Use `FOR UPDATE SKIP LOCKED` alongside advisory lock for more reliable locking

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -158,10 +158,7 @@ module GoodJob
     def self.perform_with_advisory_lock
       unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |good_jobs|
         good_job = good_jobs.first
-        # TODO: Determine why some records are fetched without an advisory lock at all
-        break unless good_job&.executable?
-
-        good_job.perform
+        good_job&.perform
       end
     end
 
@@ -239,12 +236,6 @@ module GoodJob
       end
 
       result
-    end
-
-    # Tests whether this job is safe to be executed by this thread.
-    # @return [Boolean]
-    def executable?
-      self.class.unscoped.unfinished.owns_advisory_locked.exists?(id: id)
     end
 
     private

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -177,30 +177,6 @@ RSpec.describe GoodJob::Job do
     end
   end
 
-  describe '#executable?' do
-    let(:good_job) { described_class.create! }
-
-    it 'is true when locked' do
-      good_job.with_advisory_lock do
-        expect(good_job.executable?).to eq true
-      end
-    end
-
-    it 'is false when job no longer exists' do
-      good_job.with_advisory_lock do
-        good_job.destroy!
-        expect(good_job.executable?).to eq false
-      end
-    end
-
-    it 'is false when the job has finished' do
-      good_job.with_advisory_lock do
-        good_job.update! finished_at: Time.current
-        expect(good_job.executable?).to eq false
-      end
-    end
-  end
-
   describe '#perform' do
     let(:active_job) { ExampleJob.new("a string") }
     let!(:good_job) { described_class.enqueue(active_job) }

--- a/spec/lib/good_job/lockable_spec.rb
+++ b/spec/lib/good_job/lockable_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe GoodJob::Lockable do
           FROM "rows"
           WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || "rows"."id"::text), 1, 16))::bit(64)::bigint)
           LIMIT 2
+          FOR UPDATE SKIP LOCKED
         )
         ORDER BY "good_jobs"."priority" DESC
       SQL


### PR DESCRIPTION
Found implementation in `rihanna` that is similar: https://github.com/samsondav/rihanna/blob/1840d2226fd2bcb77635f995f431b26e8f2dfc69/lib/rihanna/job.ex#L364-L367