### PR TITLE
Use custom RSpec doc formatter to show spec examples that are running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,9 @@ jobs:
         run: bin/rails db:test:prepare
         working-directory: spec/test_app
       - name: Run tests
-        run: bundle exec appraisal rspec
+        run: |
+          bundle exec appraisal rspec --require ./spec/support/pre_documentation_formatter.rb \
+                                      --format PreDocumentationFormatter
 
       # Archive
       - name: Archive system spec screenshots

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,10 +77,22 @@ jobs:
       - name: Set up test database
         run: bin/rails db:test:prepare
         working-directory: spec/test_app
-      - name: Run tests
+      - name: Run Unit tests
+        run: |
+          bundle exec appraisal rspec --exclude-pattern "spec/system/**/*_spec.rb, spec/lib/generators/**/*_spec.rb" \
+                                      --require ./spec/support/pre_documentation_formatter.rb \
+                                      --format PreDocumentationFormatter
+      - name: Run System tests
         run: |
           bundle exec appraisal rspec --require ./spec/support/pre_documentation_formatter.rb \
-                                      --format PreDocumentationFormatter
+                                      --format PreDocumentationFormatter \
+                                      spec/system
+
+      - name: Run Generators tests
+        run: |
+          bundle exec appraisal rspec --require ./spec/support/pre_documentation_formatter.rb \
+                                      --format PreDocumentationFormatter \
+                                      spec/lib/generators
 
       # Archive
       - name: Archive system spec screenshots

--- a/spec/support/pg_locks.rb
+++ b/spec/support/pg_locks.rb
@@ -5,8 +5,19 @@ module PostgresXidExtension
   end
 end
 
+PostgresNoticeError = Class.new(StandardError)
+
 ActiveSupport.on_load :active_record do
   ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.prepend PostgresXidExtension
+
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback :checkout, :before, lambda { |conn|
+    raw_connection = conn.raw_connection
+    next unless raw_connection.respond_to? :set_notice_receiver
+
+    raw_connection.set_notice_receiver do |result|
+      raise PostgresNoticeError, result.error_message
+    end
+  }
 end
 
 class PgLock < ActiveRecord::Base
@@ -23,11 +34,19 @@ class PgLock < ActiveRecord::Base
     SQL
     self.class.unscoped.exists?([where_sql, classid, objid])
   end
+
+  def unlock!
+    where_sql = <<~SQL.squish
+      pg_terminate_backend(?)
+    SQL
+    self.class.unscoped.exists?([where_sql, pid])
+  end
 end
 
 RSpec.configure do |config|
   config.before do
-    PgLock.advisory_lock.each(&:unlock) if PgLock.advisory_lock.count > 0
+    PgLock.advisory_lock.owns.each(&:unlock) if PgLock.advisory_lock.owns.count > 0
+    PgLock.advisory_lock.others.each(&:unlock!) if PgLock.advisory_lock.others.count > 0
     expect(PgLock.advisory_lock.count).to eq(0), "Existing advisory locks BEFORE test run"
   end
 

--- a/spec/support/pre_documentation_formatter.rb
+++ b/spec/support/pre_documentation_formatter.rb
@@ -1,0 +1,63 @@
+RSpec::Support.require_rspec_core "formatters/base_text_formatter"
+RSpec::Support.require_rspec_core "formatters/console_codes"
+
+class PreDocumentationFormatter < RSpec::Core::Formatters::BaseTextFormatter
+  RSpec::Core::Formatters.register self, :example_started, :example_group_started, :example_group_finished,
+                                   :example_passed, :example_pending, :example_failed
+
+  def initialize(output)
+    super
+    @group_level = 0
+  end
+
+  def example_group_started(notification)
+    output.puts if @group_level == 0
+    output.puts "#{current_indentation}#{notification.group.description.strip}"
+
+    @group_level += 1
+  end
+
+  def example_group_finished(_notification)
+    @group_level -= 1 if @group_level > 0
+  end
+
+  def example_passed(passed)
+    output.puts passed_output(passed.example)
+  end
+
+  def example_pending(pending)
+    output.puts pending_output(pending.example,
+                               pending.example.execution_result.pending_message)
+  end
+
+  def example_failed(failure)
+    output.puts failure_output(failure.example)
+  end
+
+  def example_started(notification)
+    output.puts "#{current_indentation}RUNNING: #{notification.example.description}"
+  end
+
+  private
+
+  def passed_output(example)
+    RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{example.description.strip}", :success)
+  end
+
+  def pending_output(example, message)
+    RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{example.description.strip} (PENDING: #{message})", :pending)
+  end
+
+  def failure_output(example)
+    RSpec::Core::Formatters::ConsoleCodes.wrap("#{current_indentation}#{example.description.strip} (FAILED - #{next_failure_index})", :failure)
+  end
+
+  def next_failure_index
+    @next_failure_index ||= 0
+    @next_failure_index += 1
+  end
+
+  def current_indentation
+    '  ' * @group_level
+  end
+end


### PR DESCRIPTION
- Separate Unit, System and Generator tests
- Unlock other connections' advisory locks by disconnecting them