### PR TITLE
Add concurrency extension for ActiveJob

### DIFF
--- a/lib/good_job/active_job_extensions.rb
+++ b/lib/good_job/active_job_extensions.rb
@@ -1,0 +1,4 @@
+module GoodJob
+  module ActiveJobExtensions
+  end
+end

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -1,0 +1,68 @@
+module GoodJob
+  module ActiveJobExtensions
+    module Concurrency
+      extend ActiveSupport::Concern
+
+      ConcurrencyExceededError = Class.new(StandardError)
+
+      included do
+        class_attribute :good_job_concurrency_config, instance_accessor: false, default: {}
+
+        before_enqueue do |job|
+          # Always allow jobs to be retried because the current job's execution will complete momentarily
+          next if CurrentExecution.active_job_id == job.job_id
+
+          limit = job.class.good_job_concurrency_config.fetch(:enqueue_limit, Float::INFINITY)
+          next if limit.blank? || (0...Float::INFINITY).exclude?(limit)
+
+          key = job.good_job_concurrency_key
+          next if key.blank?
+
+          GoodJob::Job.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
+            # TODO: Why is `unscoped` necessary? Nested scope is bleeding into subsequent query?
+            enqueue_concurrency = GoodJob::Job.unscoped.where(concurrency_key: key).unfinished.count
+            # The job has not yet been enqueued, so check if adding it will go over the limit
+            throw :abort if enqueue_concurrency + 1 > limit
+          end
+        end
+
+        retry_on(
+          GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+          attempts: Float::INFINITY,
+          wait: :exponentially_longer
+        )
+
+        before_perform do |job|
+          limit = job.class.good_job_concurrency_config.fetch(:perform_limit, Float::INFINITY)
+          next if limit.blank? || (0...Float::INFINITY).exclude?(limit)
+
+          key = job.good_job_concurrency_key
+          next if key.blank?
+
+          GoodJob::Job.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
+            perform_concurrency = GoodJob::Job.unscoped.where(concurrency_key: key).advisory_locked.count
+            # The current job has already been locked and will appear in the previous query
+            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError if perform_concurrency > limit
+          end
+        end
+      end
+
+      class_methods do
+        def good_job_control_concurrency_with(config)
+          self.good_job_concurrency_config = config
+        end
+      end
+
+      def good_job_concurrency_key
+        key = self.class.good_job_concurrency_config[:key]
+        return if key.blank?
+
+        if key.respond_to? :call
+          instance_exec(&key)
+        else
+          key
+        end
+      end
+    end
+  end
+end

--- a/lib/good_job/current_execution.rb
+++ b/lib/good_job/current_execution.rb
@@ -4,11 +4,11 @@ module GoodJob
   # Thread-local attributes for passing values from Instrumentation.
   # (Cannot use ActiveSupport::CurrentAttributes because ActiveJob resets it)
   module CurrentExecution
-    # @!attribute [rw] error_on_retry
+    # @!attribute [rw] active_job_id
     #   @!scope class
-    #   Error captured by retry_on
-    #   @return [Exception, nil]
-    thread_mattr_accessor :error_on_retry
+    #   ActiveJob ID
+    #   @return [String, nil]
+    thread_mattr_accessor :active_job_id
 
     # @!attribute [rw] error_on_discard
     #   @!scope class
@@ -16,11 +16,18 @@ module GoodJob
     #   @return [Exception, nil]
     thread_mattr_accessor :error_on_discard
 
+    # @!attribute [rw] error_on_retry
+    #   @!scope class
+    #   Error captured by retry_on
+    #   @return [Exception, nil]
+    thread_mattr_accessor :error_on_retry
+
     # Resets attributes
     # @return [void]
     def self.reset
-      self.error_on_retry = nil
+      self.active_job_id = nil
       self.error_on_discard = nil
+      self.error_on_retry = nil
     end
 
     # @return [Integer] Current process ID

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
+  before do
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+
+    stub_const 'TestJob', (Class.new(ActiveJob::Base) do
+      include GoodJob::ActiveJobExtensions::Concurrency
+
+      good_job_control_concurrency_with(
+        enqueue_limit: 2,
+        perform_limit: 0,
+        key: -> { arguments.first[:name] }
+      )
+
+      def perform(name:)
+        name && sleep(1)
+      end
+    end)
+  end
+
+  describe '.good_job_control_concurrency_with' do
+    describe 'enqueue_limit', skip_rails_5: true do
+      it "does not enqueue if enqueue concurrency limit is exceeded for a particular key" do
+        expect(TestJob.perform_later(name: "Alice")).to be_present
+        expect(TestJob.perform_later(name: "Alice")).to be_present
+
+        # Third usage of key does not enqueue
+        expect(TestJob.perform_later(name: "Alice")).to eq false
+
+        # Usage of different key does enqueue
+        expect(TestJob.perform_later(name: "Bob")).to be_present
+
+        expect(GoodJob::Job.where(concurrency_key: "Alice").count).to eq 2
+        expect(GoodJob::Job.where(concurrency_key: "Bob").count).to eq 1
+      end
+    end
+
+    describe 'perform_limit' do
+      before do
+        allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+      end
+
+      it "will error and retry jobs if concurrency is exceeded" do
+        TestJob.perform_later(name: "Alice")
+
+        performer = GoodJob::JobPerformer.new('*')
+        scheduler = GoodJob::Scheduler.new(performer, max_threads: 5)
+        5.times { scheduler.create_thread }
+
+        sleep_until(max: 10, increments_of: 0.5) do
+          GoodJob::Job.where(concurrency_key: "Alice").finished.count >= 1
+        end
+        scheduler.shutdown
+
+        expect(GoodJob::Job.count).to be >= 1
+        expect(GoodJob::Job.where("error LIKE '%GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError%'")).to be_present
+      end
+    end
+  end
+end

--- a/spec/lib/good_job/current_execution_spec.rb
+++ b/spec/lib/good_job/current_execution_spec.rb
@@ -52,4 +52,19 @@ RSpec.describe GoodJob::CurrentExecution do
       expect(described_class.error_on_retry).to eq nil
     end
   end
+
+  describe '.active_job_id' do
+    it 'is assignable, thread-safe, and resettable' do
+      described_class.active_job_id = 'duck'
+
+      Thread.new do
+        described_class.active_job_id = 'bear'
+      end.join
+
+      expect(described_class.active_job_id).to eq 'duck'
+
+      described_class.reset
+      expect(described_class.active_job_id).to eq nil
+    end
+  end
 end

--- a/spec/lib/good_job/lockable_spec.rb
+++ b/spec/lib/good_job/lockable_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe GoodJob::Lockable do
 
       job.advisory_unlock(key: "alternative")
     end
+
+    it 'can lock alternative postgres functions' do
+      job.advisory_lock!(function: "pg_advisory_lock")
+      expect(job.advisory_locked?).to be true
+      job.advisory_unlock
+    end
   end
 
   describe '#advisory_unlock' do

--- a/spec/support/rails_versions.rb
+++ b/spec/support/rails_versions.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |c|
+  less_than_rails_6 = Gem::Version.new(Rails.version) < Gem::Version.new('6')
+  c.filter_run_excluding(:skip_rails_5) if less_than_rails_6
+end


### PR DESCRIPTION
Creates`GoodJob::ActiveJobExtensions::Concurrency` module that can be included into ActiveJob classes.

When enqueuing jobs and concurrency is reached/exceeded, jobs are not enqueued and the `MyJob.perform_later` returns `false` using native callback behavior of `throw :abort`

When performing jobs and concurrency is reached/exceeded, jobs are retried using an incremental backoff, using native ActiveJob `retry_on ... attempts: Float::INFINITY, wait: :exponentially_longer` functionality.

Closes #206.