### PR TITLE
Dashboard AssetsController does not raise if verify_authenticity_token is not in the callback chain

### DIFF
--- a/engine/app/controllers/good_job/assets_controller.rb
+++ b/engine/app/controllers/good_job/assets_controller.rb
@@ -1,6 +1,6 @@
 module GoodJob
   class AssetsController < ActionController::Base # rubocop:disable Rails/ApplicationController
-    skip_before_action :verify_authenticity_token
+    skip_before_action :verify_authenticity_token, raise: false
 
     before_action do
       expires_in 1.year, public: true


### PR DESCRIPTION
Closes #282.