### PR TITLE
Remove `FOR UPDATE SKIP LOCKED` from job locking sql statement

### DIFF
--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -48,15 +48,9 @@ module GoodJob
                    end
 
         composed_cte = Arel::Nodes::As.new(cte_table, Arel::Nodes::SqlLiteral.new([cte_type, "(", cte_query.to_sql, ")"].join(' ')))
-
-        # In addition to an advisory lock, there is also a FOR UPDATE SKIP LOCKED
-        # because this causes the query to skip jobs that were completed (and deleted)
-        # by another session in the time since the table snapshot was taken.
-        # In rare cases under high concurrency levels, leaving this out can result in double executions.
         query = cte_table.project(cte_table[:id])
                          .with(composed_cte)
                          .where(Arel.sql(sanitize_sql_for_conditions(["#{function}(('x' || substr(md5(:table_name || #{connection.quote_table_name(cte_table.name)}.#{connection.quote_column_name(column)}::text), 1, 16))::bit(64)::bigint)", { table_name: table_name }])))
-                         .lock(Arel.sql("FOR UPDATE SKIP LOCKED"))
 
         limit = original_query.arel.ast.limit
         query.limit = limit.value if limit.present?

--- a/spec/lib/good_job/lockable_spec.rb
+++ b/spec/lib/good_job/lockable_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe GoodJob::Lockable do
           FROM "rows"
           WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || "rows"."id"::text), 1, 16))::bit(64)::bigint)
           LIMIT 2
-          FOR UPDATE SKIP LOCKED
         )
         ORDER BY "good_jobs"."priority" DESC
       SQL
@@ -58,7 +57,6 @@ RSpec.describe GoodJob::Lockable do
           FROM "rows"
           WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || "rows"."queue_name"::text), 1, 16))::bit(64)::bigint)
           LIMIT 2
-          FOR UPDATE SKIP LOCKED
         )
         ORDER BY "good_jobs"."priority" DESC
       SQL


### PR DESCRIPTION
The `FOR UPDATE SKIP LOCKED` was introduced in #273.

1. it never addressed this line: https://github.com/bensheldon/good_job/blob/4fbf340dae50d6df88705a1fabb81c5738324c6b/lib/good_job/job.rb#L162

2. I hypothesize that it is causing lock contention on the `good_jobs` table (#287), which is preventing migrations without having to shut down the job workers. 