### PR TITLE
Add cron-like support for recurring/repeating jobs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ PATH
       activejob (>= 5.2.0)
       activerecord (>= 5.2.0)
       concurrent-ruby (>= 1.0.2)
+      fugit (>= 1.1)
       railties (>= 5.2.0)
       thor (>= 0.14.1)
       zeitwerk (>= 2.0)
@@ -154,6 +155,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.10.0)
+    et-orbi (1.2.4)
+      tzinfo
     faraday (1.5.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -177,6 +180,9 @@ GEM
     ffi (1.15.3-java)
     fiber-local (1.0.0)
     foreman (0.87.2)
+    fugit (1.5.0)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     gem-release (2.2.2)
     github_changelog_generator (1.16.4)
       activesupport
@@ -220,7 +226,6 @@ GEM
     mixlib-shellout (3.2.5)
       chef-utils
     msgpack (1.4.2)
-    msgpack (1.4.2-java)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     nio4r (2.5.7)
@@ -262,6 +267,7 @@ GEM
       nio4r (~> 2.0)
     puma (5.3.2-java)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.5.2)
     racc (1.5.2-java)
     rack (2.2.3)

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", ">= 5.2.0"
   spec.add_dependency "activerecord", ">= 5.2.0"
   spec.add_dependency "concurrent-ruby", ">= 1.0.2"
+  spec.add_dependency "fugit", ">= 1.1"
   spec.add_dependency "railties", ">= 5.2.0"
   spec.add_dependency "thor", ">= 0.14.1"
   spec.add_dependency "zeitwerk", ">= 2.0"

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -57,6 +57,8 @@ module GoodJob
         @scheduler = GoodJob::Scheduler.from_configuration(@configuration, warm_cache_on_initialize: Rails.application.initialized?)
         @notifier.recipients << [@scheduler, :create_thread]
         @poller.recipients << [@scheduler, :create_thread]
+
+        @cron_manager = GoodJob::CronManager.new(@configuration.cron, start_on_initialize: Rails.application.initialized?) if @configuration.enable_cron?
       end
     end
 

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -18,6 +18,8 @@ module GoodJob
     DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO = 24 * 60 * 60
     # Default to always wait for jobs to finish for {Adapter#shutdown}
     DEFAULT_SHUTDOWN_TIMEOUT = -1
+    # Default to not running cron
+    DEFAULT_ENABLE_CRON = false
 
     # The options that were explicitly set when initializing +Configuration+.
     # @return [Hash]
@@ -127,6 +129,28 @@ module GoodJob
           env['GOOD_JOB_SHUTDOWN_TIMEOUT'] ||
           DEFAULT_SHUTDOWN_TIMEOUT
       ).to_f
+    end
+
+    # Whether to run cron
+    # @return [Boolean]
+    def enable_cron
+      value = ActiveModel::Type::Boolean.new.cast(
+        options[:enable_cron] ||
+        rails_config[:enable_cron] ||
+        env['GOOD_JOB_ENABLE_CRON'] ||
+        false
+      )
+      value && cron.size.positive?
+    end
+    alias enable_cron? enable_cron
+
+    def cron
+      env_cron = JSON.parse(ENV['GOOD_JOB_CRON']) if ENV['GOOD_JOB_CRON'].present?
+
+      options[:cron] ||
+        rails_config[:cron] ||
+        env_cron ||
+        {}
     end
 
     # Number of seconds to preserve jobs when using the +good_job cleanup_preserved_jobs+ CLI command.

--- a/lib/good_job/cron_manager.rb
+++ b/lib/good_job/cron_manager.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+require "concurrent/hash"
+require "concurrent/scheduled_task"
+require "fugit"
+
+module GoodJob # :nodoc:
+  #
+  # CronManagers enqueue jobs on a repeating schedule.
+  #
+  class CronManager
+    # @!attribute [r] instances
+    #   @!scope class
+    #   List of all instantiated CronManagers in the current process.
+    #   @return [Array<GoodJob::CronManagers>, nil]
+    cattr_reader :instances, default: [], instance_reader: false
+
+    # Task observer for cron task
+    # @param time [Time]
+    # @param output [Object]
+    # @param thread_error [Exception]
+    def self.task_observer(time, output, thread_error) # rubocop:disable Lint/UnusedMethodArgument
+      return if thread_error.is_a? Concurrent::CancelledOperationError
+
+      GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+    end
+
+    # Job configuration to be scheduled
+    # @return [Hash]
+    attr_reader :schedules
+
+    # @param schedules [Hash]
+    # @param start_on_initialize [Boolean]
+    def initialize(schedules = {}, start_on_initialize: false)
+      @running = false
+      @schedules = schedules
+      @tasks = Concurrent::Hash.new
+
+      self.class.instances << self
+
+      start if start_on_initialize
+    end
+
+    # Schedule tasks that will enqueue jobs based on their schedule
+    def start
+      ActiveSupport::Notifications.instrument("cron_manager_start.good_job", cron_jobs: @schedules) do
+        @running = true
+        schedules.each_key { |cron_key| create_task(cron_key) }
+      end
+    end
+
+    # Stop/cancel any scheduled tasks
+    # @param timeout [Numeric, nil] Unused but retained for compatibility
+    def shutdown(timeout: nil) # rubocop:disable Lint/UnusedMethodArgument
+      @running = false
+      @tasks.each do |_cron_key, task|
+        task.cancel
+      end
+      @tasks.clear
+    end
+
+    # Stop and restart
+    # @param timeout [Numeric, nil] Unused but retained for compatibility
+    def restart(timeout: nil) # rubocop:disable Lint/UnusedMethodArgument
+      shutdown
+      start
+    end
+
+    # Tests whether the manager is running.
+    # @return [Boolean, nil]
+    def running?
+      @running
+    end
+
+    # Tests whether the manager is shutdown.
+    # @return [Boolean, nil]
+    def shutdown?
+      !running?
+    end
+
+    # Enqueues a scheduled task
+    # @param cron_key [Symbol, String] the key within the schedule to use
+    def create_task(cron_key)
+      schedule = @schedules[cron_key]
+      return false if schedule.blank?
+
+      fugit = Fugit::Cron.parse(schedule.fetch(:cron))
+      delay = [(fugit.next_time - Time.current).to_f, 0].max
+
+      future = Concurrent::ScheduledTask.new(delay, args: [self, cron_key]) do |thr_scheduler, thr_cron_key|
+        # Re-schedule the next cron task before executing the current task
+        thr_scheduler.create_task(thr_cron_key)
+
+        CurrentExecution.reset
+        CurrentExecution.cron_key = thr_cron_key
+
+        Rails.application.executor.wrap do
+          schedule = thr_scheduler.schedules.fetch(thr_cron_key).with_indifferent_access
+          job_class = schedule.fetch(:class).constantize
+
+          job_set_value = schedule.fetch(:set, {})
+          job_set = job_set_value.respond_to?(:call) ? job_set_value.call : job_set_value
+
+          job_args_value = schedule.fetch(:args, [])
+          job_args = job_args_value.respond_to?(:call) ? job_args_value.call : job_args_value
+
+          job_class.set(job_set).perform_later(*job_args)
+        end
+      end
+
+      @tasks[cron_key] = future
+      future.add_observer(self.class, :task_observer)
+      future.execute
+    end
+  end
+end

--- a/lib/good_job/current_execution.rb
+++ b/lib/good_job/current_execution.rb
@@ -11,6 +11,12 @@ module GoodJob
     #   @return [String, nil]
     thread_mattr_accessor :active_job_id
 
+    # @!attribute [rw] cron_key
+    #   @!scope class
+    #   Cron Key
+    #   @return [String, nil]
+    thread_mattr_accessor :cron_key
+
     # @!attribute [rw] error_on_discard
     #   @!scope class
     #   Error captured by discard_on

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -58,6 +58,16 @@ module GoodJob
     end
 
     # @!macro notification_responder
+    def cron_manager_start(event)
+      cron_jobs = event.payload[:cron_jobs]
+      cron_jobs_count = cron_jobs.size
+
+      info do
+        "GoodJob started cron with #{cron_jobs_count} #{'jobs'.pluralize(cron_jobs_count)}."
+      end
+    end
+
+    # @!macro notification_responder
     def scheduler_shutdown_start(event)
       process_id = event.payload[:process_id]
 

--- a/lib/good_job/railtie.rb
+++ b/lib/good_job/railtie.rb
@@ -3,6 +3,7 @@ module GoodJob
   # Ruby on Rails integration.
   class Railtie < ::Rails::Railtie
     config.good_job = ActiveSupport::OrderedOptions.new
+    config.good_job.cron = {}
 
     initializer "good_job.logger" do |_app|
       ActiveSupport.on_load(:good_job) do
@@ -23,6 +24,7 @@ module GoodJob
 
     config.after_initialize do
       GoodJob::Scheduler.instances.each(&:warm_cache)
+      GoodJob::CronManager.instances.each(&:start)
     end
   end
 end

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -22,10 +22,12 @@ RSpec.describe 'Server modes', skip_if_java: true do
       env = {
         "RAILS_ENV" => "production",
         "GOOD_JOB_EXECUTION_MODE" => "async",
+        "GOOD_JOB_ENABLE_CRON" => "true",
       }
       ShellOut.command('bundle exec rails s', env: env) do |shell|
         wait_until(max: 30) do
           expect(shell.output).to include(/GoodJob started scheduler/)
+          expect(shell.output).to include(/GoodJob started cron/)
         end
       end
     end

--- a/spec/lib/good_job/cron_manager_spec.rb
+++ b/spec/lib/good_job/cron_manager_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GoodJob::CronManager do
+  let(:schedules) { {} }
+
+  describe '#start' do
+    it 'stops the cron manager' do
+      cron_manager = described_class.new(schedules, start_on_initialize: false)
+      expect do
+        cron_manager.start
+      end.to change(cron_manager, :running?).from(false).to true
+    end
+  end
+
+  describe '#stop' do
+    it 'starts the cron manager' do
+      cron_manager = described_class.new(schedules, start_on_initialize: true)
+      expect do
+        cron_manager.shutdown
+      end.to change(cron_manager, :running?).from(true).to false
+    end
+  end
+
+  describe 'schedules' do
+    let(:schedules) do
+      {
+        example: {
+          cron: "* * * * * *", # cron-style scheduling format by fugit gem, allows seconds resolution
+          class: "TestJob", # reference the Job class with a string
+          args: [42, { name: "Alice" }], # arguments to pass.  Could also allow a Proc for dynamic args, but problematic?
+          set: { priority: -10 }, # additional ActiveJob properties. Could also allow a Proc for dynamic args, but problematic?
+          description: "Something helpful", # optional description that appears in Dashboard
+        },
+      }
+    end
+
+    before do
+      stub_const 'TestJob', Class.new(ActiveJob::Base)
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    end
+
+    it 'executes the defined tasks' do
+      cron_manager = described_class.new(schedules, start_on_initialize: true)
+
+      wait_until(max: 5) do
+        expect(GoodJob::Job.count).to eq 3
+      end
+
+      good_job = GoodJob::Job.first
+      expect(good_job).to have_attributes(
+        cron_key: 'example',
+        priority: -10
+      )
+
+      cron_manager.shutdown
+    end
+  end
+end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -32,6 +32,9 @@ RSpec.configure do |config|
     expect(GoodJob::Poller.instances).to all be_shutdown
     GoodJob::Poller.instances.clear
 
+    expect(GoodJob::CronManager.instances).to all be_shutdown
+    GoodJob::CronManager.instances.clear
+
     expect(GoodJob::Scheduler.instances).to all be_shutdown
     GoodJob::Scheduler.instances.clear
 

--- a/spec/test_app/app/jobs/cleanup_job.rb
+++ b/spec/test_app/app/jobs/cleanup_job.rb
@@ -1,0 +1,6 @@
+class CleanupJob < ApplicationJob
+  def perform(limit: 5_000)
+    earliest = GoodJob::Job.finished.order(created_at: :desc).limit(limit).last.created_at
+    GoodJob::Job.where("created_at < ?", earliest).delete_all
+  end
+end

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -19,6 +19,14 @@ module TestApp
 
     # config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
     config.log_level = :debug
+
+    config.good_job.cron = {
+      example: {
+        cron: '*/5 * * * * *', # every 5 seconds
+        class: 'ExampleJob',
+        description: "Enqueue ExampleJob every 5 seconds",
+      },
+    }
   end
 end
 

--- a/spec/test_app/config/environments/demo.rb
+++ b/spec/test_app/config/environments/demo.rb
@@ -7,4 +7,33 @@ Rails.application.configure do
   config.active_job.queue_adapter = :good_job
   config.good_job.execution_mode = :async_server
   config.good_job.poll_interval = 30
+
+  config.good_job.enable_cron = true
+  config.good_job.cron = {
+    frequent_example: {
+      description: "Enqueue an ExampleJob with a random sample of configuration",
+      cron: "*/5 * * * * *", # every 5 seconds
+      class: "ExampleJob",
+      args: [],
+      set: (lambda do
+        queue = [:default, :elephants, :mice].sample
+        delay = (0..60).to_a.sample
+        priority = [-10, 0, 10].sample
+
+        { wait: delay, queue: queue, priority: priority }
+      end),
+    },
+    other_example: {
+      description: "Enqueue an OtherJob occasionally",
+      cron: "* * * * *", # every minute
+      class: "OtherJob",
+      set: { queue: :default },
+    },
+    cleanup: {
+      description: "Delete old jobs every hour",
+      cron: "0 * * * *", # every hour
+      class: "CleanupJob",
+      set: { queue: :default },
+    }
+  }
 end


### PR DESCRIPTION
- Separates Cron Configuration (`config.good_job.cron = {}`) from enabling cron (`config.good_job.enable_cron`). The intention is that configuration should be global to the application and whether it is enabled or not be process specific. This will more easily allow cron configuration to be displayed on the web Dashboard which might be a separate process from the worker.
- Can run via the CLI or via `async` / `async_server` 
- Closes #53 / #129