### PR TITLE
Lock GoodJob::Job on active_job_id instead of the row id; adds separator hyphen to lock key

### DIFF
--- a/lib/good_job/job.rb
+++ b/lib/good_job/job.rb
@@ -16,7 +16,7 @@ module GoodJob
     DEFAULT_PRIORITY = 0
 
     self.table_name = 'good_jobs'
-    self.advisory_lockable_column = 'id'
+    self.advisory_lockable_column = 'active_job_id'
 
     attr_readonly :serialized_params
 

--- a/spec/lib/good_job/job_spec.rb
+++ b/spec/lib/good_job/job_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe GoodJob::Job do
   end
 
   describe '#executable?' do
-    let(:good_job) { described_class.create! }
+    let(:good_job) { described_class.create!(active_job_id: SecureRandom.uuid) }
 
     it 'is true when locked' do
       good_job.with_advisory_lock do


### PR DESCRIPTION
Closes #272. Closes #335.