### PR TITLE
v2.0: Generators support multiple databases: `--database` option, `migrations_paths`, custom `GoodJob.active_record_parent_class`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
     $ bin/rails db:migrate
     ```
 
+   Optional: If using Rails' multiple databases with the `migrations_paths` configuration option, use the `--database` option:
+
+    ```bash
+    bin/rails g good_job:install --database animals
+    bin/rails db:migrate:animals
+    ```
+
 1. Configure the ActiveJob adapter:
 
     ```ruby
@@ -419,6 +426,12 @@ To perform upgrades to the GoodJob database tables:
 
     ```bash
     bin/rails g good_job:update
+    ```
+
+   Optional: If using Rails' multiple databases with the `migrations_paths` configuration option, use the `--database` option:
+
+    ```bash
+    $ bin/rails g good_job:update --database animals
     ```
 
 1. Run the database migration locally

--- a/lib/generators/good_job/install_generator.rb
+++ b/lib/generators/good_job/install_generator.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 require 'rails/generators'
 require 'rails/generators/active_record'
+
 module GoodJob
   #
   # Rails generator used for setting up GoodJob in a Rails application.
   # Run it with +bin/rails g good_job:install+ in your console.
   #
   class InstallGenerator < Rails::Generators::Base
-    include Rails::Generators::Migration
+    include ActiveRecord::Generators::Migration
 
-    class << self
-      delegate :next_migration_number, to: ActiveRecord::Generators::Base
-    end
+    TEMPLATES = File.join(File.dirname(__FILE__), "templates/install")
+    source_paths << TEMPLATES
 
-    source_paths << File.join(File.dirname(__FILE__), "templates/install")
+    class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
     # Generates monolithic migration file that contains all database changes.
     def create_migration_file
-      migration_template 'migrations/create_good_jobs.rb.erb', 'db/migrate/create_good_jobs.rb'
+      migration_template 'migrations/create_good_jobs.rb.erb', File.join(db_migrate_path, "create_good_jobs.rb")
     end
   end
 end

--- a/lib/generators/good_job/update_generator.rb
+++ b/lib/generators/good_job/update_generator.rb
@@ -8,14 +8,12 @@ module GoodJob
   # Run it with +bin/rails g good_job:update+ in your console.
   #
   class UpdateGenerator < Rails::Generators::Base
-    include Rails::Generators::Migration
-
-    class << self
-      delegate :next_migration_number, to: ActiveRecord::Generators::Base
-    end
+    include ActiveRecord::Generators::Migration
 
     TEMPLATES = File.join(File.dirname(__FILE__), "templates/update")
     source_paths << TEMPLATES
+
+    class_option :database, type: :string, aliases: %i(--db), desc: "The database for your migration. By default, the current environment's primary database is used."
 
     # Generates incremental migration files unless they already exist.
     # All migrations should be idempotent e.g. +add_index+ is guarded with +if_index_exists?+
@@ -23,7 +21,7 @@ module GoodJob
       migration_templates = Dir.children(File.join(TEMPLATES, 'migrations')).sort
       migration_templates.each do |template_file|
         destination_file = template_file.match(/^\d*_(.*\.rb)/)[1] # 01_create_good_jobs.rb.erb => create_good_jobs.rb
-        migration_template "migrations/#{template_file}", "db/migrate/#{destination_file}", skip: true
+        migration_template "migrations/#{template_file}", File.join(db_migrate_path, destination_file), skip: true
       end
     end
   end

--- a/spec/test_app/db/migrate/20200224015928_create_good_jobs.rb
+++ b/spec/test_app/db/migrate/20200224015928_create_good_jobs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class CreateGoodJobs < ActiveRecord::Migration[5.2]
   def change
     enable_extension 'pgcrypto'

--- a/spec/test_app/db/migrate/20210623192050_add_active_job_id_concurrency_key_cron_key_to_good_jobs.rb
+++ b/spec/test_app/db/migrate/20210623192050_add_active_job_id_concurrency_key_cron_key_to_good_jobs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AddActiveJobIdConcurrencyKeyCronKeyToGoodJobs < ActiveRecord::Migration[5.2]
   def change
     reversible do |dir|

--- a/spec/test_app/db/migrate/20210623192051_add_active_job_id_index_and_concurrency_key_index_to_good_jobs.rb
+++ b/spec/test_app/db/migrate/20210623192051_add_active_job_id_index_and_concurrency_key_index_to_good_jobs.rb
@@ -1,11 +1,8 @@
+# frozen_string_literal: true
 class AddActiveJobIdIndexAndConcurrencyKeyIndexToGoodJobs < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
   UPDATE_BATCH_SIZE = 1_000
-
-  class GoodJobJobs < ActiveRecord::Base
-    self.table_name = "good_jobs"
-  end
 
   def change
     reversible do |dir|
@@ -20,10 +17,14 @@ class AddActiveJobIdIndexAndConcurrencyKeyIndexToGoodJobs < ActiveRecord::Migrat
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", algorithm: :concurrently, name: :index_good_jobs_on_concurrency_key_when_unfinished
     add_index :good_jobs, [:cron_key, :created_at], algorithm: :concurrently, name: :index_good_jobs_on_cron_key_and_created_at
 
+    return unless defined? GoodJob::Job
+
     reversible do |dir|
       dir.up do
+        # Ensure that all `good_jobs` records have an active_job_id value
+        start_time = Time.current
         loop do
-          break if GoodJobJobs.where(active_job_id: nil, finished_at: nil).limit(UPDATE_BATCH_SIZE).update_all("active_job_id = (serialized_params->>'job_id')::uuid").zero?
+          break if GoodJob::Job.where(active_job_id: nil, finished_at: nil).where("created_at < ?", start_time).limit(UPDATE_BATCH_SIZE).update_all("active_job_id = (serialized_params->>'job_id')::uuid").zero?
         end
       end
     end


### PR DESCRIPTION
Port of #353. Closes #352.

 