### PR TITLE
Add `total_limit:` option to GoodJob::Concurrency to be inclusive of counting both enqueued and performing jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,17 +348,20 @@ GoodJob includes a Dashboard as a mountable `Rails::Engine`.
 
 GoodJob can extend ActiveJob to provide limits on concurrently running jobs, either at time of _enqueue_ or at _perform_. Limiting concurrency can help prevent duplicate, double or unecessary jobs from being enqueued, or race conditions when performing, for example when interacting with 3rd-party APIs.
 
-**Note:** Limiting concurrency at _enqueue_ requires Rails 6.0+ because Rails 5.2 does not support `throw :abort` in ActiveJob callbacks.
+**Note:** Limiting concurrency at _enqueue_ requires Rails 6.0+ because Rails 5.2 cannot halt ActiveJob callbacks.
 
 ```ruby
 class MyJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
 
   good_job_control_concurrency_with(
-    # Maximum number of jobs with the concurrency key to be concurrently enqueued
-    enqueue_limit: 2,
+    # Maximum number of unfinished jobs to allow with the concurrency key
+    total_limit: 1,
 
-    # Maximum number of jobs with the concurrency key to be concurrently performed
+    # Or, if more control is needed:
+    # Maximum number of jobs with the concurrency key to be concurrently enqueued (excludes performing jobs)
+    enqueue_limit: 2,
+    # Maximum number of jobs with the concurrency key to be concurrently performed (excludes enqueued jobs)
     perform_limit: 1,
 
     # A unique key to be globally locked against.

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -20,17 +20,26 @@ module GoodJob
           # Always allow jobs to be retried because the current job's execution will complete momentarily
           next(block.call) if CurrentExecution.active_job_id == job.job_id
 
-          limit = job.class.good_job_concurrency_config.fetch(:enqueue_limit, Float::INFINITY)
-          next(block.call) if limit.blank? || (0...Float::INFINITY).exclude?(limit)
+          enqueue_limit = job.class.good_job_concurrency_config[:enqueue_limit]
+          total_limit = job.class.good_job_concurrency_config[:total_limit]
+
+          has_limit = (enqueue_limit.present? && (0...Float::INFINITY).cover?(enqueue_limit)) ||
+                      (total_limit.present? && (0...Float::INFINITY).cover?(total_limit))
+          next(block.call) unless has_limit
 
           key = job.good_job_concurrency_key
           next(block.call) if key.blank?
 
           GoodJob::Job.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
-            # TODO: Why is `unscoped` necessary? Nested scope is bleeding into subsequent query?
-            enqueue_concurrency = GoodJob::Job.unscoped.where(concurrency_key: key).unfinished.advisory_unlocked.count
+            enqueue_concurrency = if enqueue_limit
+                                    # TODO: Why is `unscoped` necessary? Nested scope is bleeding into subsequent query?
+                                    GoodJob::Job.unscoped.where(concurrency_key: key).unfinished.advisory_unlocked.count
+                                  else
+                                    GoodJob::Job.unscoped.where(concurrency_key: key).unfinished.count
+                                  end
+
             # The job has not yet been enqueued, so check if adding it will go over the limit
-            block.call unless enqueue_concurrency + 1 > limit
+            block.call unless enqueue_concurrency + 1 > (enqueue_limit || total_limit)
           end
         end
 
@@ -44,14 +53,17 @@ module GoodJob
           # Don't attempt to enforce concurrency limits with other queue adapters.
           next unless job.class.queue_adapter.is_a?(GoodJob::Adapter)
 
-          limit = job.class.good_job_concurrency_config.fetch(:perform_limit, Float::INFINITY)
-          next if limit.blank? || (0...Float::INFINITY).exclude?(limit)
+          perform_limit = job.class.good_job_concurrency_config[:perform_limit] ||
+                          job.class.good_job_concurrency_config[:total_limit]
+
+          has_limit = perform_limit.present? && (0...Float::INFINITY).cover?(perform_limit)
+          next unless has_limit
 
           key = job.good_job_concurrency_key
           next if key.blank?
 
           GoodJob::Job.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
-            allowed_active_job_ids = GoodJob::Job.unscoped.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(limit).pluck(:active_job_id)
+            allowed_active_job_ids = GoodJob::Job.unscoped.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
             # The current job has already been locked and will appear in the previous query
             raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.include? job.job_id
           end


### PR DESCRIPTION
- Also edits notice about incompatibility with Rails 5 because `throw :abort` is not currently used (but still doesn't work in Rails 5 because I can't figure out how to halt an `around_` callback)

Connects to #366.