### PR TITLE
Link to execution id, not active_job_id

### DIFF
--- a/engine/app/views/good_job/shared/_executions_table.erb
+++ b/engine/app/views/good_job/shared/_executions_table.erb
@@ -28,7 +28,7 @@
               <% end %>
             </td>
             <td>
-              <%= link_to active_job_path(execution.active_job_id, anchor: dom_id(execution)) do %>
+              <%= link_to active_job_path(execution.id, anchor: dom_id(execution)) do %>
                 <code><%= execution.id %></code>
               <% end %>
             </td>


### PR DESCRIPTION
Hi @bensheldon,

Thanks for this great project!


After upgrading from `2.1.0` to `2.2.0` I started seeing this error when accessing the dashboard:
```
No route matches {:action=>"show", :controller=>"good_job/active_jobs", :id=>nil}, possible unmatched constraints: [:id]

Backtrace:
good_job (2.2.0) engine/app/views/good_job/shared/_executions_table.erb:31
good_job (2.2.0) engine/app/views/good_job/shared/_executions_table.erb:23
good_job (2.2.0) engine/app/views/good_job/dashboards/index.html.erb:41
```

No idea if this is actually correct, but it did fix the error for me.