### PR TITLE
Preserve page filter when deleting execution

### DIFF
--- a/engine/app/controllers/good_job/active_jobs_controller.rb
+++ b/engine/app/controllers/good_job/active_jobs_controller.rb
@@ -4,7 +4,7 @@ module GoodJob
     def show
       @executions = GoodJob::Execution.active_job_id(params[:id])
                                       .order(Arel.sql("COALESCE(scheduled_at, created_at) DESC"))
-      raise ActiveRecord::RecordNotFound if @executions.empty?
+      redirect_to root_path, alert: "Executions for Active Job #{params[:id]} not found" if @executions.empty?
     end
   end
 end

--- a/engine/app/controllers/good_job/executions_controller.rb
+++ b/engine/app/controllers/good_job/executions_controller.rb
@@ -4,7 +4,7 @@ module GoodJob
     def destroy
       deleted_count = GoodJob::Execution.where(id: params[:id]).delete_all
       message = deleted_count.positive? ? { notice: "Job execution deleted" } : { alert: "Job execution not deleted" }
-      redirect_to root_path, **message
+      redirect_back fallback_location: root_path, **message
     end
   end
 end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -19,4 +19,19 @@ describe 'Dashboard', type: :system, js: true do
     expect(page).to have_content 'Job execution deleted'
     expect(page).not_to have_content 'ExampleJob'
   end
+
+  it 'deletes job redirecting back to applied filter' do
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+
+    ExampleJob.perform_later
+
+    visit '/good_job'
+    click_link 'unfinished'
+    expect(page).to have_content 'ExampleJob'
+
+    click_button('Delete execution')
+    expect(page).to have_content 'Job execution deleted'
+    expect(page).not_to have_content 'ExampleJob'
+    expect(current_url).to match %r{/good_job/\?state=unfinished}
+  end
 end


### PR DESCRIPTION
Example: when deleting jobs one by one with error state it is now easier as we redirect back to the same page