### PR TITLE
Wrap Scheduler task execution with Rails `reloader` instead of `executor` to avoid database connection changing during code reload

### DIFF
--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -230,7 +230,7 @@ module GoodJob # :nodoc:
     # @return [void]
     def create_task(delay = 0)
       future = Concurrent::ScheduledTask.new(delay, args: [performer], executor: executor, timer_set: timer_set) do |thr_performer|
-        Rails.application.executor.wrap do
+        Rails.application.reloader.wrap do
           thr_performer.next
         end
       end


### PR DESCRIPTION
Connects to #388. 

Related to #95, and _hopefully_ this PR does not produce deadlocks.