### PR TITLE
Display cron schedules properties in dashboard

### DIFF
--- a/engine/app/views/good_job/cron_schedules/index.html.erb
+++ b/engine/app/views/good_job/cron_schedules/index.html.erb
@@ -5,6 +5,13 @@
         <thead>
           <th>Cron Job Name</th>
           <th>Configuration</th>
+          <th>
+            Properties&nbsp;
+            <%= tag.button "Toggle", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                           data: { bs_toggle: "collapse", bs_target: ".job-properties" },
+                           aria: { expanded: false, controls: @cron_schedules.map { |job_key, _| "##{job_key.to_param}" }.join(" ") }
+            %>
+          </th>
           <th>Class</th>
           <th>Description</th>
           <th>Next scheduled</th>
@@ -14,6 +21,23 @@
             <tr>
               <td class="font-monospace"><%= job_key %></td>
               <td class="font-monospace"><%= job[:cron] %></td>
+              <td>
+                <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                  data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}" },
+                  aria: { expanded: false, controls: job_key.to_param }
+                %>
+                <%
+                  properties = case job[:set]
+                               when NilClass
+                                 "No extra properties set."
+                               when Proc
+                                 "Properties are a lambda/proc."
+                               when Hash
+                                 JSON.pretty_generate(job[:set])
+                               end
+                %>
+                <%= tag.pre properties, id: job_key.to_param, class: "collapse job-properties" %>
+              </td>
               <td class="font-monospace"><%= job[:class] %></td>
               <td><%= job[:description] %></td>
               <td><%= Fugit.parse_cron(job[:cron]).next_time.to_local_time %></td>

--- a/engine/app/views/good_job/cron_schedules/index.html.erb
+++ b/engine/app/views/good_job/cron_schedules/index.html.erb
@@ -6,7 +6,7 @@
           <th>Cron Job Name</th>
           <th>Configuration</th>
           <th>
-            Properties&nbsp;
+            Set&nbsp;
             <%= tag.button "Toggle", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
                            data: { bs_toggle: "collapse", bs_target: ".job-properties" },
                            aria: { expanded: false, controls: @cron_schedules.map { |job_key, _| "##{job_key.to_param}" }.join(" ") }
@@ -22,21 +22,19 @@
               <td class="font-monospace"><%= job_key %></td>
               <td class="font-monospace"><%= job[:cron] %></td>
               <td>
-                <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
-                  data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}" },
-                  aria: { expanded: false, controls: job_key.to_param }
+                <%=
+                  case job[:set]
+                  when NilClass
+                    "None"
+                  when Proc
+                    "Lambda/Callable"
+                  when Hash
+                    tag.button("Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                        data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}" },
+                        aria: { expanded: false, controls: job_key.to_param }) +
+                      tag.pre(JSON.pretty_generate(job[:set]), id: job_key.to_param, class: "collapse job-properties")
+                  end
                 %>
-                <%
-                  properties = case job[:set]
-                               when NilClass
-                                 "No extra properties set."
-                               when Proc
-                                 "Properties are a lambda/proc."
-                               when Hash
-                                 JSON.pretty_generate(job[:set])
-                               end
-                %>
-                <%= tag.pre properties, id: job_key.to_param, class: "collapse job-properties" %>
               </td>
               <td class="font-monospace"><%= job[:class] %></td>
               <td><%= job[:description] %></td>


### PR DESCRIPTION
I saw this in [sidekiq-scheduler](https://github.com/ondrejbartas/sidekiq-cron#web-ui-for-cron-jobs) and thought this is actually quite useful for us at work.

Since the README calls `:set` additional properties, I went with that name, but I'm open to other suggestions.

The code is a bit crude, but I thought maybe a PR is easier for discussing this than just an issue.

If this is something you're interested in and once the initial review is done, I'd also add the same for `args` perhaps?

Here it is in action:

https://user-images.githubusercontent.com/1301152/135626719-9826a95e-4ffe-4e3f-a59f-d9eb13a15e1c.mp4



