### PR TITLE
Display cron schedules args in dashboard

### DIFF
--- a/engine/app/views/good_job/cron_schedules/index.html.erb
+++ b/engine/app/views/good_job/cron_schedules/index.html.erb
@@ -9,7 +9,14 @@
             Set&nbsp;
             <%= tag.button "Toggle", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
                            data: { bs_toggle: "collapse", bs_target: ".job-properties" },
-                           aria: { expanded: false, controls: @cron_schedules.map { |job_key, _| "##{job_key.to_param}" }.join(" ") }
+                           aria: { expanded: false, controls: @cron_schedules.map { |job_key, _| "#{job_key.to_param}-properties" }.join(" ") }
+            %>
+          </th>
+          <th>
+            Args&nbsp;
+            <%= tag.button "Toggle", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                           data: { bs_toggle: "collapse", bs_target: ".job-args" },
+                           aria: { expanded: false, controls: @cron_schedules.map { |job_key, _| "#{job_key.to_param}-args" }.join(" ") }
             %>
           </th>
           <th>Class</th>
@@ -30,9 +37,24 @@
                     "Lambda/Callable"
                   when Hash
                     tag.button("Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
-                        data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}" },
-                        aria: { expanded: false, controls: job_key.to_param }) +
-                      tag.pre(JSON.pretty_generate(job[:set]), id: job_key.to_param, class: "collapse job-properties")
+                        data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}-properties" },
+                        aria: { expanded: false, controls: "#{job_key.to_param}-properties" }) +
+                      tag.pre(JSON.pretty_generate(job[:set]), id: "#{job_key.to_param}-properties", class: "collapse job-properties")
+                  end
+                %>
+              </td>
+              <td>
+                <%=
+                  case job[:args]
+                  when NilClass
+                    "None"
+                  when Proc
+                    "Lambda/Callable"
+                  when Hash
+                    tag.button("Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                        data: { bs_toggle: "collapse", bs_target: "##{job_key.to_param}-args" },
+                        aria: { expanded: false, controls: "#{job_key.to_param}-args" }) +
+                      tag.pre(JSON.pretty_generate(job[:args]), id: "#{job_key.to_param}-args", class: "collapse job-args")
                   end
                 %>
               </td>

--- a/spec/test_app/config/environments/demo.rb
+++ b/spec/test_app/config/environments/demo.rb
@@ -36,6 +36,7 @@ Rails.application.configure do
       description: "Delete old jobs.",
       cron: "*/15 * * * *",
       class: "CleanupJob",
-    }
+      args: { limit: 1_000 },
+    },
   }
 end


### PR DESCRIPTION
As promised the follow-up. Now there's quite a bit of code duplication. Do you want me to deduplicate the code or do we go by the [rule of three](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming))?

Removed the `#` from `aria-controls` as the list of ID references doesn't use the `#` afaik.

Added args to the cleanup job so that we cover all cases for this column again.

Video shows that the buttons still trigger what they're supposed to.

https://user-images.githubusercontent.com/1301152/135731088-adb068ad-5ff3-4ff7-841f-d9c6b4fcd5c9.mp4


