### PR TITLE
Display info about used timezone.

### DIFF
--- a/engine/app/views/layouts/good_job/base.html.erb
+++ b/engine/app/views/layouts/good_job/base.html.erb
@@ -49,6 +49,7 @@
             </li>
           -->
         </ul>
+        <div class="text-muted" title="Now is <%= Time.current %>">Times are displayed in <%= Time.current.zone %> timezone</div>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
It might be confusing if one is using UTC in the app, but is placed in
different timezone. Make it clear by expclitily stating it.