### PR TITLE
Enforce english locale in UI

### DIFF
--- a/engine/app/controllers/good_job/base_controller.rb
+++ b/engine/app/controllers/good_job/base_controller.rb
@@ -3,8 +3,12 @@ module GoodJob
   class BaseController < ActionController::Base # rubocop:disable Rails/ApplicationController
     protect_from_forgery with: :exception
 
-    around_action do
-      I18n.with_locale(:en) { yield }
+    around_action :switch_locale
+
+    private
+
+    def switch_locale(&action)
+      I18n.with_locale(:en, &action)
     end
   end
 end


### PR DESCRIPTION
Without it the last set locale in the app is used, which now may display relative time text in different language