### PR TITLE
Replace worker wording

### DIFF
--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -230,6 +230,7 @@ module GoodJob # :nodoc:
     # @return [void]
     def create_task(delay = 0)
       future = Concurrent::ScheduledTask.new(delay, args: [performer], executor: executor, timer_set: timer_set) do |thr_performer|
+        Thread.current.name = Thread.current.name.sub("-worker-", "-thread-") if Thread.current.name
         Rails.application.reloader.wrap do
           thr_performer.next
         end


### PR DESCRIPTION
Closes #406.

* Replace `worker` by `thread` in thread's name given by [Concurrent::ThreadPoolExecutor](https://github.com/ruby-concurrency/concurrent-ruby/blob/a9ae6de3a703bfb031335d8e5156c127497d97b7/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb#L313), as soon as we get it in `ScheduledTask`