### PR TITLE
Add Monitoring section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
     - [Execute jobs async / in-process](#execute-jobs-async--in-process)
     - [Migrate to GoodJob from a different ActiveJob backend](#migrate-to-goodjob-from-a-different-activejob-backend)
     - [Monitor and preserve worked jobs](#monitor-and-preserve-worked-jobs)
+    - [Monitoring](#monitoring)
     - [PgBouncer compatibility](#pgbouncer-compatibility)
 - [Contribute](#contribute)
     - [Gem development](#gem-development)
@@ -787,6 +788,10 @@ It is also necessary to delete these preserved jobs from the database after a ce
     ```bash
     $ bundle exec good_job cleanup_preserved_jobs --before-seconds-ago=86400
     ```
+
+### Monitoring
+
+You can monitor ActiveJob using e.g. DataDog's [`dd-trace-rb`](https://github.com/DataDog/dd-trace-rb) starting with version 0.53.0 of the gem.
 
 ### PgBouncer compatibility
 


### PR DESCRIPTION
Closes #323.

This is a rather tiny section right now and it feels like it doesn't completely tie in with the section above it of monitoring preserved jobs. Although I'm not entirely sure if this warrants its own section at all, especially since I don't think we could ever claim for this section to be exhaustive with regards to external implementations. As in, why list this gem exclusively but not ones like [`okcomputer`](https://github.com/sportngin/okcomputer) for health checks etc.

The idea would be that this section would be expanded once #403 would be implemented and other external gems listed only as examples like you already did with bug reporting/monitoring like Bugsnag, Airbrake, Honeybadger.

TBH, instead of having a single line in a section of its own I'd rather have this mentioned somewhere along the line, but I didn't find a place that seemed appropriate. 

WDYT?