### PR TITLE
Add Reschedule, Discard, Retry Job buttons to Dashboard

### DIFF
--- a/engine/app/controllers/good_job/jobs_controller.rb
+++ b/engine/app/controllers/good_job/jobs_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 module GoodJob
   class JobsController < GoodJob::BaseController
+    rescue_from GoodJob::ActiveJobJob::AdapterNotGoodJobError,
+                GoodJob::ActiveJobJob::ActionForStateMismatchError,
+                with: :redirect_on_error
+
     def index
       @filter = JobsFilter.new(params)
     end
@@ -9,6 +13,38 @@ module GoodJob
       @executions = GoodJob::Execution.active_job_id(params[:id])
                                       .order(Arel.sql("COALESCE(scheduled_at, created_at) DESC"))
       redirect_to root_path, alert: "Executions for Active Job #{params[:id]} not found" if @executions.empty?
+    end
+
+    def discard
+      @job = ActiveJobJob.find(params[:id])
+      @job.discard_job("Discarded through dashboard")
+      redirect_back(fallback_location: jobs_path, notice: "Job has been discarded")
+    end
+
+    def reschedule
+      @job = ActiveJobJob.find(params[:id])
+      @job.reschedule_job
+      redirect_back(fallback_location: jobs_path, notice: "Job has been rescheduled")
+    end
+
+    def retry
+      @job = ActiveJobJob.find(params[:id])
+      @job.retry_job
+      redirect_back(fallback_location: jobs_path, notice: "Job has been retried")
+    end
+
+    private
+
+    def redirect_on_error(exception)
+      alert = case exception
+              when GoodJob::ActiveJobJob::AdapterNotGoodJobError
+                "ActiveJob Queue Adapter must be GoodJob."
+              when GoodJob::ActiveJobJob::ActionForStateMismatchError
+                "Job is not in an appropriate state for this action."
+              else
+                exception.to_s
+              end
+      redirect_back(fallback_location: jobs_path, alert: alert)
     end
   end
 end

--- a/engine/app/filters/good_job/jobs_filter.rb
+++ b/engine/app/filters/good_job/jobs_filter.rb
@@ -19,7 +19,9 @@ module GoodJob
     end
 
     def filtered_query
-      query = base_query
+      query = base_query.includes(:executions)
+                        .joins_advisory_locks.select('good_jobs.*', 'pg_locks.locktype AS locktype')
+
       query = query.job_class(params[:job_class]) if params[:job_class]
       query = query.where(queue_name: params[:queue_name]) if params[:queue_name]
 

--- a/engine/app/views/good_job/shared/_jobs_table.erb
+++ b/engine/app/views/good_job/shared/_jobs_table.erb
@@ -43,11 +43,23 @@
               %>
               <%= tag.pre JSON.pretty_generate(job.serialized_params), id: dom_id(job, "params"), class: "collapse job-params" %>
             </td>
-<!--            <td>-->
-              <%#= button_to execution_path(execution.id), method: :delete, class: "btn btn-sm btn-outline-danger", title: "Delete execution" do %>
-                <%#= render "good_job/shared/icons/trash" %>
-              <%# end %>
-<!--            </td>-->
+            <td>
+              <div class="text-nowrap">
+                <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
+                <%= button_to reschedule_job_path(job.id), method: :put, class: "btn btn-sm #{job_reschedulable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_reschedulable, aria: { label: "Reschedule job" }, title: "Reschedule job" do %>
+                  <%= render "good_job/shared/icons/skip_forward" %>
+                <% end %>
+
+                <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
+                <%= button_to discard_job_path(job.id), method: :put, class: "btn btn-sm #{job_discardable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_discardable, aria: { label: "Discard job" }, title: "Discard job" do %>
+                  <%= render "good_job/shared/icons/stop" %>
+                <% end %>
+
+                <%= button_to retry_job_path(job.id), method: :put, class: "btn btn-sm #{job.status == :discarded ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: job.status != :discarded, aria: { label: "Retry job" }, title: "Retry job" do %>
+                  <%= render "good_job/shared/icons/arrow_clockwise" %>
+                <% end %>
+              </div>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/engine/app/views/good_job/shared/icons/_arrow_clockwise.html.erb
+++ b/engine/app/views/good_job/shared/icons/_arrow_clockwise.html.erb
@@ -1,0 +1,5 @@
+<!-- https://icons.getbootstrap.com/icons/arrow-clockwise/ -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z" />
+  <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z" />
+</svg>

--- a/engine/app/views/good_job/shared/icons/_skip_forward.html.erb
+++ b/engine/app/views/good_job/shared/icons/_skip_forward.html.erb
@@ -1,0 +1,4 @@
+<!-- https://icons.getbootstrap.com/icons/skip-forward/ -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-skip-forward" viewBox="0 0 16 16">
+  <path d="M15.5 3.5a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-1 0V8.752l-6.267 3.636c-.52.302-1.233-.043-1.233-.696v-2.94l-6.267 3.636C.713 12.69 0 12.345 0 11.692V4.308c0-.653.713-.998 1.233-.696L7.5 7.248v-2.94c0-.653.713-.998 1.233-.696L15 7.248V4a.5.5 0 0 1 .5-.5zM1 4.633v6.734L6.804 8 1 4.633zm7.5 0v6.734L14.304 8 8.5 4.633z" />
+</svg>

--- a/engine/app/views/good_job/shared/icons/_stop.html.erb
+++ b/engine/app/views/good_job/shared/icons/_stop.html.erb
@@ -1,0 +1,4 @@
+<!-- https://icons.getbootstrap.com/icons/stop/ -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-stop" viewBox="0 0 16 16">
+  <path d="M3.5 5A1.5 1.5 0 0 1 5 3.5h6A1.5 1.5 0 0 1 12.5 5v6a1.5 1.5 0 0 1-1.5 1.5H5A1.5 1.5 0 0 1 3.5 11V5zM5 4.5a.5.5 0 0 0-.5.5v6a.5.5 0 0 0 .5.5h6a.5.5 0 0 0 .5-.5V5a.5.5 0 0 0-.5-.5H5z" />
+</svg>

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -2,7 +2,13 @@
 GoodJob::Engine.routes.draw do
   root to: 'executions#index'
   resources :cron_schedules, only: %i[index]
-  resources :jobs, only: %i[index show]
+  resources :jobs, only: %i[index show] do
+    member do
+      put :discard
+      put :reschedule
+      put :retry
+    end
+  end
   resources :executions, only: %i[destroy]
 
   scope controller: :assets do

--- a/lib/good_job/current_thread.rb
+++ b/lib/good_job/current_thread.rb
@@ -52,5 +52,13 @@ module GoodJob
     def self.thread_name
       (Thread.current.name || Thread.current.object_id).to_s
     end
+
+    # @return [void]
+    def self.within
+      reset
+      yield(self)
+    ensure
+      reset
+    end
   end
 end

--- a/spec/engine/models/good_job/active_job_job_spec.rb
+++ b/spec/engine/models/good_job/active_job_job_spec.rb
@@ -4,14 +4,30 @@ require 'rails_helper'
 RSpec.describe GoodJob::ActiveJobJob do
   subject(:job) { described_class.find(head_execution.active_job_id) }
 
+  before do
+    allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+
+    stub_const 'TestJob', (Class.new(ActiveJob::Base) do
+      def perform
+      end
+    end)
+    stub_const 'TestJob::Error', Class.new(StandardError)
+  end
+
   let!(:tail_execution) do
+    active_job_id = SecureRandom.uuid
     GoodJob::Execution.create!(
       active_job_id: SecureRandom.uuid,
       created_at: 1.minute.ago,
       queue_name: 'mice',
+      priority: 10,
       serialized_params: {
+        'job_id' => active_job_id,
         'job_class' => 'TestJob',
         'executions' => 0,
+        'queue_name' => 'mice',
+        'priority' => 10,
       }
     )
   end
@@ -19,10 +35,16 @@ RSpec.describe GoodJob::ActiveJobJob do
   let!(:head_execution) do
     GoodJob::Execution.create!(
       active_job_id: tail_execution.active_job_id,
+      scheduled_at: 10.minutes.from_now,
       queue_name: 'mice',
+      priority: 10,
       serialized_params: {
+        'job_id' => tail_execution.active_job_id,
         'job_class' => 'TestJob',
         'executions' => 1,
+        'exception_executions' => { 'TestJob::Error' => 1 },
+        'queue_name' => 'mice',
+        'priority' => 10,
       }
     ).tap do |execution|
       tail_execution.update!(
@@ -93,6 +115,104 @@ RSpec.describe GoodJob::ActiveJobJob do
       job.with_advisory_lock do
         job_with_locktype = described_class.where(active_job_id: job.id).joins_advisory_locks.select('good_jobs.*', 'pg_locks.locktype AS locktype').first
         expect(job_with_locktype).to be_running
+      end
+    end
+  end
+
+  describe '#retry_job' do
+    context 'when job is discarded' do
+      before do
+        head_execution.update!(
+          finished_at: Time.current,
+          error: "TestJob::Error: TestJob::Error"
+        )
+      end
+
+      it 'enqueues another execution and updates the original job' do
+        original_head_execution = job.head_execution
+
+        expect do
+          job.retry_job
+        end.to change { job.executions.reload.size }.by(1)
+
+        new_head_execution = job.head_execution(reload: true)
+        expect(new_head_execution.serialized_params).to include(
+          "executions" => 2,
+          "queue_name" => "mice",
+          "priority" => 10
+        )
+
+        original_head_execution.reload
+        expect(original_head_execution.retried_good_job_id).to eq new_head_execution.id
+      end
+    end
+
+    context 'when job is already locked' do
+      it 'raises an Error' do
+        ActiveRecord::Base.clear_active_connections!
+        job.with_advisory_lock do
+          expect do
+            Concurrent::Promises.future(job, &:retry_job).value!
+          end.to raise_error GoodJob::Lockable::RecordAlreadyAdvisoryLockedError
+        end
+      end
+    end
+
+    context 'when job is not discarded' do
+      it 'raises an ActionForStateMismatchError' do
+        expect(job.reload.status).not_to eq :discarded
+        expect { job.retry_job }.to raise_error GoodJob::ActiveJobJob::ActionForStateMismatchError
+      end
+    end
+  end
+
+  describe '#discard_job' do
+    context 'when a job is unfinished' do
+      it 'discards the job with a DiscardJobError' do
+        expect do
+          job.discard_job("Discarded in test")
+        end.to change { job.reload.status }.from(:scheduled).to(:discarded)
+
+        expect(job.head_execution(reload: true)).to have_attributes(
+          error: "GoodJob::ActiveJobJob::DiscardJobError: Discarded in test",
+          finished_at: within(1.second).of(Time.current)
+        )
+      end
+    end
+
+    context 'when a job is not in scheduled/queued state' do
+      before do
+        job.head_execution.update! finished_at: Time.current
+      end
+
+      it 'raises an ActionForStateMismatchError' do
+        expect(job.reload.status).to eq :finished
+        expect { job.discard_job("Discard in test") }.to raise_error GoodJob::ActiveJobJob::ActionForStateMismatchError
+      end
+    end
+  end
+
+  describe '#reschedule_job' do
+    context 'when a job is scheduled' do
+      it 'reschedules the job to right now by default' do
+        expect do
+          job.reschedule_job
+        end.to change { job.reload.status }.from(:scheduled).to(:queued)
+
+        expect(job.head_execution(reload: true)).to have_attributes(
+          scheduled_at: within(1.second).of(Time.current)
+        )
+      end
+    end
+
+    context 'when a job is not in scheduled/queued state' do
+      before do
+        job.head_execution.update! finished_at: Time.current
+      end
+
+      it 'raises an ActionForStateMismatchError' do
+        expect(job.reload.status).to eq :finished
+        expect { job.reschedule_job }.to raise_error GoodJob::ActiveJobJob::ActionForStateMismatchError
       end
     end
   end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'Dashboard', type: :system, js: true do
+describe 'Dashboard', type: :system do
+  before do
+    allow(GoodJob).to receive(:retry_on_unhandled_error).and_return(false)
+    allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+  end
+
+  it 'renders chart js', js: true do
+    visit '/good_job'
+    expect(page).to have_content 'GoodJob 👍'
+  end
+
   it 'renders each top-level page successfully' do
     visit '/good_job'
     expect(page).to have_content 'GoodJob 👍'
@@ -16,18 +26,62 @@ describe 'Dashboard', type: :system, js: true do
     expect(page).to have_content 'GoodJob 👍'
   end
 
-  it 'deletes job and redirects back to applied filter' do
-    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+  describe 'Executions' do
+    it 'deletes executions and redirects back to applied filter' do
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
 
-    ExampleJob.perform_later
+      ExampleJob.perform_later
 
-    visit '/good_job'
-    click_link 'unfinished'
-    expect(page).to have_content 'ExampleJob'
+      visit '/good_job'
+      click_link 'unfinished'
+      expect(page).to have_content 'ExampleJob'
 
-    click_button('Delete execution')
-    expect(page).to have_content 'Job execution deleted'
-    expect(page).not_to have_content 'ExampleJob'
-    expect(current_url).to match %r{/good_job/\?state=unfinished}
+      click_button('Delete execution')
+      expect(page).to have_content 'Job execution deleted'
+      expect(page).not_to have_content 'ExampleJob'
+      expect(current_url).to match %r{/good_job/\?state=unfinished}
+    end
+  end
+
+  describe 'Jobs' do
+    let(:unfinished_job) do
+      ExampleJob.set(wait: 10.minutes).perform_later
+      GoodJob::ActiveJobJob.order(created_at: :asc).last
+    end
+
+    let(:discarded_job) do
+      ExampleJob.perform_later(ExampleJob::DEAD_TYPE)
+    rescue StandardError
+      GoodJob::ActiveJobJob.order(created_at: :asc).last
+    end
+
+    before do
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+      discarded_job
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+      unfinished_job
+    end
+
+    it 'can retry discarded jobs' do
+      visit '/good_job'
+      click_on "All Jobs"
+
+      expect do
+        within "##{dom_id(discarded_job)}" do
+          click_on 'Retry job'
+        end
+      end.to change { discarded_job.executions.reload.size }.by(1)
+    end
+
+    it 'can discard jobs' do
+      visit '/good_job'
+      click_on "All Jobs"
+
+      expect do
+        within "##{dom_id(unfinished_job)}" do
+          click_on 'Discard job'
+        end
+      end.to change { unfinished_job.head_execution(reload: true).finished_at }.to within(1.second).of(Time.current)
+    end
   end
 end

--- a/spec/test_app/config/environments/demo.rb
+++ b/spec/test_app/config/environments/demo.rb
@@ -15,8 +15,7 @@ Rails.application.configure do
       cron: "* * * * * *",
       class: "ExampleJob",
       args: (lambda do
-        type = ExampleJob::TYPES.sample
-        [type.to_s]
+        [ExampleJob::TYPES.sample.to_s]
       end),
       set: (lambda do
         queue = [:default, :elephants, :mice].sample

--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -61,17 +61,17 @@ Rails.application.configure do
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.active_job.queue_adapter = :good_job
+  GoodJob.retry_on_unhandled_error = false
   GoodJob.preserve_job_records = true
 
-  config.good_job.enable_cron = true
+  config.good_job.enable_cron = ActiveModel::Type::Boolean.new.cast(ENV.fetch('GOOD_JOB_ENABLE_CRON', true))
   config.good_job.cron = {
     frequent_example: {
       description: "Enqueue an ExampleJob",
       cron: "*/5 * * * * *",
       class: "ExampleJob",
       args: (lambda do
-        type = ExampleJob::SLOW_TYPE  # ExampleJob::TYPES.sample
-        [type.to_s]
+        [ExampleJob::TYPES.sample.to_s]
       end),
       set: (lambda do
         queue = [:default, :elephants, :mice].sample


### PR DESCRIPTION
Connects to #256.

~~The Retry action is only available upon Discarded Jobs. I'm considering having each job have all of the actions displayed but disabled if they are not relevant for the current state of the action. Once there are more actions, it should be clearer whether this is good or not.~~

Adds Schedule Now, Retry, and Discard buttons to Jobs. All of the buttons are present but are disabled if not relevant to the current job state.

<img width="381" alt="Screen Shot 2021-10-20 at 9 45 45 PM" src="https://user-images.githubusercontent.com/47554/138213471-9e058a6b-8371-4b94-b08b-8b671a0c26ac.png">

