### PR TITLE
Remove v1.99/v2 transitional extra advisory lock

### DIFF
--- a/lib/good_job/execution.rb
+++ b/lib/good_job/execution.rb
@@ -174,13 +174,7 @@ module GoodJob
         break if execution.blank?
         break :unlocked unless execution&.executable?
 
-        begin
-          execution.with_advisory_lock(key: "good_jobs-#{execution.active_job_id}") do
-            execution.perform
-          end
-        rescue RecordAlreadyAdvisoryLockedError => e
-          ExecutionResult.new(value: nil, handled_error: e)
-        end
+        execution.perform
       end
     end
 

--- a/spec/integration/scheduler_spec.rb
+++ b/spec/integration/scheduler_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe 'Schedule Integration' do
       def perform(*_args, **_kwargs)
         thread_name = Thread.current.name || Thread.current.object_id
 
-        expected_locks_per_thread = 2 # TODO: Temporary value for GoodJob v1.99. Should be reduced to 1 for GoodJob 2.0.
-
+        expected_locks_per_thread = 1
         locks_count = PgLock.advisory_lock.owns.count
+
         if locks_count > expected_locks_per_thread
           puts "Thread #{thread_name} owns #{locks_count} locks."
 


### PR DESCRIPTION
Forgot to remove this as part of #307. The lock was identical to the lock generated by `with_advisory_lock` i.e. it took 2 identical locks.