### PR TITLE
Explicitly unscope queries within block yielded to Lockable.within_advisory_lock

### DIFF
--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -149,7 +149,7 @@ module GoodJob
 
         records = advisory_lock(column: column, function: function).to_a
         begin
-          yield(records)
+          unscoped { yield(records) }
         ensure
           if unlock_session
             advisory_unlock_session

--- a/spec/lib/good_job/lockable_spec.rb
+++ b/spec/lib/good_job/lockable_spec.rb
@@ -112,6 +112,14 @@ RSpec.describe GoodJob::Lockable do
       expect(another_record).not_to be_advisory_locked
       expect(PgLock.advisory_lock.count).to eq 0
     end
+
+    it 'does not leak relation scope into inner queries' do
+      sql = model_class.where(finished_at: nil).limit(1).with_advisory_lock do |_results|
+        model_class.all.to_sql
+      end
+
+      expect(sql).to eq 'SELECT "good_jobs".* FROM "good_jobs"'
+    end
   end
 
   describe '#advisory_lock' do


### PR DESCRIPTION
TIL `yield` within an ActiveRecord class method will leak query scope into queries on the same model class within the block.

Discovered because the demo `CleanupJob` was not working correctly because its queries for `GoodJob::Execution` were being improperly scoped.