### PR TITLE
Add fulltext search filter

### DIFF
--- a/engine/app/filters/good_job/base_filter.rb
+++ b/engine/app/filters/good_job/base_filter.rb
@@ -39,13 +39,14 @@ module GoodJob
       raise NotImplementedError
     end
 
-    def to_params(override)
+    def to_params(override = {})
       {
         job_class: params[:job_class],
         limit: params[:limit],
         queue_name: params[:queue_name],
+        query: params[:query],
         state: params[:state],
-      }.merge(override).delete_if { |_, v| v.nil? }
+      }.merge(override).delete_if { |_, v| v.blank? }
     end
 
     def chart_data

--- a/engine/app/filters/good_job/executions_filter.rb
+++ b/engine/app/filters/good_job/executions_filter.rb
@@ -18,8 +18,9 @@ module GoodJob
 
     def filtered_query
       query = base_query
-      query = query.job_class(params[:job_class]) if params[:job_class]
-      query = query.where(queue_name: params[:queue_name]) if params[:queue_name]
+      query = query.job_class(params[:job_class]) if params[:job_class].present?
+      query = query.where(queue_name: params[:queue_name]) if params[:queue_name].present?
+      query = query.search(params['query']) if params[:query].present?
 
       if params[:state]
         case params[:state]

--- a/engine/app/filters/good_job/jobs_filter.rb
+++ b/engine/app/filters/good_job/jobs_filter.rb
@@ -22,8 +22,9 @@ module GoodJob
       query = base_query.includes(:executions)
                         .joins_advisory_locks.select('good_jobs.*', 'pg_locks.locktype AS locktype')
 
-      query = query.job_class(params[:job_class]) if params[:job_class]
-      query = query.where(queue_name: params[:queue_name]) if params[:queue_name]
+      query = query.job_class(params[:job_class]) if params[:job_class].present?
+      query = query.where(queue_name: params[:queue_name]) if params[:queue_name].present?
+      query = query.search(params['query']) if params[:query].present?
 
       if params[:state]
         case params[:state]

--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -22,7 +22,7 @@
       </thead>
       <tbody>
         <% jobs.each do |job| %>
-          <tr id="<%= dom_id(job) %>">
+          <tr class="<%= dom_class(job) %>" id="<%= dom_id(job) %>">
             <td>
               <%= link_to job_path(job.id) do %>
                 <code><%= job.id %></code>

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -1,6 +1,6 @@
 <div class='card mb-2'>
   <div class='card-body d-flex flex-wrap'>
-    <div class='me-4'>
+    <div class='mb-2 me-4'>
       <small>Filter by job class</small>
       <br>
       <% filter.job_classes.each do |name, count| %>
@@ -16,7 +16,7 @@
       <% end %>
     </div>
 
-    <div class='me-4'>
+    <div class='mb-2 me-4'>
       <small>Filter by state</small>
       <br>
       <% filter.states.each do |name, count| %>
@@ -32,7 +32,7 @@
       <% end %>
     </div>
 
-    <div>
+    <div class='mb-2 me-4'>
       <small>Filter by queue</small>
       <br>
       <% filter.queues.each do |name, count| %>
@@ -45,6 +45,21 @@
             <%= name %> (<%= count %>)
           <% end %>
         <% end %>
+      <% end %>
+    </div>
+
+    <div class="mb-2">
+      <%= form_with(url: "", method: :get, local: true) do |form| %>
+        <% filter.to_params(query: nil).each do |key, value| %>
+          <%= form.hidden_field(key.to_sym, value: value) %>
+        <% end %>
+
+        <small><%= form.label :query, "Search" %></small>
+        <div class="input-group input-group-sm">
+          <%= form.search_field :query, value: params[:query], class: "form-control" %>
+          <%= form.button "Search", type: "submit", name: nil, class: "btn btn-sm btn-outline-secondary" %>
+          <%= link_to "Clear", filter.to_params(query: nil), class: "btn btn-sm btn-outline-secondary" %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/engine/app/views/layouts/good_job/base.html.erb
+++ b/engine/app/views/layouts/good_job/base.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>Good Job Dashboard</title>
   <%= csrf_meta_tags %>

--- a/lib/good_job/execution.rb
+++ b/lib/good_job/execution.rb
@@ -6,6 +6,7 @@ module GoodJob
   #   class Execution < ActiveRecord::Base; end
   class Execution < Object.const_get(GoodJob.active_record_parent_class)
     include Lockable
+    include Filterable
 
     # Raised if something attempts to execute a previously completed Execution again.
     PreviouslyPerformedError = Class.new(StandardError)
@@ -154,24 +155,6 @@ module GoodJob
       elsif parsed[:include]
         where(queue_name: parsed[:include])
       end
-    end)
-
-    # Get Jobs in display order with optional keyset pagination.
-    # @!method display_all(after_scheduled_at: nil, after_id: nil)
-    # @!scope class
-    # @param after_scheduled_at [DateTime, String, nil]
-    #   Display records scheduled after this time for keyset pagination
-    # @param after_id [Numeric, String, nil]
-    #   Display records after this ID for keyset pagination
-    # @return [ActiveRecord::Relation]
-    scope :display_all, (lambda do |after_scheduled_at: nil, after_id: nil|
-      query = order(Arel.sql('COALESCE(scheduled_at, created_at) DESC, id DESC'))
-      if after_scheduled_at.present? && after_id.present?
-        query = query.where(Arel.sql('(COALESCE(scheduled_at, created_at), id) < (:after_scheduled_at, :after_id)'), after_scheduled_at: after_scheduled_at, after_id: after_id)
-      elsif after_scheduled_at.present?
-        query = query.where(Arel.sql('(COALESCE(scheduled_at, created_at)) < (:after_scheduled_at)'), after_scheduled_at: after_scheduled_at)
-      end
-      query
     end)
 
     # Finds the next eligible Execution, acquire an advisory lock related to it, and

--- a/lib/good_job/filterable.rb
+++ b/lib/good_job/filterable.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module GoodJob
+  # Shared methods for filtering Execution/Job records from the +good_jobs+ table.
+  module Filterable
+    extend ActiveSupport::Concern
+
+    included do
+      # Get records in display order with optional keyset pagination.
+      # @!method display_all(after_scheduled_at: nil, after_id: nil)
+      # @!scope class
+      # @param after_scheduled_at [DateTime, String, nil]
+      #   Display records scheduled after this time for keyset pagination
+      # @param after_id [Numeric, String, nil]
+      #   Display records after this ID for keyset pagination
+      # @return [ActiveRecord::Relation]
+      scope :display_all, (lambda do |after_scheduled_at: nil, after_id: nil|
+        query = order(Arel.sql('COALESCE(scheduled_at, created_at) DESC, id DESC'))
+        if after_scheduled_at.present? && after_id.present?
+          query = query.where(Arel.sql('(COALESCE(scheduled_at, created_at), id) < (:after_scheduled_at, :after_id)'), after_scheduled_at: after_scheduled_at, after_id: after_id)
+        elsif after_scheduled_at.present?
+          query = query.where(Arel.sql('(COALESCE(scheduled_at, created_at)) < (:after_scheduled_at)'), after_scheduled_at: after_scheduled_at)
+        end
+        query
+      end)
+
+      # Search records by text query.
+      # @!method search(query)
+      # @!scope class
+      # @param query [String]
+      #   Search Query
+      # @return [ActiveRecord::Relation]
+      scope :search, (lambda do |query|
+        query = query.to_s.strip
+        next if query.blank?
+
+        tsvector = "(to_tsvector('english', serialized_params) || to_tsvector('english', id::text) || to_tsvector('english', COALESCE(error, '')::text))"
+        where("#{tsvector} @@ to_tsquery(?)", query)
+          .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, to_tsquery(?))"), query]) => 'DESC')
+      end)
+    end
+  end
+end

--- a/spec/lib/good_job/filterable_spec.rb
+++ b/spec/lib/good_job/filterable_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GoodJob::Filterable do
+  let(:model_class) { GoodJob::Execution }
+  let!(:execution) { model_class.create(active_job_id: SecureRandom.uuid, queue_name: "default", serialized_params: { example_key: 'example_value' }, error: "ExampleError: a message") }
+
+  describe '.search' do
+    it 'searches serialized params' do
+      expect(model_class.search('example_value')).to include(execution)
+    end
+
+    it 'searches record id' do
+      expect(model_class.search(execution.id)).to include(execution)
+    end
+
+    it 'searches errors' do
+      expect(model_class.search('ExampleError')).to include(execution)
+    end
+
+    it 'filters out non-matching records' do
+      expect(model_class.search('ghost')).to be_empty
+    end
+
+    it 'is chainable and reversible' do
+      expect(model_class.where.not(id: nil).search('example_value').reverse).to include(execution)
+    end
+  end
+end

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -62,6 +62,18 @@ describe 'Dashboard', type: :system do
       unfinished_job
     end
 
+    describe 'filtering' do
+      it 'can search by argument' do
+        visit '/good_job'
+        click_on "All Jobs"
+
+        expect(page).to have_selector('.active_job_job', count: 2)
+        fill_in 'query', with: ExampleJob::DEAD_TYPE
+        click_on 'Search'
+        expect(page).to have_selector('.active_job_job', count: 1)
+      end
+    end
+
     it 'can retry discarded jobs' do
       visit '/good_job'
       click_on "All Jobs"


### PR DESCRIPTION
Closes #432.

~~Bit of a spike, but wanted to open up for feedback.~~

Some quirks:
- When searching jobs, it only searches the properties of the most recent execution. So while the "Last Error" (i.e. the error from the previous execution) of a job will appear in the dashboard, it's not queryable.
-  There is no search indexing, so this results in a row scan.

