### PR TITLE
Add explicit Content Security Policy (CSP) for Dashboard

### DIFF
--- a/engine/app/controllers/good_job/base_controller.rb
+++ b/engine/app/controllers/good_job/base_controller.rb
@@ -5,6 +5,25 @@ module GoodJob
 
     around_action :switch_locale
 
+    content_security_policy do |policy|
+      policy.default_src(:none) if policy.default_src.blank?
+      policy.connect_src(:self) if policy.connect_src.blank?
+      policy.base_uri(:none) if policy.base_uri.blank?
+      policy.font_src(:self) if policy.font_src.blank?
+      policy.img_src(:self, :data) if policy.img_src.blank?
+      policy.object_src(:none) if policy.object_src.blank?
+      policy.script_src(:self) if policy.script_src.blank?
+      policy.style_src(:self) if policy.style_src.blank?
+      policy.form_action(:self) if policy.form_action.blank?
+      policy.frame_ancestors(:none) if policy.frame_ancestors.blank?
+    end
+
+    before_action do
+      next if request.content_security_policy_nonce_generator
+
+      request.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+    end
+
     private
 
     def switch_locale(&action)

--- a/spec/test_app/config/initializers/content_security_policy.rb
+++ b/spec/test_app/config/initializers/content_security_policy.rb
@@ -26,18 +26,3 @@
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
-
-Rails.application.config.content_security_policy do |policy|
-  policy.default_src :none
-  policy.connect_src :self
-  policy.base_uri :none
-  policy.font_src :self, :https, :data
-  policy.img_src :self, :https, :data
-  policy.object_src :none
-  policy.script_src :self
-  policy.style_src :self
-  policy.form_action :self
-  policy.frame_ancestors :self
-end
-
-Rails.application.config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }


### PR DESCRIPTION
Closes #420. 

Allows each directive to be overridden. I'm imagining they would be overriden with more strict values, but I'll leave it for the future if it should be smarter about ensuring that it isn't overriden with less-strict values.

It does _force_ the usage of a nonce for the Dashboard because the nonce value both defaults to `nil` and is disabled by setting to `nil`, so it's indeterminate as to what the application's intention is. 

It does allow `data:` images because Chart.js embeds some SVGs.