### PR TITLE
Add http probe for CLI healthcheck/readiness/liveliness

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
       fugit (>= 1.1)
       railties (>= 5.2.0)
       thor (>= 0.14.1)
+      webrick (>= 1.3)
       zeitwerk (>= 2.0)
 
 GEM
@@ -372,6 +373,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.5-java)

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -54,6 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fugit", ">= 1.1"
   spec.add_dependency "railties", ">= 5.2.0"
   spec.add_dependency "thor", ">= 0.14.1"
+  spec.add_dependency "webrick", ">= 1.3"
   spec.add_dependency "zeitwerk", ">= 2.0"
 
   spec.add_development_dependency "benchmark-ips"

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -195,6 +195,13 @@ module GoodJob
         Rails.application.root.join('tmp', 'pids', 'good_job.pid')
     end
 
+    # Port of the probe server
+    # @return [nil,Integer]
+    def probe_port
+      options[:probe_port] ||
+        env['GOOD_JOB_PROBE_PORT']
+    end
+
     private
 
     def rails_config

--- a/lib/good_job/probe_server.rb
+++ b/lib/good_job/probe_server.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module GoodJob
+  class ProbeServer
+    RACK_SERVER = 'webrick'
+
+    def self.task_observer(time, output, thread_error) # rubocop:disable Lint/UnusedMethodArgument
+      return if thread_error.is_a? Concurrent::CancelledOperationError
+
+      GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+    end
+
+    def initialize(port:)
+      @port = port
+    end
+
+    def start
+      @handler = Rack::Handler.get(RACK_SERVER)
+      @future = Concurrent::Future.new(args: [@handler, @port, GoodJob.logger]) do |thr_handler, thr_port, thr_logger|
+        thr_handler.run(self, Port: thr_port, Logger: thr_logger, AccessLog: [])
+      end
+      @future.add_observer(self.class, :task_observer)
+      @future.execute
+    end
+
+    def running?
+      @handler&.instance_variable_get(:@server)&.status == :Running
+    end
+
+    def stop
+      @handler&.shutdown
+      @future&.value # wait for Future to exit
+    end
+
+    def call(env)
+      case Rack::Request.new(env).path
+      when '/', '/status'
+        [200, {}, ["OK"]]
+      when '/status/started'
+        started = GoodJob::Scheduler.instances.any? && GoodJob::Scheduler.instances.all?(&:running?)
+        started ? [200, {}, ["Started"]] : [503, {}, ["Not started"]]
+      when '/status/connected'
+        connected = GoodJob::Scheduler.instances.any? && GoodJob::Scheduler.instances.all?(&:running?) &&
+                    GoodJob::Notifier.instances.any? && GoodJob::Notifier.instances.all?(&:listening?)
+        connected ? [200, {}, ["Connected"]] : [503, {}, ["Not connected"]]
+      else
+        [404, {}, ["Not found"]]
+      end
+    end
+  end
+end

--- a/spec/lib/good_job/cli_spec.rb
+++ b/spec/lib/good_job/cli_spec.rb
@@ -76,6 +76,24 @@ RSpec.describe GoodJob::CLI do
         expect(performer_query.to_sql).to eq GoodJob::Execution.where(queue_name: %w[mice elephant]).to_sql
       end
     end
+
+    describe 'probe-port' do
+      let(:probe_server) { instance_double GoodJob::ProbeServer, start: nil, stop: nil }
+
+      before do
+        allow(Kernel).to receive(:loop)
+        allow(GoodJob::ProbeServer).to receive(:new).and_return probe_server
+      end
+
+      it 'starts a ProbeServer' do
+        cli = described_class.new([], { probe_port: 3838 }, {})
+        cli.start
+
+        expect(GoodJob::ProbeServer).to have_received(:new).with(port: 3838)
+        expect(probe_server).to have_received(:start)
+        expect(probe_server).to have_received(:stop)
+      end
+    end
   end
 
   describe '#cleanup_preserved_jobs' do

--- a/spec/lib/good_job/probe_server_spec.rb
+++ b/spec/lib/good_job/probe_server_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'net/http'
+
+RSpec.describe GoodJob::ProbeServer do
+  let(:probe_server) { described_class.new(port: port) }
+  let(:port) { 3434 }
+
+  after do
+    probe_server.stop
+  end
+
+  describe '#start' do
+    it 'starts a webrick server' do
+      probe_server.start
+      wait_until(max: 1) { expect(probe_server).to be_running }
+
+      response = Net::HTTP.get("127.0.0.1", "/", port)
+      expect(response).to eq("OK")
+    end
+  end
+
+  describe '#call' do
+    let(:path) { nil }
+    let(:env) { Rack::MockRequest.env_for("http://127.0.0.1:#{port}#{path}") }
+
+    describe '/' do
+      let(:path) { '/' }
+
+      it 'returns "OK"' do
+        response = probe_server.call(env)
+        expect(response[0]).to eq(200)
+      end
+    end
+
+    describe '/status/started' do
+      let(:path) { '/status/started' }
+
+      context 'when there are no running schedulers' do
+        it 'returns 503' do
+          response = probe_server.call(env)
+          expect(response[0]).to eq(503)
+        end
+      end
+
+      context 'when there are running schedulers' do
+        it 'returns 200' do
+          scheduler = instance_double(GoodJob::Scheduler, running?: true, shutdown: true, shutdown?: true)
+          GoodJob::Scheduler.instances << scheduler
+
+          response = probe_server.call(env)
+          expect(response[0]).to eq(200)
+        end
+      end
+    end
+
+    describe '/status/connected' do
+      let(:path) { '/status/connected' }
+
+      context 'when there are no running schedulers or notifiers' do
+        it 'returns 503' do
+          response = probe_server.call(env)
+          expect(response[0]).to eq(503)
+        end
+      end
+
+      context 'when there are running schedulers and listening notifiers' do
+        it 'returns 200' do
+          scheduler = instance_double(GoodJob::Scheduler, running?: true, shutdown: true, shutdown?: true)
+          GoodJob::Scheduler.instances << scheduler
+
+          notifier = instance_double(GoodJob::Notifier, listening?: true, shutdown: true, shutdown?: true)
+          GoodJob::Notifier.instances << notifier
+
+          response = probe_server.call(env)
+          expect(response[0]).to eq(200)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects to #403. Adds separate endpoints that are descriptive of GoodJob's state (started/connected) because I do not want to be opinionated about what constitutes an appropriate probe. 

This PR uses WEBrick as the http server. Ruby 3.0 removes webrick from the stdlib and thus it has to be included in the gemspec.