### PR TITLE
Do not delete csp policies when checking csp policies

### DIFF
--- a/engine/app/controllers/good_job/base_controller.rb
+++ b/engine/app/controllers/good_job/base_controller.rb
@@ -6,16 +6,16 @@ module GoodJob
     around_action :switch_locale
 
     content_security_policy do |policy|
-      policy.default_src(:none) if policy.default_src.blank?
-      policy.connect_src(:self) if policy.connect_src.blank?
-      policy.base_uri(:none) if policy.base_uri.blank?
-      policy.font_src(:self) if policy.font_src.blank?
-      policy.img_src(:self, :data) if policy.img_src.blank?
-      policy.object_src(:none) if policy.object_src.blank?
-      policy.script_src(:self) if policy.script_src.blank?
-      policy.style_src(:self) if policy.style_src.blank?
-      policy.form_action(:self) if policy.form_action.blank?
-      policy.frame_ancestors(:none) if policy.frame_ancestors.blank?
+      policy.default_src(:none) if policy.default_src(*policy.default_src).blank?
+      policy.connect_src(:self) if policy.connect_src(*policy.connect_src).blank?
+      policy.base_uri(:none) if policy.base_uri(*policy.base_uri).blank?
+      policy.font_src(:self) if policy.font_src(*policy.font_src).blank?
+      policy.img_src(:self, :data) if policy.img_src(*policy.img_src).blank?
+      policy.object_src(:none) if policy.object_src(*policy.object_src).blank?
+      policy.script_src(:self) if policy.script_src(*policy.script_src).blank?
+      policy.style_src(:self) if policy.style_src(*policy.style_src).blank?
+      policy.form_action(:self) if policy.form_action(*policy.form_action).blank?
+      policy.frame_ancestors(:none) if policy.frame_ancestors(*policy.frame_ancestors).blank?
     end
 
     before_action do


### PR DESCRIPTION
I noticed that updating the good_job dashboard broke the javascript, due to it being blocked by the content security policy.
For applications that use a custom CSP, good_job breaks. It is due to very strange code in the `action_dispatch` gem. If you check the policies it triggers a side effect. See below the offending method source.

This pull request enabled good_job to check the csp policies without actually removing them.

This is the code in `action_dispatch` that causes the issue. Really strange to me that checking the policies' values causes them to be removed.

```ruby
From: /Users/jonathan/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actionpack-6.1.4/lib/action_dispatch/http/content_security_policy.rb:164:
Owner: ActionDispatch::ContentSecurityPolicy
Visibility: public
Signature: default_src(*sources)
Number of lines: 7

define_method(name) do |*sources|
  if sources.first
    @directives[directive] = apply_mappings(sources)
  else
    @directives.delete(directive)
  end
end
```