### PR TITLE
Remove Concurrent::Delay wrapping of database-loading methods

### DIFF
--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -13,9 +13,6 @@ module GoodJob
     # @param queue_string [String] Queues to execute jobs from
     def initialize(queue_string)
       @queue_string = queue_string
-
-      @job_query = Concurrent::Delay.new { GoodJob::Execution.queue_string(queue_string) }
-      @parsed_queues = Concurrent::Delay.new { GoodJob::Execution.queue_parser(queue_string) }
     end
 
     # A meaningful name to identify the performer in logs and for debugging.
@@ -65,11 +62,11 @@ module GoodJob
     attr_reader :queue_string
 
     def job_query
-      @job_query.value
+      @_job_query ||= GoodJob::Execution.queue_string(queue_string)
     end
 
     def parsed_queues
-      @parsed_queues.value
+      @_parsed_queues ||= GoodJob::Execution.queue_parser(queue_string)
     end
   end
 end

--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -24,7 +24,7 @@ module GoodJob
 
     included do
       # Default column to be used when creating Advisory Locks
-      class_attribute :advisory_lockable_column, instance_accessor: false, default: Concurrent::Delay.new { primary_key }
+      class_attribute :advisory_lockable_column, instance_accessor: false, default: nil
 
       # Default Postgres function to be used for Advisory Locks
       class_attribute :advisory_lockable_function, default: "pg_try_advisory_lock"
@@ -161,10 +161,8 @@ module GoodJob
         end
       end
 
-      # Allow advisory_lockable_column to be a `Concurrent::Delay`
       def _advisory_lockable_column
-        column = advisory_lockable_column
-        column.respond_to?(:value) ? column.value : column
+        advisory_lockable_column || primary_key
       end
 
       def supports_cte_materialization_specifiers?


### PR DESCRIPTION
Fixes #457.

Using memoization, rather than a `Concurrent::Delay` should be threadsafe enough because the results are idempotent.