### PR TITLE
Allow GoodJob global configuration accessors to also be set via Rails config hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
 1. Configure the ActiveJob adapter:
 
     ```ruby
-    # config/application.rb
+    # config/application.rb or config/environments/{RAILS_ENV}.rb
     config.active_job.queue_adapter = :good_job
     ```
 
@@ -212,41 +212,48 @@ to delete old records and preserve space in your database.
 
 ### Configuration options
 
-To use GoodJob, you can set `config.active_job.queue_adapter` to a `:good_job`.
+ActiveJob configuration depends on where the code is placed:
 
-Additional configuration can be provided via `config.good_job.OPTION = ...`.
+- `config.active_job.queue_adapter = :good_job` within `config/application.rb` or `config/environments/*.rb`.
+- `ActiveJob::Base.queue_adapter = :good_job` within an initializer (e.g. `config/initializers/active_job.rb`).
+
+GoodJob configuration can be placed within Rails `config` directory for all environments (`config/application.rb`), within a particular environment (e.g. `config/environments/development.rb`), or within an initializer (e.g. `config/initializers/good_job.rb`).
 
 Configuration examples:
 
 ```ruby
-# config/application.rb
+Rails.application.configure do
+  # Configure options individually...
+  config.good_job.preserve_job_records = true
+  config.good_job.retry_on_unhandled_error = false
+  config.good_job.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+  config.good_job.execution_mode = :async
+  config.good_job.max_threads = 5
+  config.good_job.poll_interval = 30 # seconds
+  config.good_job.shutdown_timeout = 25 # seconds
+  config.good_job.enable_cron = true
+  config.good_job.cron = { example: { cron: '0 * * * *', class: 'ExampleJob'  } }
+  config.good_job.queues = '*'
 
-config.active_job.queue_adapter = :good_job
-
-# Configure options individually...
-config.good_job.execution_mode = :async
-config.good_job.max_threads = 5
-config.good_job.poll_interval = 30 # seconds
-config.good_job.shutdown_timeout = 25 # seconds
-config.good_job.enable_cron = true
-config.good_job.cron = { example: { cron: '0 * * * *', class: 'ExampleJob'  } }
-config.good_job.queues = '*'
-
-# ...or all at once.
-config.good_job = {
-  execution_mode: :async,
-  max_threads: 5,
-  poll_interval: 30,
-  shutdown_timeout: 25,
-  enable_cron: true,
-  cron: {
-    example: {
-      cron: '0 * * * *',
-      class: 'ExampleJob'
+  # ...or all at once.
+  config.good_job = {
+    preserve_job_records: true,
+    retry_on_unhandled_error: false,
+    on_thread_error: -> (exception) { Raven.capture_exception(exception) },
+    execution_mode: :async,
+    max_threads: 5,
+    poll_interval: 30,
+    shutdown_timeout: 25,
+    enable_cron: true,
+    cron: {
+      example: {
+        cron: '0 * * * *',
+        class: 'ExampleJob'
+      },
     },
-  },
-  queues: '*',
-}
+    queues: '*',
+  }
+end
 ```
 
 Available configuration options are:
@@ -263,6 +270,14 @@ Available configuration options are:
 - `shutdown_timeout` (float) number of seconds to wait for jobs to finish when shutting down before stopping the thread. Defaults to forever: `-1`. You can also set this with the environment variable `GOOD_JOB_SHUTDOWN_TIMEOUT`.
 - `enable_cron` (boolean) whether to run cron process. Defaults to `false`. You can also set this with the environment variable `GOOD_JOB_ENABLE_CRON`.
 - `cron` (hash) cron configuration. Defaults to `{}`. You can also set this as a JSON string with the environment variable `GOOD_JOB_CRON`
+- `logger` ([Rails Logger](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html)) lets you set a custom logger for GoodJob. It should be an instance of a Rails `Logger` (Default: `Rails.logger`).
+- `preserve_job_records` (boolean) keeps job records in your database even after jobs are completed. (Default: `false`)
+- `retry_on_unhandled_error` (boolean) causes jobs to be re-queued and retried if they raise an instance of `StandardError`. Instances of `Exception`, like SIGINT, will *always* be retried, regardless of this attribute’s value. (Default: `true`)
+- `on_thread_error` (proc, lambda, or callable) will be called when an Exception. It can be useful for logging errors to bug tracking services, like Sentry or Airbrake. Example:
+
+    ```ruby
+    config.good_job.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+    ```
 
 By default, GoodJob configures the following execution modes per environment:
 
@@ -283,7 +298,7 @@ config.good_job.execution_mode = :external
 
 ### Global options
 
-Good Job’s general behavior can also be configured via several attributes directly on the `GoodJob` module:
+Good Job’s general behavior can also be configured via attributes directly on the `GoodJob` module:
 
 - **`GoodJob.active_record_parent_class`** (string) The ActiveRecord parent class inherited by GoodJob's ActiveRecord model `GoodJob::Job` (defaults to `"ActiveRecord::Base"`). Configure this when using [multiple databases with ActiveRecord](https://guides.rubyonrails.org/active_record_multiple_databases.html) or when other custom configuration is necessary for the ActiveRecord model to connect to the Postgres database. _The value must be a String to avoid premature initialization of ActiveRecord._
 - **`GoodJob.logger`** ([Rails Logger](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html)) lets you set a custom logger for GoodJob. It should be an instance of a Rails `Logger`.

--- a/lib/good_job/cron_manager.rb
+++ b/lib/good_job/cron_manager.rb
@@ -21,7 +21,7 @@ module GoodJob # :nodoc:
     def self.task_observer(time, output, thread_error) # rubocop:disable Lint/UnusedMethodArgument
       return if thread_error.is_a? Concurrent::CancelledOperationError
 
-      GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+      GoodJob._on_thread_error(thread_error) if thread_error
     end
 
     # Execution configuration to be scheduled

--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -120,7 +120,7 @@ module GoodJob # :nodoc:
       return if thread_error.is_a? AdapterCannotListenError
 
       if thread_error
-        GoodJob.on_thread_error.call(thread_error) if GoodJob.on_thread_error.respond_to?(:call)
+        GoodJob._on_thread_error(thread_error)
         ActiveSupport::Notifications.instrument("notifier_notify_error.good_job", { error: thread_error })
 
         connection_error = CONNECTION_ERRORS.any? do |error_string|

--- a/lib/good_job/poller.rb
+++ b/lib/good_job/poller.rb
@@ -91,7 +91,7 @@ module GoodJob # :nodoc:
     # @param thread_error [Exception, nil]
     # @return [void]
     def timer_observer(time, executed_task, thread_error)
-      GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+      GoodJob._on_thread_error(thread_error) if thread_error
       ActiveSupport::Notifications.instrument("finished_timer_task", { result: executed_task, error: thread_error, time: time })
     end
 

--- a/lib/good_job/probe_server.rb
+++ b/lib/good_job/probe_server.rb
@@ -7,7 +7,7 @@ module GoodJob
     def self.task_observer(time, output, thread_error) # rubocop:disable Lint/UnusedMethodArgument
       return if thread_error.is_a? Concurrent::CancelledOperationError
 
-      GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+      GoodJob._on_thread_error(thread_error) if thread_error
     end
 
     def initialize(port:)

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -169,7 +169,7 @@ module GoodJob # :nodoc:
     # @return [void]
     def task_observer(time, output, thread_error)
       error = thread_error || (output.is_a?(GoodJob::ExecutionResult) ? output.unhandled_error : nil)
-      GoodJob.on_thread_error.call(error) if error && GoodJob.on_thread_error.respond_to?(:call)
+      GoodJob._on_thread_error(error) if error
 
       instrument("finished_job_task", { result: output, error: thread_error, time: time })
       create_task if output
@@ -206,7 +206,7 @@ module GoodJob # :nodoc:
       end
 
       observer = lambda do |_time, _output, thread_error|
-        GoodJob.on_thread_error.call(thread_error) if thread_error && GoodJob.on_thread_error.respond_to?(:call)
+        GoodJob._on_thread_error(thread_error) if thread_error
         create_task # If cache-warming exhausts the threads, ensure there isn't an executable task remaining
       end
       future.add_observer(observer, :call)

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -19,14 +19,6 @@ module TestApp
 
     # config.middleware.insert_before Rack::Sendfile, ActionDispatch::DebugLocks
     config.log_level = :debug
-
-    config.good_job.cron = {
-      example: {
-        cron: '*/5 * * * * *', # every 5 seconds
-        class: 'ExampleJob',
-        description: "Enqueue ExampleJob every 5 seconds",
-      },
-    }
   end
 end
 

--- a/spec/test_app/config/environments/production.rb
+++ b/spec/test_app/config/environments/production.rb
@@ -88,8 +88,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.active_job.queue_adapter = :good_job
-
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/spec/test_app/config/initializers/good_job.rb
+++ b/spec/test_app/config/initializers/good_job.rb
@@ -1,11 +1,22 @@
+Rails.application.configure do
+  config.good_job.cron = {
+    example: {
+      cron: '*/5 * * * * *', # every 5 seconds
+      class: 'ExampleJob',
+      description: "Enqueue ExampleJob every 5 seconds",
+    },
+  }
+end
+
 case Rails.env
 when 'development'
+  ActiveJob::Base.queue_adapter = :good_job
+
   GoodJob.retry_on_unhandled_error = false
   GoodJob.preserve_job_records = true
   GoodJob.on_thread_error = -> (error) { Rails.logger.warn(error) }
 
   Rails.application.configure do
-    config.active_job.queue_adapter = :good_job
     config.good_job.enable_cron = ActiveModel::Type::Boolean.new.cast(ENV.fetch('GOOD_JOB_ENABLE_CRON', true))
     config.good_job.cron = {
       frequent_example: {
@@ -28,11 +39,12 @@ when 'development'
 when 'test'
   # test
 when 'demo'
+  ActiveJob::Base.queue_adapter = :good_job
+
   GoodJob.preserve_job_records = true
   GoodJob.retry_on_unhandled_error = false
 
   Rails.application.configure do
-    config.active_job.queue_adapter = :good_job
     config.good_job.execution_mode = :async
     config.good_job.poll_interval = 30
 
@@ -67,5 +79,5 @@ when 'demo'
     }
   end
 when 'production'
-  # production
+  ActiveJob::Base.queue_adapter = :good_job
 end


### PR DESCRIPTION
~~Deprecates all `GoodJob` configuration accessors, in favor of Rails configuration hash.~~

I was originally planning to deprecate them now, but I plan with GoodJob 3.0 to change them as a result of #412 so I'll deprecate most of them (with the exception of `logger` and `on_thread_error`) when I do that.

- Creates a callable `GoodJob._on_thread_error` method
- Wraps all of the Railtie code `initializer` blocks
- Fixes some app configuration from #454 

Connects to #380.