### PR TITLE
Use `ActiveRecord::Relation::QueryAttribute` when setting up bindings for `exec_query`

### DIFF
--- a/engine/app/charts/good_job/scheduled_by_queue_chart.rb
+++ b/engine/app/charts/good_job/scheduled_by_queue_chart.rb
@@ -30,7 +30,10 @@ module GoodJob
         ORDER BY timestamp ASC
       SQL
 
-      binds = [[nil, start_time], [nil, end_time]]
+      binds = [
+        ActiveRecord::Relation::QueryAttribute.new('start_time', start_time, ActiveRecord::Type::DateTime.new),
+        ActiveRecord::Relation::QueryAttribute.new('end_time', end_time, ActiveRecord::Type::DateTime.new),
+      ]
       executions_data = GoodJob::Execution.connection.exec_query(GoodJob::Execution.pg_or_jdbc_query(count_query), "GoodJob Dashboard Chart", binds)
 
       queue_names = executions_data.reject { |d| d['count'].nil? }.map { |d| d['queue_name'] || BaseFilter::EMPTY }.uniq

--- a/lib/good_job/lockable.rb
+++ b/lib/good_job/lockable.rb
@@ -215,7 +215,9 @@ module GoodJob
                 SQL
               end
 
-      binds = [[nil, key]]
+      binds = [
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+      ]
       self.class.connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Lock', binds).first['locked']
     end
 
@@ -229,7 +231,9 @@ module GoodJob
       query = <<~SQL.squish
         SELECT #{function}(('x'||substr(md5($1::text), 1, 16))::bit(64)::bigint) AS unlocked
       SQL
-      binds = [[nil, key]]
+      binds = [
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+      ]
       self.class.connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Unlock', binds).first['unlocked']
     end
 
@@ -279,7 +283,10 @@ module GoodJob
           AND pg_locks.classid = ('x' || substr(md5($1::text), 1, 16))::bit(32)::int
           AND pg_locks.objid = (('x' || substr(md5($2::text), 1, 16))::bit(64) << 32)::bit(32)::int
       SQL
-      binds = [[nil, key], [nil, key]]
+      binds = [
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+      ]
       self.class.connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Locked?', binds).any?
     end
 
@@ -303,7 +310,10 @@ module GoodJob
           AND pg_locks.objid = (('x' || substr(md5($2::text), 1, 16))::bit(64) << 32)::bit(32)::int
           AND pg_locks.pid = pg_backend_pid()
       SQL
-      binds = [[nil, key], [nil, key]]
+      binds = [
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+        ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
+      ]
       self.class.connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Owns Advisory Lock?', binds).any?
     end
 


### PR DESCRIPTION
Seems to be required for Rails 7