### PR TITLE
Fix Railtie configuration assignment when Rails configuration is a Hash, not an OrderedOptions

### DIFF
--- a/lib/good_job/railtie.rb
+++ b/lib/good_job/railtie.rb
@@ -24,10 +24,12 @@ module GoodJob
 
     initializer 'good_job.rails_config' do
       config.after_initialize do
-        GoodJob.logger = Rails.application.config.good_job.logger unless Rails.application.config.good_job.logger.nil?
-        GoodJob.on_thread_error = Rails.application.config.good_job.on_thread_error unless Rails.application.config.good_job.on_thread_error.nil?
-        GoodJob.preserve_job_records = Rails.application.config.good_job.preserve_job_records unless Rails.application.config.good_job.preserve_job_records.nil?
-        GoodJob.retry_on_unhandled_error = Rails.application.config.good_job.retry_on_unhandled_error unless Rails.application.config.good_job.retry_on_unhandled_error.nil?
+        rails_config = Rails.application.config.good_job
+
+        GoodJob.logger = rails_config[:logger] if rails_config.key?(:logger)
+        GoodJob.on_thread_error = rails_config[:on_thread_error] if rails_config.key?(:on_thread_error)
+        GoodJob.preserve_job_records = rails_config[:preserve_job_records] if rails_config.key?(:preserve_job_records)
+        GoodJob.retry_on_unhandled_error = rails_config[:retry_on_unhandled_error] if rails_config.key?(:retry_on_unhandled_error)
       end
     end
 


### PR DESCRIPTION
Fixes #463 introduced in #460. 