### PR TITLE
Allow Scheduler to automatically clean up preserved jobs every N jobs or seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ Available configuration options are:
 - `shutdown_timeout` (float) number of seconds to wait for jobs to finish when shutting down before stopping the thread. Defaults to forever: `-1`. You can also set this with the environment variable `GOOD_JOB_SHUTDOWN_TIMEOUT`.
 - `enable_cron` (boolean) whether to run cron process. Defaults to `false`. You can also set this with the environment variable `GOOD_JOB_ENABLE_CRON`.
 - `cron` (hash) cron configuration. Defaults to `{}`. You can also set this as a JSON string with the environment variable `GOOD_JOB_CRON`
+- `cleanup_preserved_jobs_before_seconds_ago` (integer) number of seconds to preserve jobs when using the `$ good_job cleanup_preserved_jobs` CLI command or calling `GoodJob.cleanup_preserved_jobs`. Defaults to `86400` (1 day). Can also be set with  the environment variable `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO`.  _This configuration is only used when {GoodJob.preserve_job_records} is `true`._
+- `cleanup_interval_jobs` (integer) Number of jobs a Scheduler will execute before cleaning up preserved jobs. Defaults to `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_JOBS`.
+- `cleanup_interval_seconds` (integer) Number of seconds a Scheduler will wait before cleaning up preserved jobs. Defaults to `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_SECONDS`.
 - `logger` ([Rails Logger](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html)) lets you set a custom logger for GoodJob. It should be an instance of a Rails `Logger` (Default: `Rails.logger`).
 - `preserve_job_records` (boolean) keeps job records in your database even after jobs are completed. (Default: `false`)
 - `retry_on_unhandled_error` (boolean) causes jobs to be re-queued and retried if they raise an instance of `StandardError`. Instances of `Exception`, like SIGINT, will *always* be retried, regardless of this attribute’s value. (Default: `true`)

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -121,7 +121,7 @@ module GoodJob
     end
 
     # Start async executors
-    # @return void
+    # @return [void]
     def start_async
       return unless execute_async?
 

--- a/lib/good_job/cleanup_tracker.rb
+++ b/lib/good_job/cleanup_tracker.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module GoodJob # :nodoc:
+  # Tracks thresholds for cleaning up old jobs.
+  class CleanupTracker
+    attr_accessor :cleanup_interval_seconds,
+                  :cleanup_interval_jobs,
+                  :job_count,
+                  :last_at
+
+    def initialize(cleanup_interval_seconds: nil, cleanup_interval_jobs: nil)
+      self.cleanup_interval_seconds = cleanup_interval_seconds
+      self.cleanup_interval_jobs = cleanup_interval_jobs
+
+      reset
+    end
+
+    # Increments job count.
+    # @return [void]
+    def increment
+      self.job_count += 1
+    end
+
+    # Whether a cleanup should be run.
+    # @return [Boolean]
+    def cleanup?
+      (cleanup_interval_jobs && job_count > cleanup_interval_jobs) ||
+        (cleanup_interval_seconds && last_at < Time.current - cleanup_interval_seconds) ||
+        false
+    end
+
+    # Resets the counters.
+    # @return [void]
+    def reset
+      self.job_count = 0
+      self.last_at = Time.current
+    end
+  end
+end

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -18,6 +18,10 @@ module GoodJob
     DEFAULT_MAX_CACHE = 10000
     # Default number of seconds to preserve jobs for {CLI#cleanup_preserved_jobs} and {GoodJob.cleanup_preserved_jobs}
     DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO = 24 * 60 * 60
+    # Default number of jobs to execute between preserved job cleanup runs
+    DEFAULT_CLEANUP_INTERVAL_JOBS = nil
+    # Default number of seconds to wait between preserved job cleanup runs
+    DEFAULT_CLEANUP_INTERVAL_SECONDS = nil
     # Default to always wait for jobs to finish for {Adapter#shutdown}
     DEFAULT_SHUTDOWN_TIMEOUT = -1
     # Default to not running cron
@@ -177,6 +181,28 @@ module GoodJob
           env['GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO'] ||
           DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO
       ).to_i
+    end
+
+    # Number of jobs a {Scheduler} will execute before cleaning up preserved jobs.
+    # @return [Integer, nil]
+    def cleanup_interval_jobs
+      value = (
+        rails_config[:cleanup_interval_jobs] ||
+          env['GOOD_JOB_CLEANUP_INTERVAL_JOBS'] ||
+          DEFAULT_CLEANUP_INTERVAL_JOBS
+      )
+      value.present? ? value.to_i : nil
+    end
+
+    # Number of seconds a {Scheduler} will wait before cleaning up preserved jobs.
+    # @return [Integer, nil]
+    def cleanup_interval_seconds
+      value = (
+        rails_config[:cleanup_interval_seconds] ||
+          env['GOOD_JOB_CLEANUP_INTERVAL_SECONDS'] ||
+          DEFAULT_CLEANUP_INTERVAL_SECONDS
+      )
+      value.present? ? value.to_i : nil
     end
 
     # Tests whether to daemonize the process.

--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -57,6 +57,12 @@ module GoodJob
       job_query.next_scheduled_at(after: after, limit: limit, now_limit: now_limit)
     end
 
+    # Delete expired preserved jobs
+    # @return [void]
+    def cleanup
+      GoodJob.cleanup_preserved_jobs
+    end
+
     private
 
     attr_reader :queue_string

--- a/spec/lib/good_job/cleanup_tracker_spec.rb
+++ b/spec/lib/good_job/cleanup_tracker_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe GoodJob::CleanupTracker do
+  describe '#cleanup?' do
+    context 'with default parameters' do
+      it 'will never trigger a cleanup' do
+        tracker = described_class.new
+
+        1000.times { tracker.increment }
+        travel_to 1.year.from_now do
+          expect(tracker.cleanup?).to eq false
+        end
+      end
+    end
+
+    it 'will trigger a after cleanup_interval_jobs is exceeded' do
+      tracker = described_class.new(cleanup_interval_seconds: nil, cleanup_interval_jobs: 10)
+
+      10.times { tracker.increment }
+      expect(tracker.cleanup?).to eq false
+
+      tracker.increment
+      expect(tracker.cleanup?).to eq true
+    end
+  end
+
+  describe '#increment' do
+    it 'increments cleanup_count' do
+      tracker = described_class.new
+
+      expect { tracker.increment }.to change(tracker, :job_count).by(1)
+    end
+  end
+
+  describe '#reset' do
+    it 'resets job_count and last_at' do
+      tracker = described_class.new
+
+      1000.times { tracker.increment }
+      travel_to 1.year.from_now do
+        tracker.reset
+
+        expect(tracker.job_count).to eq 0
+        expect(tracker.last_at).to be_within(0.1).of(Time.current)
+      end
+    end
+  end
+end

--- a/spec/lib/good_job/cli_spec.rb
+++ b/spec/lib/good_job/cli_spec.rb
@@ -49,7 +49,9 @@ RSpec.describe GoodJob::CLI do
           a_kind_of(GoodJob::JobPerformer),
           max_threads: 4,
           max_cache: GoodJob::Configuration::DEFAULT_MAX_CACHE,
-          warm_cache_on_initialize: true
+          warm_cache_on_initialize: true,
+          cleanup_interval_seconds: nil,
+          cleanup_interval_jobs: nil
         )
       end
     end

--- a/spec/lib/good_job/job_performer_spec.rb
+++ b/spec/lib/good_job/job_performer_spec.rb
@@ -38,4 +38,12 @@ RSpec.describe GoodJob::JobPerformer do
       expect(result).to eq false
     end
   end
+
+  describe '#cleanup' do
+    it 'calls GoodJob.cleanup_preserved_jobs' do
+      allow(GoodJob).to receive(:cleanup_preserved_jobs)
+      described_class.new('*').cleanup
+      expect(GoodJob).to have_received(:cleanup_preserved_jobs)
+    end
+  end
 end


### PR DESCRIPTION
This will be enabled by default in GoodJob 3.0. 

The general idea is a garbage collector doing a sweep on a set interval: both number of jobs executed, and a time-based interval. The time-based interval is currently reliant on a job being executed i.e. the trigger for the time-based interval is a job being executed (there is not a separate cron-like process)

Adds two new configuration options:

- `cleanup_interval_jobs` (integer) Number of jobs a Scheduler will execute before cleaning up preserved jobs. Defaults to `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_JOBS`.
- `cleanup_interval_seconds` (integer) Number of seconds a Scheduler will wait before cleaning up preserved jobs. Defaults to `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_SECONDS`.

Closes #412 