### PR TITLE
Update appraisal for Rails 7.0.0.rc1

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -22,7 +22,8 @@ if ruby_27_or_higher && !jruby
   # activerecord-jdbcpostgresql-adapter does not have a compatible version
 
   appraise "rails-7.0" do
-    gem "rails", "~> 7.0.0.alpha2"
+    gem "rails", "~> 7.0.0.rc1"
+    gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
   end
 
   # https://github.com/rails/rails/issues/43422

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,7 +5,8 @@ source "https://rubygems.org"
 gem "activerecord-jdbcpostgresql-adapter", platforms: [:jruby]
 gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/appraisal.git"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rails", "~> 7.0.0.alpha"
+gem "rails", "~> 7.0.0.rc1"
+gem "selenium-webdriver", "~> 4.0"
 
 platforms :ruby do
   gem "activerecord-explain-analyze"

--- a/spec/support/example_app_helper.rb
+++ b/spec/support/example_app_helper.rb
@@ -9,10 +9,12 @@ module ExampleAppHelper
     FileUtils.cd(root_path) do
       system("rails new #{app_name} -d postgresql --no-assets --skip-action-text --skip-action-mailer --skip-action-mailbox --skip-action-cable --skip-git --skip-sprockets --skip-listen --skip-javascript --skip-turbolinks --skip-system-test --skip-test-unit --skip-bootsnap --skip-spring --skip-active-storage")
     end
+
+    FileUtils.rm_rf("#{example_app_path}/config/initializers/assets.rb")
     FileUtils.cp(::Rails.root.join('config', 'database.yml'), "#{example_app_path}/config/database.yml")
 
     File.open("#{example_app_path}/Gemfile", 'a') do |f|
-      f.puts "gem 'good_job'"
+      f.puts 'gem "good_job", path: "#{File.dirname(__FILE__)}/../../../"' # rubocop:disable Lint/InterpolationCheck
     end
   end
 


### PR DESCRIPTION
- Locks `selenium-webdriver` version: Rails 7 System Tests uses selenium-webdriver v4.0, which is not compatible with Ruby 2.5
- Deletes the `config/initializers/assets.rb` file in generator tests: Rails 7 app generator creates that file, with a sprockets-specific directive even if sprockets is skipped https://github.com/rails/rails/issues/43793