### PR TITLE
Doublequote Ruby 3.0 in testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,16 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0, jruby-9.2, jruby-9.3]
+        ruby: [2.5, 2.6, 2.7, "3.0", jruby-9.2, jruby-9.3]
         pg: [14]
         include:
-          - ruby: 3.0
+          - ruby: "3.0"
             pg: 10
-          - ruby: 3.0
+          - ruby: "3.0"
             pg: 11
-          - ruby: 3.0
+          - ruby: "3.0"
             pg: 12
-          - ruby: 3.0
+          - ruby: "3.0"
             pg: 13
           - ruby: jruby-9.3
             pg: 10


### PR DESCRIPTION
- Doublequotes necessary: https://github.com/actions/runner/issues/849
- Not yet adding Ruby 3.1 because of other incompatibilities with Rails 6.1 and Thor