### PR TITLE
Bug Fix when using Concurrency

### DIFF
--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -64,7 +64,7 @@ module GoodJob
           GoodJob::Execution.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
             allowed_active_job_ids = GoodJob::Execution.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
             # The current job has already been locked and will appear in the previous query
-            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.include? job.job_id
+            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.select{|r| r['active_job_id'] == job.job_id}
           end
         end
       end

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -64,7 +64,7 @@ module GoodJob
           GoodJob::Execution.new.with_advisory_lock(key: key, function: "pg_advisory_lock") do
             allowed_active_job_ids = GoodJob::Execution.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
             # The current job has already been locked and will appear in the previous query
-            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.select{|r| r['active_job_id'] == job.job_id}
+            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.flat_map(&:values).include? job.job_id
           end
         end
       end


### PR DESCRIPTION
![good_job_pr](https://user-images.githubusercontent.com/51307998/148618906-210b28cf-8c20-478d-9cfa-c487068e1e7c.png)

Came across this issue in development, where .pluck on line 65 does not seem to be working properly,
it returns allowed_active_job_ids = [{'active_job_id' => XXXX}] instead of [XXX].

It's not very dry doing the .flat_map again on the next line, but it works properly.