### PR TITLE
Add details about exactly where to require the engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ _🚧 GoodJob's dashboard is a work in progress. Please contribute ideas and cod
 
 GoodJob includes a Dashboard as a mountable `Rails::Engine`.
 
-1. Explicitly require the Engine code at the top of your `config/application.rb` file, immediately after Rails is required. This is necessary because the mountable engine is an optional feature of GoodJob.
+1. Explicitly require the Engine code at the top of your `config/application.rb` file, immediately after Rails is required and before Bundler requires the Rails' groups. This is necessary because the mountable engine is an optional feature of GoodJob.
 
     ```ruby
     # config/application.rb
@@ -338,6 +338,8 @@ GoodJob includes a Dashboard as a mountable `Rails::Engine`.
     require 'good_job/engine' # <= Add this line
     # ...
     ```
+
+   Note: If you find the dashboard fails to reload due to a routing error and uninitialized constant `GoodJob::ExecutionsController`, this is likely because you are not requiring the engine early enough.
 
 1. Mount the engine in your `config/routes.rb` file. The following will mount it at `http://example.com/good_job`.
 


### PR DESCRIPTION
This clarifies exactly where to require goodjob in config/application.rb
and adds a note about how to resolve the issue when the dashboard won't
reload after saving a file.

Context: I skimmed the README when I set it up and made my
application.rb look like this:

```require "rails"

require "active_model/railtie"
require "active_job/railtie"
require "active_record/railtie"
require "active_storage/engine"
require "action_controller/railtie"
require "action_mailer/railtie"
require "action_text/engine"
require "action_view/railtie"
require "action_cable/engine"
require "sprockets/railtie"

Bundler.require(*Rails.groups)

require "good_job/engine"
```

With this setup, the dashboard would work fine until I saved any file
(ie. a model). After that reloading the dashboard would give this error:

Routing Error
uninitialized constant GoodJob::ExecutionsController

By moving the require line _before_ the `Bundler.require` line, this
problem went away.