### PR TITLE
Use `websearch_to_tsquery` or (`plainto_tsquery` for Postgres < v11) for Dashboard search filter

### DIFF
--- a/spec/engine/filters/good_job/jobs_filter_spec.rb
+++ b/spec/engine/filters/good_job/jobs_filter_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe GoodJob::JobsFilter do
       it 'returns a limited set of results' do
         expect(filter.records.size).to eq 1
       end
+
+      describe 'Ruby namespaced query' do
+        before { params[:query] = 'ExampleJob::DeadError' }
+
+        it 'returns a limited set of results' do
+          expect(filter.records.size).to eq 1
+        end
+      end
     end
   end
 

--- a/spec/lib/good_job/filterable_spec.rb
+++ b/spec/lib/good_job/filterable_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe GoodJob::Filterable do
   let(:model_class) { GoodJob::Execution }
-  let!(:execution) { model_class.create(active_job_id: SecureRandom.uuid, queue_name: "default", serialized_params: { example_key: 'example_value' }, error: "ExampleError: a message") }
+  let!(:execution) { model_class.create(active_job_id: SecureRandom.uuid, queue_name: "default", serialized_params: { example_key: 'example_value' }, error: "ExampleJob::ExampleError: a message") }
 
   describe '.search_test' do
     it 'searches serialized params' do
@@ -16,6 +16,10 @@ RSpec.describe GoodJob::Filterable do
 
     it 'searches errors' do
       expect(model_class.search_text('ExampleError')).to include(execution)
+    end
+
+    it 'searches strings with colons' do
+      expect(model_class.search_text('ExampleJob::ExampleError')).to include(execution)
     end
 
     it 'filters out non-matching records' do


### PR DESCRIPTION
Closes #487, which fixes a problem in which using a colon causes Postgres to return a "syntax error in tsquery":

```sql
# SELECT to_tsquery('alice::bob');
ERROR:  syntax error in tsquery: "alice::bob"
```