### PR TITLE
Guard LogSubscriber against tagged logger without a formatter

### DIFF
--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -206,7 +206,7 @@ module GoodJob
       good_job_tag = ["ActiveJob"].freeze
 
       self.class.loggers.inject(block) do |inner, each_logger|
-        if each_logger.respond_to?(:tagged)
+        if each_logger.respond_to?(:tagged) && each_logger.formatter
           tags_for_logger = if each_logger.formatter.current_tags.include?("ActiveJob")
                               good_job_tag + tags
                             else

--- a/spec/lib/good_job/log_subscriber_spec.rb
+++ b/spec/lib/good_job/log_subscriber_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GoodJob::LogSubscriber do
+  let(:subscriber) { described_class.new }
+
+  around do |example|
+    orig_loggers = described_class.loggers.dup
+    described_class.loggers.clear
+    described_class.reset_logger
+
+    example.run
+
+    described_class.loggers.replace(orig_loggers)
+    described_class.reset_logger
+  end
+
+  describe "loggers" do
+    let(:logs) { StringIO.new }
+
+    it 'logs output with a simple logger' do
+      described_class.loggers << Logger.new(logs)
+      event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", {})
+
+      subscriber.scheduler_create_pool(event)
+      expect(logs.string).to include("GoodJob started scheduler with queues= max_threads=")
+    end
+
+    it 'logs output with a tagged logger with missing formatter' do
+      logger = ActiveSupport::TaggedLogging.new(Logger.new(logs))
+      logger.formatter = nil
+      described_class.loggers << logger
+
+      event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", {})
+
+      subscriber.scheduler_create_pool(event)
+      expect(logs.string).to include("GoodJob started scheduler with queues= max_threads=")
+    end
+  end
+end


### PR DESCRIPTION
SemanticLogger will create a Tagged Logger that does not have a formatter. This guard against that.

See https://github.com/reidmorrison/rails_semantic_logger/issues/29

Closes #502 
 