### PR TITLE
README: Limiting concurrency - fetch symbol instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ class MyJob < ApplicationJob
     key: -> { "Unique-#{arguments.first}" } #  MyJob.perform_later("Alice") => "Unique-Alice"
 
     # If the method uses named parameters, they can be accessed like so:
-    # key: -> { "Unique-#{arguments.first['name']}" } #  MyJob.perform_later(name: "Alice")
+    # key: -> { "Unique-#{arguments.first.fetch(:name)}" } #  MyJob.perform_later(name: "Alice")
   )
 
   def perform(first_name)

--- a/README.md
+++ b/README.md
@@ -399,11 +399,9 @@ class MyJob < ApplicationJob
 
     # A unique key to be globally locked against.
     # Can be String or Lambda/Proc that is invoked in the context of the job.
-    # Note: Arguments passed to #perform_later must be accessed through `arguments` method.
-    key: -> { "Unique-#{arguments.first}" } #  MyJob.perform_later("Alice") => "Unique-Alice"
-
-    # If the method uses named parameters, they can be accessed like so:
-    # key: -> { "Unique-#{arguments.first.fetch(:name)}" } #  MyJob.perform_later(name: "Alice")
+    # Note: Arguments passed to #perform_later can be accessed through ActiveJob's `arguments` method
+    # which is an array containing positional arguments and, optionally, a kwarg hash.
+    key: -> { "Unique-#{arguments.first}-#{arguments.last[:version]}" } #  MyJob.perform_later("Alice", version: 'v2') => "Unique-Alice-v2"
   )
 
   def perform(first_name)


### PR DESCRIPTION
Hi,

first of all thanks for the great work, indeed a good job! 

I found a minor mistake in the README regarding the concurrency limitation when using a keyword argument. Currently it says to use `[]` with a string, but the key in the arguments hash is a symbol, so the expression always turns into `nil` . 
Like proposed in this PR it should be a symbol instead of a string and I think it is also better to use `.fetch` instead of `[]`, so it raises immediately a `KeyError` instead of turning silently into `nil`, if the key does not exist.

Feel free to just adapt the README and close this PR.