### PR TITLE
Dashboard: update search filters and some small UI updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc
 .yardoc
 gemfiles/*.gemfile.lock
 tmp/rspec_examples.txt
+.DS_Store

--- a/engine/app/filters/good_job/executions_filter.rb
+++ b/engine/app/filters/good_job/executions_filter.rb
@@ -2,7 +2,7 @@
 module GoodJob
   class ExecutionsFilter < BaseFilter
     def states
-      {
+      @states ||= {
         'finished' => base_query.finished.count,
         'unfinished' => base_query.unfinished.count,
         'running' => base_query.running.count,

--- a/engine/app/filters/good_job/executions_filter.rb
+++ b/engine/app/filters/good_job/executions_filter.rb
@@ -2,7 +2,7 @@
 module GoodJob
   class ExecutionsFilter < BaseFilter
     def states
-      @states ||= {
+      @_states ||= {
         'finished' => base_query.finished.count,
         'unfinished' => base_query.unfinished.count,
         'running' => base_query.running.count,

--- a/engine/app/helpers/good_job/application_helper.rb
+++ b/engine/app/helpers/good_job/application_helper.rb
@@ -5,5 +5,20 @@ module GoodJob
       text = timestamp.future? ? "in #{time_ago_in_words(timestamp)}" : "#{time_ago_in_words(timestamp)} ago"
       tag.time(text, datetime: timestamp, title: timestamp)
     end
+
+    def status_badge(status)
+      classes = case status
+                when :finished
+                  "badge rounded-pill bg-success"
+                when :queued, :scheduled, :retried
+                  "badge rounded-pill bg-secondary"
+                when :running
+                  "badge rounded-pill bg-primary"
+                when :discarded
+                  "badge rounded-pill bg-danger"
+                end
+
+      content_tag :span, status.to_s, class: classes
+    end
   end
 end

--- a/engine/app/views/good_job/cron_entries/index.html.erb
+++ b/engine/app/views/good_job/cron_entries/index.html.erb
@@ -1,3 +1,7 @@
+<div class="my-3 flex">
+  <h2>Cron Schedules</h2>
+</div>
+
 <% if @cron_entries.present? %>
   <div class="card my-3">
     <div class="table-responsive">
@@ -47,5 +51,11 @@
     </div>
   </div>
 <% else %>
-  <em>No cron schedules present.</em>
+  <div class="card my-3">
+    <div class="card-body">
+      <p class="card-text">
+        <em>No cron schedules found.</em>
+      </p>
+    </div>
+  </div>
 <% end %>

--- a/engine/app/views/good_job/executions/_table.erb
+++ b/engine/app/views/good_job/executions/_table.erb
@@ -1,6 +1,6 @@
 <div class="card my-3">
   <div class="table-responsive">
-    <table class="table card-table table-bordered table-hover table-sm mb-0">
+    <table class="table card-table table-bordered table-hover table-sm mb-0" id="executions_index_table">
       <thead>
         <tr>
           <th>ActiveJob ID</th>

--- a/engine/app/views/good_job/executions/_table.erb
+++ b/engine/app/views/good_job/executions/_table.erb
@@ -20,34 +20,40 @@
         </tr>
       </thead>
       <tbody>
-        <% executions.each do |execution| %>
-          <tr id="<%= dom_id(execution) %>">
-            <td>
-              <%= link_to job_path(execution.serialized_params['job_id']) do %>
-                <code><%= execution.active_job_id %></code>
-              <% end %>
-            </td>
-            <td>
-              <%= link_to job_path(execution.active_job_id, anchor: dom_id(execution)) do %>
-                <code><%= execution.id %></code>
-              <% end %>
-            </td>
-            <td><%= execution.serialized_params['job_class'] %></td>
-            <td><%= execution.queue_name %></td>
-            <td><%= relative_time(execution.scheduled_at || execution.created_at) %></td>
-            <td class="text-break"><%= truncate(execution.error, length: 1_000) %></td>
-            <td>
-              <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
-                data: { bs_toggle: "collapse", bs_target: "##{dom_id(execution, 'params')}" },
-                aria: { expanded: false, controls: dom_id(execution, "params") }
-              %>
-              <%= tag.pre JSON.pretty_generate(execution.serialized_params), id: dom_id(execution, "params"), class: "collapse job-params" %>
-            </td>
-            <td>
-              <%= button_to execution_path(execution.id), method: :delete, class: "btn btn-sm btn-outline-danger", title: "Delete execution", data: { confirm: "Confirm delete" } do %>
-                <%= render "good_job/shared/icons/trash" %>
-              <% end %>
-            </td>
+        <% if executions.present? %>
+          <% executions.each do |execution| %>
+            <tr id="<%= dom_id(execution) %>">
+              <td>
+                <%= link_to job_path(execution.serialized_params['job_id']) do %>
+                  <code><%= execution.active_job_id %></code>
+                <% end %>
+              </td>
+              <td>
+                <%= link_to job_path(execution.active_job_id, anchor: dom_id(execution)) do %>
+                  <code><%= execution.id %></code>
+                <% end %>
+              </td>
+              <td><%= execution.serialized_params['job_class'] %></td>
+              <td><%= execution.queue_name %></td>
+              <td><%= relative_time(execution.scheduled_at || execution.created_at) %></td>
+              <td class="text-break"><%= truncate(execution.error, length: 1_000) %></td>
+              <td>
+                <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                  data: { bs_toggle: "collapse", bs_target: "##{dom_id(execution, 'params')}" },
+                  aria: { expanded: false, controls: dom_id(execution, "params") }
+                %>
+                <%= tag.pre JSON.pretty_generate(execution.serialized_params), id: dom_id(execution, "params"), class: "collapse job-params" %>
+              </td>
+              <td>
+                <%= button_to execution_path(execution.id), method: :delete, class: "btn btn-sm btn-outline-danger", title: "Delete execution", data: { confirm: "Confirm delete" } do %>
+                  <%= render "good_job/shared/icons/trash" %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="8" class="py-2 text-center text-muted">No executions found.</td>
           </tr>
         <% end %>
       </tbody>

--- a/engine/app/views/good_job/executions/index.html.erb
+++ b/engine/app/views/good_job/executions/index.html.erb
@@ -4,9 +4,9 @@
 
 <%= render 'good_job/shared/filter', filter: @filter %>
 
-<% if @filter.records.present? %>
-  <%= render 'good_job/executions/table', executions: @filter.records %>
+<%= render 'good_job/executions/table', executions: @filter.records %>
 
+<% if @filter.records.present? %>
   <nav aria-label="Job pagination" class="mt-3">
     <ul class="pagination">
       <li class="page-item">
@@ -16,6 +16,4 @@
       </li>
     </ul>
   </nav>
-<% else %>
-  <em>No executions present.</em>
 <% end %>

--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -21,45 +21,51 @@
         </tr>
       </thead>
       <tbody>
-        <% jobs.each do |job| %>
-          <tr class="<%= dom_class(job) %>" id="<%= dom_id(job) %>">
-            <td>
-              <%= link_to job_path(job.id) do %>
-                <code><%= job.id %></code>
-              <% end %>
-            </td>
-            <td>
-              <span class="badge bg-secondary"><%= job.status %></span>
-            </td>
-            <td><%= job.job_class %></td>
-            <td><%= job.queue_name %></td>
-            <td><%= relative_time(job.scheduled_at || job.created_at) %></td>
-            <td><%= job.executions_count %></td>
-            <td class="text-break"><%= truncate(job.recent_error, length: 1_000) %></td>
-            <td>
-              <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
-                data: { bs_toggle: "collapse", bs_target: "##{dom_id(job, 'params')}" },
-                aria: { expanded: false, controls: dom_id(job, "params") }
-              %>
-              <%= tag.pre JSON.pretty_generate(job.serialized_params), id: dom_id(job, "params"), class: "collapse job-params" %>
-            </td>
-            <td>
-              <div class="text-nowrap">
-                <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
-                <%= button_to reschedule_job_path(job.id), method: :put, class: "btn btn-sm #{job_reschedulable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_reschedulable, aria: { label: "Reschedule job" }, title: "Reschedule job", data: { confirm: "Confirm reschedule" } do %>
-                  <%= render "good_job/shared/icons/skip_forward" %>
+        <% if jobs.present? %>
+          <% jobs.each do |job| %>
+            <tr class="<%= dom_class(job) %>" id="<%= dom_id(job) %>">
+              <td>
+                <%= link_to job_path(job.id) do %>
+                  <code><%= job.id %></code>
                 <% end %>
+              </td>
+              <td>
+                <span class="badge bg-secondary"><%= job.status %></span>
+              </td>
+              <td><%= job.job_class %></td>
+              <td><%= job.queue_name %></td>
+              <td><%= relative_time(job.scheduled_at || job.created_at) %></td>
+              <td><%= job.executions_count %></td>
+              <td class="text-break"><%= truncate(job.recent_error, length: 1_000) %></td>
+              <td>
+                <%= tag.button "Preview", type: "button", class: "btn btn-sm btn-outline-primary", role: "button",
+                  data: { bs_toggle: "collapse", bs_target: "##{dom_id(job, 'params')}" },
+                  aria: { expanded: false, controls: dom_id(job, "params") }
+                %>
+                <%= tag.pre JSON.pretty_generate(job.serialized_params), id: dom_id(job, "params"), class: "collapse job-params" %>
+              </td>
+              <td>
+                <div class="text-nowrap">
+                  <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
+                  <%= button_to reschedule_job_path(job.id), method: :put, class: "btn btn-sm #{job_reschedulable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_reschedulable, aria: { label: "Reschedule job" }, title: "Reschedule job", data: { confirm: "Confirm reschedule" } do %>
+                    <%= render "good_job/shared/icons/skip_forward" %>
+                  <% end %>
 
-                <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
-                <%= button_to discard_job_path(job.id), method: :put, class: "btn btn-sm #{job_discardable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_discardable, aria: { label: "Discard job" }, title: "Discard job", data: { confirm: "Confirm discard" } do %>
-                  <%= render "good_job/shared/icons/stop" %>
-                <% end %>
+                  <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
+                  <%= button_to discard_job_path(job.id), method: :put, class: "btn btn-sm #{job_discardable ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: !job_discardable, aria: { label: "Discard job" }, title: "Discard job", data: { confirm: "Confirm discard" } do %>
+                    <%= render "good_job/shared/icons/stop" %>
+                  <% end %>
 
-                <%= button_to retry_job_path(job.id), method: :put, class: "btn btn-sm #{job.status == :discarded ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: job.status != :discarded, aria: { label: "Retry job" }, title: "Retry job", data: { confirm: "Confirm retry" } do %>
-                  <%= render "good_job/shared/icons/arrow_clockwise" %>
-                <% end %>
-              </div>
-            </td>
+                  <%= button_to retry_job_path(job.id), method: :put, class: "btn btn-sm #{job.status == :discarded ? 'btn-outline-primary' : 'btn-outline-secondary'}", form_class: "d-inline-block", disabled: job.status != :discarded, aria: { label: "Retry job" }, title: "Retry job", data: { confirm: "Confirm retry" } do %>
+                    <%= render "good_job/shared/icons/arrow_clockwise" %>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr>
+            <td colspan="8" class="py-2 text-center text-muted">No jobs found.</td>
           </tr>
         <% end %>
       </tbody>

--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -29,9 +29,7 @@
                   <code><%= job.id %></code>
                 <% end %>
               </td>
-              <td>
-                <span class="badge bg-secondary"><%= job.status %></span>
-              </td>
+              <td><%= status_badge(job.status) %></td>
               <td><%= job.job_class %></td>
               <td><%= job.queue_name %></td>
               <td><%= relative_time(job.scheduled_at || job.created_at) %></td>

--- a/engine/app/views/good_job/jobs/index.html.erb
+++ b/engine/app/views/good_job/jobs/index.html.erb
@@ -8,8 +8,9 @@
 
 <%= render 'good_job/shared/filter', filter: @filter %>
 
+<%= render 'good_job/jobs/table', jobs: @filter.records %>
+
 <% if @filter.records.present? %>
-  <%= render 'good_job/jobs/table', jobs: @filter.records %>
   <nav aria-label="Job pagination" class="mt-3">
     <ul class="pagination">
       <li class="page-item">
@@ -19,6 +20,4 @@
       </li>
     </ul>
   </nav>
-<% else %>
-  <em>No jobs present.</em>
 <% end %>

--- a/engine/app/views/good_job/jobs/index.html.erb
+++ b/engine/app/views/good_job/jobs/index.html.erb
@@ -1,3 +1,7 @@
+<div class="my-3 flex">
+  <h2>All Jobs</h2>
+</div>
+
 <div class="card my-3 p-6">
   <%= render 'good_job/shared/chart', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
 </div>

--- a/engine/app/views/good_job/processes/index.html.erb
+++ b/engine/app/views/good_job/processes/index.html.erb
@@ -1,3 +1,7 @@
+<div class="my-3 flex">
+  <h2>Processes</h2>
+</div>
+
 <% if !GoodJob::Process.migrated? %>
   <div class="card my-3">
     <div class="card-body">

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -1,66 +1,59 @@
-<div class='card mb-2'>
-  <div class='card-body d-flex flex-wrap'>
-    <div class='mb-2 me-4'>
-      <small>Filter by job class</small>
-      <br>
-      <% filter.job_classes.each do |name, count| %>
-        <% if params[:job_class] == name %>
-          <%= link_to(filter.to_params(job_class: nil), class: 'btn btn-sm btn-outline-secondary active', role: "button", "aria-pressed": true)  do %>
-            <%= name %> (<%= count %>)
-          <% end %>
-        <% else %>
-          <%= link_to(filter.to_params(job_class: name), class: 'btn btn-sm btn-outline-secondary', role: "button") do %>
-            <%= name %> (<%= count %>)
-          <% end %>
+<%= form_with(url: "", method: :get, local: true, id: "filter_form") do |form| %>
+  <div class="d-flex flex-row w-100">
+    <div class="me-2">
+      <label for="job_class_filter">Job class</label>
+      <select name="job_class" id="job_class_filter" class="form-select">
+        <option value="" <%= "selected='selected'" if params[:job_class].blank? %>>All jobs</option>
+
+        <% filter.job_classes.each do |name, count| %>
+          <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:job_class] == name %>><%= name %> (<%= count %>)</option>
         <% end %>
-      <% end %>
+      </select>
     </div>
 
-    <div class='mb-2 me-4'>
-      <small>Filter by state</small>
-      <br>
-      <% filter.states.each do |name, count| %>
-        <% if params[:state] == name %>
-          <%= link_to(filter.to_params(state: nil), class: 'btn btn-sm btn-outline-secondary active', role: "button", "aria-pressed": true)  do %>
-            <%= name %> (<%= count %>)
-          <% end %>
-        <% else %>
-          <%= link_to(filter.to_params(state: name), class: 'btn btn-sm btn-outline-secondary', role: "button") do %>
-            <%= name %> (<%= count %>)
-          <% end %>
+    <div class="me-2">
+      <label for="job_state_filter">State</label>
+      <select name="state" id="job_state_filter" class="form-select">
+        <option value="" <%= "selected='selected'" if params[:state].blank? %>>All states</option>
+
+        <% filter.states.each do |name, count| %>
+          <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:state] == name %>><%= name %> (<%= count %>)</option>
         <% end %>
-      <% end %>
+      </select>
     </div>
 
-    <div class='mb-2 me-4'>
-      <small>Filter by queue</small>
-      <br>
-      <% filter.queues.each do |name, count| %>
-        <% if params[:queue_name] == name %>
-          <%= link_to(filter.to_params(queue_name: nil), class: 'btn btn-sm btn-outline-secondary active', role: "button", "aria-pressed": true)  do %>
-            <%= name %> (<%= count %>)
-          <% end %>
-        <% else %>
-          <%= link_to(filter.to_params(queue_name: name), class: 'btn btn-sm btn-outline-secondary', role: "button") do %>
-            <%= name %> (<%= count %>)
-          <% end %>
+    <div class="me-2">
+      <label for="job_queue_filter">Queue</label>
+      <select name="queue_name" id="job_queue_filter" class="form-select">
+        <option value="" <%= "selected='selected'" if params[:queue_name].blank? %>>All queues</option>
+
+        <% filter.queues.each do |name, count| %>
+          <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:queue_name] == name %>><%= name %> (<%= count %>)</option>
         <% end %>
-      <% end %>
+      </select>
     </div>
 
-    <div class="mb-2">
-      <%= form_with(url: "", method: :get, local: true) do |form| %>
-        <% filter.to_params(query: nil).each do |key, value| %>
-          <%= form.hidden_field(key.to_sym, value: value) %>
-        <% end %>
+    <div class="me-2 flex-fill">
+      <label for="query"></label>
+      <%= search_field_tag "query", params[:query], class: "form-control", placeholder: "Search by class, job id, job params, and error text." %>
+    </div>
 
-        <small><%= form.label :query, "Search" %></small>
-        <div class="input-group input-group-sm">
-          <%= form.search_field :query, value: params[:query], class: "form-control" %>
-          <%= form.button "Search", type: "submit", name: nil, class: "btn btn-sm btn-outline-secondary" %>
-          <%= link_to "Clear", filter.to_params(query: nil), class: "btn btn-sm btn-outline-secondary" %>
-        </div>
-      <% end %>
+    <div class="flex-col">
+      <label></label>
+      <div>
+        <%= form.submit "Search", name: nil, class: "btn btn-primary" %>
+        <%= link_to "Clear all", filter.to_params(job_class: nil, state: nil, queue_name: nil, query: nil), class: "btn btn-secondary" %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>
+
+<%= javascript_tag nonce: true do %>
+  document.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll("#job_class_filter, #job_state_filter, #job_queue_filter").forEach((filter) => {
+      filter.addEventListener("change", () => {
+        document.querySelector("#filter_form").submit();
+      });
+    })
+  })
+<% end %>

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -33,13 +33,12 @@
       </select>
     </div>
 
-    <div class="me-2 flex-fill">
-      <label for="query"></label>
+    <div class="me-2 flex-fill d-flex flex-col align-items-end">
+      <label class="visually-hidden" for="query" aria-label="Search by class, job id, job params, and error text.">Search by class, job id, job params, and error text.</label>
       <%= search_field_tag "query", params[:query], class: "form-control", placeholder: "Search by class, job id, job params, and error text." %>
     </div>
 
-    <div class="flex-col">
-      <label></label>
+    <div class="d-flex flex-col align-items-end">
       <div>
         <%= form.submit "Search", name: nil, class: "btn btn-primary" %>
         <%= link_to "Clear all", filter.to_params(job_class: nil, state: nil, queue_name: nil, query: nil), class: "btn btn-secondary" %>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'Dashboard', type: :system do
+describe 'Dashboard', type: :system, js: true do
   before do
     allow(GoodJob).to receive(:retry_on_unhandled_error).and_return(false)
     allow(GoodJob).to receive(:preserve_job_records).and_return(true)
   end
 
-  it 'renders chart js', js: true do
+  it 'renders chart js' do
     visit '/good_job'
     expect(page).to have_content 'GoodJob 👍'
   end
@@ -135,8 +135,9 @@ describe 'Dashboard', type: :system do
 
       expect do
         within "##{dom_id(discarded_job)}" do
-          click_on 'Retry job'
+          accept_confirm { click_on 'Retry job' }
         end
+        expect(page).to have_content "Job has been retried"
       end.to change { discarded_job.executions.reload.size }.by(1)
     end
 
@@ -146,9 +147,10 @@ describe 'Dashboard', type: :system do
 
       expect do
         within "##{dom_id(unfinished_job)}" do
-          click_on 'Discard job'
+          accept_confirm { click_on 'Discard job' }
         end
-      end.to change { unfinished_job.head_execution(reload: true).finished_at }.to within(1.second).of(Time.current)
+        expect(page).to have_content "Job has been discarded"
+      end.to change { unfinished_job.head_execution(reload: true).finished_at }.from(nil).to within(1.second).of(Time.current)
     end
   end
 end

--- a/spec/test_app/app/jobs/configurable_queue_job.rb
+++ b/spec/test_app/app/jobs/configurable_queue_job.rb
@@ -1,0 +1,9 @@
+class ConfigurableQueueJob < ApplicationJob
+  queue_as do
+    kword_args = self.arguments.first
+    kword_args.fetch(:queue_as)
+  end
+
+  def perform
+  end
+end


### PR DESCRIPTION
This PR updates a few things in the Dashboard UI:
-  Change the search filter UI in the dashboard to be select/dropdown menus. This should scale better for a large amount of jobs and queues. 
- Updated the headline and empty states on the Cron Schedules index and Processes index.
- Adds a simple badge helper for job state badges.
- Adds an empty state for the Executions and Jobs tables.
- Adds specs for the filter changes.

Interface preferences can be very subjective. 
With that in mind, I'd love to get others' input on these changes and have a discussion on the overall direction of the dashboard.
