### PR TITLE
Add support for live polling the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ GoodJob includes a Dashboard as a mountable `Rails::Engine`.
     end
     ```
 
+#### Live Polling
+
+The Dashboard can be set to automatically refresh by checking "Live Poll" in the Dashboard header, or by setting `?poll=10` with the interval in seconds (default 30 seconds).
+
 ### ActiveJob concurrency
 
 GoodJob can extend ActiveJob to provide limits on concurrently running jobs, either at time of _enqueue_ or at _perform_. Limiting concurrency can help prevent duplicate, double or unecessary jobs from being enqueued, or race conditions when performing, for example when interacting with 3rd-party APIs.

--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -33,14 +33,20 @@ GoodJob = {
     if (urlParams.has('poll')) {
       GoodJob.pollEnabled = true
       GoodJob.pollInterval = parseInt(urlParams.get('poll'))
+      GoodJob.setStorage('pollInterval', GoodJob.pollInterval)
     } else {
-      GoodJob.pollEnabled = false
-      GoodJob.pollInterval = 5000 // default 5sec
+      GoodJob.pollEnabled = GoodJob.getStorage('pollEnabled') || false
+      GoodJob.pollInterval = GoodJob.getStorage('pollInterval') || 5000 // default 5sec
+      if (GoodJob.pollEnabled) {
+        // Update the UI element
+        document.getElementById('toggle-poll').checked = true
+      }
     }
   },
 
   togglePoll: (ev) => {
     GoodJob.pollEnabled = ev.currentTarget.checked
+    GoodJob.setStorage('pollEnabled', GoodJob.pollEnabled)
   },
 
   pollUpdates: () => {
@@ -67,9 +73,21 @@ GoodJob = {
       const oldEl = document.getElementById(newEl.id)
 
       if (oldEl) {
-        oldEl.parentNode.replaceChild(newEl, oldEl)
+        oldEl.replaceWith(newEl)
       }
     }
+  },
+
+  getStorage: (key) => {
+    const value = localStorage.getItem('goodjob-' + key)
+
+    if (value === 'true') { return true }
+    else if (value === 'false') { return false }
+    else { return value }
+  },
+
+  setStorage: (key, value) => {
+    localStorage.setItem('goodjob-' + key, value)
   }
 };
 

--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -12,6 +12,7 @@ GoodJob = {
     GoodJob.updateSettings()
     GoodJob.addListeners()
     GoodJob.pollUpdates()
+    GoodJob.renderCharts(true)
   },
 
   addListeners() {
@@ -75,6 +76,36 @@ GoodJob = {
       if (oldEl) {
         oldEl.replaceWith(newEl)
       }
+    }
+
+    GoodJob.renderCharts(false)
+  },
+
+  renderCharts: (animate) => {
+    const charts = document.querySelectorAll('.chart')
+
+    for (let i = 0; i < charts.length; i++) {
+      const chartEl = charts[i]
+      const chartData = JSON.parse(chartEl.dataset.json)
+
+      const ctx = chartEl.getContext('2d');
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: chartData.labels,
+          datasets: chartData.datasets
+        },
+        options: {
+          animation: animate,
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: {
+            y: {
+              beginAtZero: true
+            }
+          }
+        }
+      });
     }
   },
 

--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -1,1 +1,76 @@
-GoodJob = {};
+GoodJob = {
+  // Register functions to execute when the DOM is ready
+  ready: (callback) => {
+    if (document.readyState != "loading"){
+      callback()
+    } else {
+      document.addEventListener("DOMContentLoaded", callback)
+    }
+  },
+
+  init: () => {
+    GoodJob.updateSettings()
+    GoodJob.addListeners()
+    GoodJob.pollUpdates()
+  },
+
+  addListeners() {
+    const gjActionEls = document.querySelectorAll('[data-gj-action]')
+
+    for (let i = 0; i < gjActionEls.length; i++) {
+      const el = gjActionEls[i]
+      const [eventName, func] = el.dataset.gjAction.split('#')
+
+      el.addEventListener(eventName, GoodJob[func])
+    }
+  },
+
+  updateSettings() {
+    const queryString = window.location.search
+    const urlParams = new URLSearchParams(queryString)
+
+    // livepoll interval and enablement
+    if (urlParams.has('poll')) {
+      GoodJob.pollEnabled = true
+      GoodJob.pollInterval = parseInt(urlParams.get('poll'))
+    } else {
+      GoodJob.pollEnabled = false
+      GoodJob.pollInterval = 5000 // default 5sec
+    }
+  },
+
+  togglePoll: (ev) => {
+    GoodJob.pollEnabled = ev.currentTarget.checked
+  },
+
+  pollUpdates: () => {
+    setTimeout(() => {
+      if (GoodJob.pollEnabled == true) {
+        fetch(window.location.href)
+          .then(resp => resp.text())
+          .then(GoodJob.updateContent)
+          .finally(GoodJob.pollUpdates)
+      } else {
+        GoodJob.pollUpdates()
+      }
+    }, GoodJob.pollInterval)
+  },
+
+  updateContent: (newContent) => {
+    const domParser = new DOMParser()
+    const parsedDOM = domParser.parseFromString(newContent, "text/html")
+
+    const newElements = parsedDOM.querySelectorAll('[data-gj-poll-replace]')
+
+    for (let i = 0; i < newElements.length; i++) {
+      const newEl = newElements[i]
+      const oldEl = document.getElementById(newEl.id)
+
+      if (oldEl) {
+        oldEl.parentNode.replaceChild(newEl, oldEl)
+      }
+    }
+  }
+};
+
+GoodJob.ready(GoodJob.init)

--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -15,7 +15,7 @@ GoodJob = {
     GoodJob.renderCharts(true)
   },
 
-  addListeners() {
+  addListeners: () => {
     const gjActionEls = document.querySelectorAll('[data-gj-action]')
 
     for (let i = 0; i < gjActionEls.length; i++) {
@@ -26,18 +26,21 @@ GoodJob = {
     }
   },
 
-  updateSettings() {
+  updateSettings: () => {
     const queryString = window.location.search
     const urlParams = new URLSearchParams(queryString)
 
     // livepoll interval and enablement
     if (urlParams.has('poll')) {
+      const parsedInterval = parseInt(urlParams.get('poll')) || 5000
+
       GoodJob.pollEnabled = true
-      GoodJob.pollInterval = parseInt(urlParams.get('poll'))
+      GoodJob.pollInterval = Math.max(parsedInterval, 1000)
       GoodJob.setStorage('pollInterval', GoodJob.pollInterval)
     } else {
       GoodJob.pollEnabled = GoodJob.getStorage('pollEnabled') || false
       GoodJob.pollInterval = GoodJob.getStorage('pollInterval') || 5000 // default 5sec
+
       if (GoodJob.pollEnabled) {
         // Update the UI element
         document.getElementById('toggle-poll').checked = true

--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -1,95 +1,96 @@
-GoodJob = {
+/*jshint esversion: 6, strict: false */
+const GOOD_JOB_DEFAULT_POLL_INTERVAL_SECONDS = 30;
+const GOOD_JOB_MINIMUM_POLL_INTERVAL = 1000;
+
+const GoodJob = {
   // Register functions to execute when the DOM is ready
   ready: (callback) => {
-    if (document.readyState != "loading"){
-      callback()
+    if (document.readyState !== "loading") {
+      callback();
     } else {
-      document.addEventListener("DOMContentLoaded", callback)
+      document.addEventListener("DOMContentLoaded", callback);
     }
   },
 
   init: () => {
-    GoodJob.updateSettings()
-    GoodJob.addListeners()
-    GoodJob.pollUpdates()
-    GoodJob.renderCharts(true)
+    GoodJob.updateSettings();
+    GoodJob.addListeners();
+    GoodJob.pollUpdates();
+    GoodJob.renderCharts(true);
   },
 
   addListeners: () => {
-    const gjActionEls = document.querySelectorAll('[data-gj-action]')
+    const gjActionEls = document.querySelectorAll('[data-gj-action]');
 
     for (let i = 0; i < gjActionEls.length; i++) {
-      const el = gjActionEls[i]
-      const [eventName, func] = el.dataset.gjAction.split('#')
+      const el = gjActionEls[i];
+      const [eventName, func] = el.dataset.gjAction.split('#');
 
-      el.addEventListener(eventName, GoodJob[func])
+      el.addEventListener(eventName, GoodJob[func]);
     }
   },
 
   updateSettings: () => {
-    const queryString = window.location.search
-    const urlParams = new URLSearchParams(queryString)
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
 
-    // livepoll interval and enablement
+    // live poll interval and enablement
     if (urlParams.has('poll')) {
-      const parsedInterval = parseInt(urlParams.get('poll')) || 5000
+      const parsedInterval = (parseInt(urlParams.get('poll')) || GOOD_JOB_DEFAULT_POLL_INTERVAL_SECONDS) * 1000;
 
-      GoodJob.pollEnabled = true
-      GoodJob.pollInterval = Math.max(parsedInterval, 1000)
-      GoodJob.setStorage('pollInterval', GoodJob.pollInterval)
+      GoodJob.pollEnabled = true;
+      GoodJob.pollInterval = Math.max(parsedInterval, GOOD_JOB_MINIMUM_POLL_INTERVAL);
+      GoodJob.setStorage('pollInterval', GoodJob.pollInterval);
     } else {
-      GoodJob.pollEnabled = GoodJob.getStorage('pollEnabled') || false
-      GoodJob.pollInterval = GoodJob.getStorage('pollInterval') || 5000 // default 5sec
-
-      if (GoodJob.pollEnabled) {
-        // Update the UI element
-        document.getElementById('toggle-poll').checked = true
-      }
+      GoodJob.pollEnabled = GoodJob.getStorage('pollEnabled') || false;
+      GoodJob.pollInterval = GoodJob.getStorage('pollInterval') || GOOD_JOB_DEFAULT_POLL_INTERVAL_SECONDS;
     }
+
+    document.getElementById('toggle-poll').checked = GoodJob.pollEnabled;
   },
 
   togglePoll: (ev) => {
-    GoodJob.pollEnabled = ev.currentTarget.checked
-    GoodJob.setStorage('pollEnabled', GoodJob.pollEnabled)
+    GoodJob.pollEnabled = ev.currentTarget.checked;
+    GoodJob.setStorage('pollEnabled', GoodJob.pollEnabled);
   },
 
   pollUpdates: () => {
     setTimeout(() => {
-      if (GoodJob.pollEnabled == true) {
+      if (GoodJob.pollEnabled === true) {
         fetch(window.location.href)
           .then(resp => resp.text())
           .then(GoodJob.updateContent)
-          .finally(GoodJob.pollUpdates)
+          .finally(GoodJob.pollUpdates);
       } else {
-        GoodJob.pollUpdates()
+        GoodJob.pollUpdates();
       }
-    }, GoodJob.pollInterval)
+    }, GoodJob.pollInterval);
   },
 
   updateContent: (newContent) => {
-    const domParser = new DOMParser()
-    const parsedDOM = domParser.parseFromString(newContent, "text/html")
+    const domParser = new DOMParser();
+    const parsedDOM = domParser.parseFromString(newContent, "text/html");
 
-    const newElements = parsedDOM.querySelectorAll('[data-gj-poll-replace]')
+    const newElements = parsedDOM.querySelectorAll('[data-gj-poll-replace]');
 
     for (let i = 0; i < newElements.length; i++) {
-      const newEl = newElements[i]
-      const oldEl = document.getElementById(newEl.id)
+      const newEl = newElements[i];
+      const oldEl = document.getElementById(newEl.id);
 
       if (oldEl) {
-        oldEl.replaceWith(newEl)
+        oldEl.replaceWith(newEl);
       }
     }
 
-    GoodJob.renderCharts(false)
+    GoodJob.renderCharts(false);
   },
 
   renderCharts: (animate) => {
-    const charts = document.querySelectorAll('.chart')
+    const charts = document.querySelectorAll('.chart');
 
     for (let i = 0; i < charts.length; i++) {
-      const chartEl = charts[i]
-      const chartData = JSON.parse(chartEl.dataset.json)
+      const chartEl = charts[i];
+      const chartData = JSON.parse(chartEl.dataset.json);
 
       const ctx = chartEl.getContext('2d');
       const chart = new Chart(ctx, {
@@ -113,16 +114,20 @@ GoodJob = {
   },
 
   getStorage: (key) => {
-    const value = localStorage.getItem('goodjob-' + key)
+    const value = localStorage.getItem('good_job-' + key);
 
-    if (value === 'true') { return true }
-    else if (value === 'false') { return false }
-    else { return value }
+    if (value === 'true') {
+      return true;
+    } else if (value === 'false') {
+      return false;
+    } else {
+      return value;
+    }
   },
 
   setStorage: (key, value) => {
-    localStorage.setItem('goodjob-' + key, value)
+    localStorage.setItem('good_job-' + key, value);
   }
 };
 
-GoodJob.ready(GoodJob.init)
+GoodJob.ready(GoodJob.init);

--- a/engine/app/views/good_job/executions/_table.erb
+++ b/engine/app/views/good_job/executions/_table.erb
@@ -1,4 +1,4 @@
-<div class="card my-3">
+<div class="card my-3" data-gj-poll-replace id="executions-table">
   <div class="table-responsive">
     <table class="table card-table table-bordered table-hover table-sm mb-0" id="executions_index_table">
       <thead>

--- a/engine/app/views/good_job/executions/index.html.erb
+++ b/engine/app/views/good_job/executions/index.html.erb
@@ -1,4 +1,4 @@
-<div class="card my-3 p-6">
+<div class="card my-3 p-6" data-gj-poll-replace id="executions-chart">
   <%= render 'good_job/shared/chart', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
 </div>
 
@@ -7,7 +7,7 @@
 <%= render 'good_job/executions/table', executions: @filter.records %>
 
 <% if @filter.records.present? %>
-  <nav aria-label="Job pagination" class="mt-3">
+  <nav aria-label="Job pagination" class="mt-3" data-gj-poll-replace id="executions-pagination">
     <ul class="pagination">
       <li class="page-item">
         <%= link_to({ after_scheduled_at: (@filter.last.scheduled_at || @filter.last.created_at), after_id: @filter.last.id }, class: "page-link") do %>

--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -1,4 +1,4 @@
-<div class="card my-3">
+<div class="card my-3" data-gj-poll-replace id="jobs-table">
   <div class="table-responsive">
     <table class="table card-table table-bordered table-hover table-sm mb-0">
       <thead>

--- a/engine/app/views/good_job/jobs/index.html.erb
+++ b/engine/app/views/good_job/jobs/index.html.erb
@@ -2,7 +2,7 @@
   <h2>All Jobs</h2>
 </div>
 
-<div class="card my-3 p-6">
+<div class="card my-3 p-6" data-gj-poll-replace id="jobs-chart">
   <%= render 'good_job/shared/chart', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
 </div>
 
@@ -11,7 +11,7 @@
 <%= render 'good_job/jobs/table', jobs: @filter.records %>
 
 <% if @filter.records.present? %>
-  <nav aria-label="Job pagination" class="mt-3">
+  <nav aria-label="Job pagination" class="mt-3" data-gj-poll-replace id="jobs-pagination">
     <ul class="pagination">
       <li class="page-item">
         <%= link_to(@filter.to_params(after_scheduled_at: (@filter.last.scheduled_at || @filter.last.created_at), after_id: @filter.last.id), class: "page-link") do %>

--- a/engine/app/views/good_job/processes/index.html.erb
+++ b/engine/app/views/good_job/processes/index.html.erb
@@ -2,7 +2,7 @@
   <h2>Processes</h2>
 </div>
 
-<div  data-gj-poll-replace id="processes">
+<div data-gj-poll-replace id="processes">
   <% if !GoodJob::Process.migrated? %>
     <div class="card my-3">
       <div class="card-body">

--- a/engine/app/views/good_job/processes/index.html.erb
+++ b/engine/app/views/good_job/processes/index.html.erb
@@ -2,43 +2,45 @@
   <h2>Processes</h2>
 </div>
 
-<% if !GoodJob::Process.migrated? %>
-  <div class="card my-3">
-    <div class="card-body">
-      <p class="card-text">
-        <em>Feature unavailable because of pending database migration.</em>
-      </p>
+<div  data-gj-poll-replace id="processes">
+  <% if !GoodJob::Process.migrated? %>
+    <div class="card my-3">
+      <div class="card-body">
+        <p class="card-text">
+          <em>Feature unavailable because of pending database migration.</em>
+        </p>
+      </div>
     </div>
-  </div>
-<% elsif @processes.present? %>
-  <div class="card my-3">
-    <div class="table-responsive">
-      <table class="table card-table table-bordered table-hover table-sm mb-0">
-        <thead>
-        <tr>
-          <th>Process UUID</th>
-          <th>Created At</th></th>
-          <th>State</th>
-        </tr>
-        </thead>
-        <tbody>
-        <% @processes.each do |process| %>
-          <tr class="<%= dom_class(process) %>" id="<%= dom_id(process) %>">
-            <td><%= process.id %></td>
-            <td><%= relative_time(process.created_at) %></td>
-            <td><%= tag.pre JSON.pretty_generate(process.state) %></td>
+  <% elsif @processes.present? %>
+    <div class="card my-3">
+      <div class="table-responsive">
+        <table class="table card-table table-bordered table-hover table-sm mb-0">
+          <thead>
+          <tr>
+            <th>Process UUID</th>
+            <th>Created At</th></th>
+            <th>State</th>
           </tr>
-        <% end %>
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+          <% @processes.each do |process| %>
+            <tr class="<%= dom_class(process) %>" id="<%= dom_id(process) %>">
+              <td><%= process.id %></td>
+              <td><%= relative_time(process.created_at) %></td>
+              <td><%= tag.pre JSON.pretty_generate(process.state) %></td>
+            </tr>
+          <% end %>
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
-<% else %>
-  <div class="card my-3">
-    <div class="card-body">
-      <p class="card-text">
-        <em>No GoodJob processes found.</em>
-      </p>
+  <% else %>
+    <div class="card my-3">
+      <div class="card-body">
+        <p class="card-text">
+          <em>No GoodJob processes found.</em>
+        </p>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/engine/app/views/good_job/shared/_chart.erb
+++ b/engine/app/views/good_job/shared/_chart.erb
@@ -1,25 +1,3 @@
 <div class="chart-wrapper">
-  <canvas id="chart"></canvas>
+  <canvas class="chart" data-json="<%= chart_data.to_json %>"></canvas>
 </div>
-
-<%= javascript_tag nonce: true do %>
-  const chartData = <%== chart_data.to_json %>;
-
-  const ctx = document.getElementById('chart').getContext('2d');
-  const chart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: chartData.labels,
-      datasets: chartData.datasets
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      scales: {
-        y: {
-          beginAtZero: true
-        }
-      }
-    }
-  });
-<% end %>

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -1,4 +1,5 @@
 <%= form_with(url: "", method: :get, local: true, id: "filter_form") do |form| %>
+  <%= hidden_field_tag :poll, value: params[:poll] %>
   <div class="d-flex flex-row w-100">
     <div class="me-2">
       <label for="job_class_filter">Job class</label>

--- a/engine/app/views/layouts/good_job/base.html.erb
+++ b/engine/app/views/layouts/good_job/base.html.erb
@@ -45,7 +45,10 @@
             </div>
           </li>
         </ul>
-        <div class="text-muted" title="Now is <%= Time.current %>">Times are displayed in <%= Time.current.zone %> timezone</div>
+        <div>
+          <input type="checkbox" id="toggle-poll" name="toggle-poll" data-gj-action='change#togglePoll' <%= 'checked' if params[:poll].present? %>>
+          <label for="toggle-poll">Live Poll</label>
+        </div>
       </div>
     </div>
   </nav>
@@ -70,7 +73,26 @@
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
     <% end %>
-    <%= yield %>
+
+    <div id="content" data-gj-poll-replace>
+      <%= yield %>
+    </div>
   </div>
+
+  <footer class="footer mt-auto py-3 bg-light fixed-bottom" id="footer" data-gj-poll-replace>
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-6">
+          <span class="text-muted" title="Now is <%= Time.current %>">
+            Last updated: <%= Time.current %>
+          </span>
+        </div>
+
+        <div class="col-6 text-end">
+          Remember, you're doing a Good Job too!
+        </div>
+      </div>
+    </div>
+  </footer>
 </body>
 </html>

--- a/engine/app/views/layouts/good_job/base.html.erb
+++ b/engine/app/views/layouts/good_job/base.html.erb
@@ -81,8 +81,8 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-6">
-          <span class="text-muted" title="Now is <%= Time.current %>">
-            Last updated: <%= Time.current %>
+          <span class="text-muted">
+            Last updated: <time id="page-updated-at" datetime="<%= Time.current.utc.iso8601 %>"><%= Time.current %></time>
           </span>
         </div>
 

--- a/engine/app/views/layouts/good_job/base.html.erb
+++ b/engine/app/views/layouts/good_job/base.html.erb
@@ -74,9 +74,7 @@
       </div>
     <% end %>
 
-    <div id="content" data-gj-poll-replace>
-      <%= yield %>
-    </div>
+    <%= yield %>
   </div>
 
   <footer class="footer mt-auto py-3 bg-light fixed-bottom" id="footer" data-gj-poll-replace>

--- a/spec/system/live_poll_spec.rb
+++ b/spec/system/live_poll_spec.rb
@@ -9,7 +9,7 @@ describe 'Live Poll', type: :system, js: true do
 
   it 'reloads the dashboard when active' do
     # Load the page with live poll enabled
-    visit 'good_job?poll=1000'
+    visit 'good_job?poll=1'
     expect(page).to have_checked_field('toggle-poll')
 
     # Verify that the page reloads

--- a/spec/system/live_poll_spec.rb
+++ b/spec/system/live_poll_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'Live Poll', type: :system, js: true do
+  before do
+    allow(GoodJob).to receive(:retry_on_unhandled_error).and_return(false)
+    allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+  end
+
+  it 'reloads the dashboard when active' do
+    # Load the page with live poll enabled
+    visit 'good_job?poll=1000'
+    expect(page).to have_checked_field('toggle-poll')
+
+    # Verify that the page reloads
+    last_updated = page.find('#page-updated-at')['datetime']
+    wait_until do
+      expect(last_updated).not_to eq(page.find('#page-updated-at')['datetime'])
+    end
+
+    # Disable live polling and verify that the page does not reload
+    uncheck('toggle-poll')
+    last_updated = page.find('#page-updated-at')['datetime']
+    sleep 2
+    expect(last_updated).to eq(page.find('#page-updated-at')['datetime'])
+
+    # Re-enable live polling and verify it is reloading again
+    check('toggle-poll')
+    last_updated = page.find('#page-updated-at')['datetime']
+    wait_until do
+      expect(last_updated).not_to eq(page.find('#page-updated-at')['datetime'])
+    end
+  end
+end


### PR DESCRIPTION
Adds support for live polling the dashboard, adding replaceable content areas anywhere on the page, register event listeners which act upon the `GoodJob` javacript object, and a footer.

### Polling UX
1. Toggle the `Live Poll` checkbox in the navbar (every 5000ms by default)
2. Add a query parameter to the url `/good_job?poll=5000`. The integer (in ms) sets the poll interval.
3. Live Poll enablement and interval is persisted to localstorage. Query parameter overrides all settings.

### Register event listeners
1. Add `data-gj-action` attribute with the event name and the `GoodJob` function to call when the event is triggered. `change#togglePoll` => `element.addEventListener('change, GoodJob.togglePoll)`

### Adding replaceable content areas
1. Add the `data-gj-poll-replace` attribute to the element
2. Add a unique ID to the same element

Fixes #526