### PR TITLE
Enable DB table names customization

### DIFF
--- a/engine/app/charts/good_job/scheduled_by_queue_chart.rb
+++ b/engine/app/charts/good_job/scheduled_by_queue_chart.rb
@@ -9,6 +9,7 @@ module GoodJob
     def data
       end_time = Time.current
       start_time = end_time - 1.day
+      table_name = GoodJob::ActiveJobJob.table_name
 
       count_query = Arel.sql(GoodJob::Execution.pg_or_jdbc_query(<<~SQL.squish))
         SELECT *
@@ -23,7 +24,7 @@ module GoodJob
               queue_name,
               count(*) AS count
             FROM (
-              #{@filter.filtered_query.except(:select, :order).select('queue_name', 'COALESCE(good_jobs.scheduled_at, good_jobs.created_at)::timestamp AS scheduled_at').to_sql}
+              #{@filter.filtered_query.except(:select, :order).select('queue_name', "COALESCE(#{table_name}.scheduled_at, #{table_name}.created_at)::timestamp AS scheduled_at").to_sql}
             ) sources
             GROUP BY date_trunc('hour', scheduled_at), queue_name
         ) sources ON sources.scheduled_at = timestamp

--- a/engine/app/filters/good_job/jobs_filter.rb
+++ b/engine/app/filters/good_job/jobs_filter.rb
@@ -14,7 +14,7 @@ module GoodJob
 
     def filtered_query
       query = base_query.includes(:executions)
-                        .joins_advisory_locks.select('good_jobs.*', 'pg_locks.locktype AS locktype')
+                        .joins_advisory_locks.select("#{GoodJob::ActiveJobJob.table_name}.*", 'pg_locks.locktype AS locktype')
 
       query = query.job_class(params[:job_class]) if params[:job_class].present?
       query = query.where(queue_name: params[:queue_name]) if params[:queue_name].present?
@@ -31,7 +31,7 @@ module GoodJob
         when 'scheduled'
           query = query.scheduled
         when 'running'
-          query = query.running.select('good_jobs.*', 'pg_locks.locktype')
+          query = query.running.select("#{GoodJob::ActiveJobJob.table_name}.*", 'pg_locks.locktype')
         when 'queued'
           query = query.queued
         end


### PR DESCRIPTION
With this patch it is possible to assign custom table names for `GoodJob::Process` and `GoodJob::ActiveJobJob` and have `good_job` function as usual.

It enables the use of a common database for two or more schedulers while keeping the dashboard functional.

My motive was working on two apps that share a database and both need to run a scheduler and we want to run `good_job` because well, it's too good for our use case :). I believe this is a legit, while ugly, requirement in some projects.

There is no need to complicate things by making the migrations take the custom table names into account for upgrades. It is possible, but the added complexity would possibly make migrations fragile and certainly harder to reason about. After all, anyone who opts to change the table name this way would review migrations coming from updates before running them. Even if not, they would fail and the person would iterate.

The table names have been added without quoting into the SQL code because, well, it's a table name.

I like to believe that the only reason to consider not including this is that future code would need to use table names via model classes instead of hardcoded, which is not necessarily a bad thing.