### PR TITLE
Wrap Rspec before and example blocks with a mutex for JRuby

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,16 +20,6 @@ require 'database_cleaner'
 require 'pry'
 # Add additional requires below this line. Rails is not loaded until this point!
 
-# https://stackoverflow.com/a/63442278
-RSPEC_LOCK = Mutex.new
-RSpec.configure do |config|
-  config.around do |example|
-    RSPEC_LOCK.synchronize do
-      example.run
-    end
-  end
-end
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end

--- a/spec/support/jruby.rb
+++ b/spec/support/jruby.rb
@@ -6,3 +6,18 @@ RSpec.configure do |c|
     c.filter_run_excluding :skip_if_java
   end
 end
+
+# https://stackoverflow.com/a/63442278
+RSPEC_MUTEX = Mutex.new
+RSpec::Core::Example.prepend(Module.new do
+  def run_before_example
+    RSPEC_MUTEX.synchronize { super }
+  end
+end)
+
+# It's not possible to wrap the example block itself, but `current_scope` is changed enough to ensure synchronization
+RSpec.singleton_class.prepend(Module.new do
+  def current_scope=(scope)
+    RSPEC_MUTEX.synchronize { super }
+  end
+end)


### PR DESCRIPTION
A better implementation of 205 / https://github.com/bensheldon/good_job/commit/fc548e707b7c80cdac155121a0b0540c32fabe44#diff-053aa3ea46cb7c6a649e0d0fc592ce729b66e1d44be475516fd58857ba695862R14 which in hindsight doesn't actually look functional because it wraps the entire before/example/after with a mutex, rather than wrapping individual components.

The intention is to avoid this sort of error when a class method is stubbed:

![Screen Shot 2022-03-02 at 7 21 17 PM](https://user-images.githubusercontent.com/47554/156489909-fc0e816c-8713-4e0f-b56e-57ffb0b0dd77.png)

