### PR TITLE
Update Readme to better explain queues, pools, threads, and database connections; update CLI to frontload queue option

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -50,14 +50,14 @@ module GoodJob
       separate isolated execution pools with semicolons and threads with colons.
 
     DESCRIPTION
-    method_option :max_threads,
-                  type: :numeric,
-                  banner: 'COUNT',
-                  desc: "Maximum number of threads to use for working jobs. (env var: GOOD_JOB_MAX_THREADS, default: 5)"
     method_option :queues,
                   type: :string,
                   banner: "QUEUE_LIST",
-                  desc: "Queues to work from. (env var: GOOD_JOB_QUEUES, default: *)"
+                  desc: "Queues or queue pools to work from. (env var: GOOD_JOB_QUEUES, default: *)"
+    method_option :max_threads,
+                  type: :numeric,
+                  banner: 'COUNT',
+                  desc: "Default number of threads per pool to use for working jobs. (env var: GOOD_JOB_MAX_THREADS, default: 5)"
     method_option :poll_interval,
                   type: :numeric,
                   banner: 'SECONDS',


### PR DESCRIPTION
This PR more explicitly introduces the term "pool". 

Connects to #538 

```mermaid
graph TD
    Process["--queues=mice:2;elephants,whales:1"] --> PoolA[Pool A]
    Process --> PoolB[Pool B]
    PoolA --> QueuesA[Queue: mice]
    PoolA --> ThreadsA[Threads: 2]
    PoolB --> QueuesB[Queue: elephants, whales]
    PoolB --> ThreadsB[Threads: 1]
    Total[Total Threads: 2 + 1 => 3]
```