### PR TITLE
Deprecate Adapter configuration of job execution/cron

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -27,7 +27,13 @@ module GoodJob
     # @param queues [String, nil] determines which queues to execute jobs from when +execution_mode+ is set to +:async+. See {file:README.md#optimize-queues-threads-and-processes} for more details on the format of this string. You can also set this with the environment variable +GOOD_JOB_QUEUES+. Defaults to +"*"+.
     # @param poll_interval [Integer, nil] sets the number of seconds between polls for jobs when +execution_mode+ is set to +:async+. You can also set this with the environment variable +GOOD_JOB_POLL_INTERVAL+. Defaults to +1+.
     # @param start_async_on_initialize [Boolean] whether to start the async scheduler when the adapter is initialized.
-    def initialize(execution_mode: nil, queues: nil, max_threads: nil, poll_interval: nil, start_async_on_initialize: GoodJob.async_ready?)
+    def initialize(execution_mode: nil, queues: nil, max_threads: nil, poll_interval: nil, start_async_on_initialize: nil)
+      if execution_mode || queues || max_threads || poll_interval || start_async_on_initialize
+        ActiveSupport::Deprecation.warn(
+          "The GoodJob::Adapter's initialization parameters have been deprecated and will be removed in GoodJob v3. These options should be configured through GoodJob global configuration instead."
+        )
+      end
+
       @configuration = GoodJob::Configuration.new(
         {
           execution_mode: execution_mode,
@@ -39,7 +45,7 @@ module GoodJob
       @configuration.validate!
       self.class.instances << self
 
-      start_async if start_async_on_initialize
+      start_async if start_async_on_initialize || GoodJob.async_ready?
     end
 
     # Enqueues the ActiveJob job to be performed.


### PR DESCRIPTION
Connects to #380 and #421.

This configuration was never documented in the Readme, and I'm not sure if anyone uses it.

My current thinking is that the ActiveJob Adapter should only concern itself with enqueuing jobs. And GoodJob's global configuration will cover executing jobs and cron, etc. This also helps move closer to a goal of GoodJob have a single global supervisor for Schedulers/CronManager, etc. which will make tracking Process lifecycle much easier.