### PR TITLE
FIX: make 'default_url_options' method private

### DIFF
--- a/engine/app/controllers/good_job/application_controller.rb
+++ b/engine/app/controllers/good_job/application_controller.rb
@@ -3,7 +3,7 @@ module GoodJob
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
 
-    around_action :switch_locale
+    around_action :switch_locale, :default_url_options
 
     content_security_policy do |policy|
       policy.default_src(:none) if policy.default_src(*policy.default_src).blank?
@@ -24,11 +24,11 @@ module GoodJob
       request.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
     end
 
+    private
+
     def default_url_options(options = {})
       { locale: I18n.locale }.merge(options)
     end
-
-    private
 
     def switch_locale(&action)
       I18n.with_locale(current_locale, &action)

--- a/engine/app/controllers/good_job/application_controller.rb
+++ b/engine/app/controllers/good_job/application_controller.rb
@@ -3,7 +3,7 @@ module GoodJob
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
 
-    around_action :switch_locale, :default_url_options
+    around_action :switch_locale
 
     content_security_policy do |policy|
       policy.default_src(:none) if policy.default_src(*policy.default_src).blank?


### PR DESCRIPTION
Further to [this conversation.](https://github.com/bensheldon/good_job/pull/497/files#r843531378) with @igas

minor fix to move `default_url_options` under private