### PR TITLE
Remove WIP comments from dashboard

### DIFF
--- a/engine/app/views/good_job/shared/_announcement.erb
+++ b/engine/app/views/good_job/shared/_announcement.erb
@@ -1,7 +1,0 @@
-<div class="card border-warning text-dark my-3">
-  <div class="card-body">
-    <p class="card-text">
-      <%= t(".work_in_progress_html") %>
-    </p>
-  </div>
-</div>

--- a/engine/app/views/good_job/shared/_navbar.erb
+++ b/engine/app/views/good_job/shared/_navbar.erb
@@ -19,11 +19,6 @@
         <li class="nav-item">
           <%= link_to t(".processes"), processes_path, class: ["nav-link", ("active" if current_page?(processes_path))] %>
         </li>
-        <li class="nav-item">
-          <div class="nav-link">
-            <span class="badge bg-secondary"><%= t(".coming_soon") %></span>
-          </div>
-        </li>
       </ul>
       <div class="nav-item pe-2">
         <div class="form-check">

--- a/engine/app/views/layouts/good_job/application.html.erb
+++ b/engine/app/views/layouts/good_job/application.html.erb
@@ -21,7 +21,6 @@
   <%= render "good_job/shared/navbar" %>
 
   <div class="container-fluid">
-    <%= render "good_job/shared/announcement" %>
     <%= render "good_job/shared/alert" %>
 
     <%= yield %>

--- a/engine/config/locales/en.yml
+++ b/engine/config/locales/en.yml
@@ -41,13 +41,10 @@ en:
         other: "%{count} years"
   good_job:
     shared:
-      announcement:
-        work_in_progress_html: "🚧 GoodJob's dashboard is a work in progress. Please contribute ideas and code on <a href=\"https://github.com/bensheldon/good_job/issues\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">Github</a>."
       footer:
         last_update_html: Last updated <time id="page-updated-at" datetime="%{time}">%{time}</time>
         wording: Remember, you're doing a Good Job too!
       navbar:
-        coming_soon: More views coming soon
         cron_schedules: Cron Schedules
         executions: All Executions
         jobs: All Jobs

--- a/engine/config/locales/es.yml
+++ b/engine/config/locales/es.yml
@@ -41,13 +41,10 @@ es:
         other: "%{count} años"
   good_job:
     shared:
-      announcement:
-        work_in_progress_html: "🚧 GoodJob se encuentra en desarrollo. Por favor contribuya en <a href=\"https://github.com/bensheldon/good_job/issues\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">GoodJob</a> con ideas y código."
       footer:
         last_update_html: Última actualización <time id="page-updated-at" datetime="%{time}">%{time}</time>
         wording: "¡Recuerda, también tú estás haciendo un buen trabajo!"
       navbar:
-        coming_soon: Próximamente más vistas
         cron_schedules: Tareas Programadas
         executions: Ejecuciones
         jobs: Tareas

--- a/engine/config/locales/ru.yaml
+++ b/engine/config/locales/ru.yaml
@@ -41,13 +41,10 @@ ru:
         other: "%{count} года"
   good_job:
     shared:
-      announcement:
-        work_in_progress_html: "🚧 GoodJob панель все еще в разработке. Пожалуйста расскажите нам о ваших идеях и наработках в <a href=\"https://github.com/bensheldon/good_job/issues\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">Github</a>."
       footer:
         last_update_html: Последнее обновление <time id="page-updated-at" datetime="%{time}">%{time}</time>
         wording: Запомни, ты делаешь Good Job тоже!
       navbar:
-        coming_soon: Скоро будет больше секций
         cron_schedules: Cron Расписания
         executions: Все Исполнения
         jobs: Все Задачи


### PR DESCRIPTION
Thanks for all your work on good_job! I've been using it on a few projects lately and really like it. As the primary maintainer for delayed_job for many years, I have a special appreciation for the care and attention that you and the community have put into it.

I'm hoping to contribute more, but as my first pull request, I suggest removing the WIP messages from the dashboard. It looks like the one has been there for about two years now.

![](https://upload.wikimedia.org/wikipedia/commons/1/19/Under_construction_graphic.gif?20090304223820)