### PR TITLE
Fix Russian translation linting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ platforms :ruby do
   gem "rbtrace"
 
   group :lint do
+    gem 'easy_translate'
     gem "erb_lint", ">= 0.0.35"
     gem 'i18n-tasks'
     gem "mdl"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,9 @@ GEM
     database_cleaner-core (2.0.1)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
+    easy_translate (0.5.1)
+      thread
+      thread_safe
     erb_lint (0.1.1)
       activesupport
       better_html (~> 1.0.7)
@@ -206,7 +209,7 @@ GEM
     html_tokenizer (0.0.7)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (1.0.5)
+    i18n-tasks (1.0.9)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       better_html (~> 1.0)
@@ -222,7 +225,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    loofah (2.15.0)
+    loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -389,6 +392,8 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
+    thread (0.2.2)
+    thread_safe (0.3.6)
     timers (4.3.3)
     tomlrb (2.0.1)
     tzinfo (2.0.4)
@@ -422,6 +427,7 @@ DEPENDENCIES
   capybara (~> 3.35.0)
   database_cleaner
   dotenv
+  easy_translate
   erb_lint (>= 0.0.35)
   foreman
   gem-release

--- a/engine/config/locales/ru.yml
+++ b/engine/config/locales/ru.yml
@@ -3,40 +3,64 @@ ru:
   datetime:
     distance_in_words:
       about_x_hours:
+        few: около %{count} часов
+        many: около %{count} часов
         one: около 1 часа
-        other: около %{count} часов
+        other: около %{count} часа
       about_x_months:
+        few: около %{count} месяцев
+        many: около %{count} месяцев
         one: около 1 месяца
-        other: около %{count} месяцев
+        other: около %{count} месяца
       about_x_years:
+        few: около %{count} лет
+        many: около %{count} лет
         one: около 1 года
         other: около %{count} лет
       almost_x_years:
+        few: почти %{count} года
+        many: почти %{count} лет
         one: почти 1 год
-        other: почти %{count} года
-      half_a_minute: пол минуты
+        other: почти %{count} лет
+      half_a_minute: полминуты
       less_than_x_minutes:
+        few: меньше %{count} минут
+        many: меньше %{count} минут
         one: меньше 1 минуты
-        other: меньше %{count} минут
+        other: меньше %{count} минуты
       less_than_x_seconds:
+        few: меньше %{count} секунд
+        many: меньше %{count} секунд
         one: меньше 1 секунды
-        other: меньше %{count} секунд
+        other: меньше %{count} секунды
       over_x_years:
+        few: больше %{count} лет
+        many: больше %{count} лет
         one: больше 1 года
         other: больше %{count} лет
       x_days:
+        few: "%{count} дня"
+        many: "%{count} дней"
         one: 1 день
-        other: "%{count} дней"
+        other: "%{count} дня"
       x_minutes:
-        one: 1 минута
-        other: "%{count} минут"
+        few: "%{count} минуты"
+        many: "%{count} минут"
+        one: 1 минуту
+        other: "%{count} минуты"
       x_months:
+        few: "%{count} месяца"
+        many: "%{count} месяцев"
         one: 1 месяц
         other: "%{count} месяца"
       x_seconds:
-        one: 1 секунда
-        other: "%{count} секунд"
+        few: "%{count} секунды"
+        many: "%{count} секунд"
+        one: 1 секунду
+        other: "%{count} секунды"
       x_years:
+        few: "%{count} года"
+        many: "%{count} лет"
         one: 1 год
         other: "%{count} года"
   good_job:


### PR DESCRIPTION
I'm not sure why Russian specifically seems to want `few` and `other` keys for datetime strings in i18n-tasks