### PR TITLE
Dashboard: show more details about jobs

### DIFF
--- a/engine/app/controllers/good_job/jobs_controller.rb
+++ b/engine/app/controllers/good_job/jobs_controller.rb
@@ -10,6 +10,7 @@ module GoodJob
     end
 
     def show
+      @job = ActiveJobJob.find(params[:id])
       @executions = GoodJob::Execution.active_job_id(params[:id])
                                       .order(Arel.sql("COALESCE(scheduled_at, created_at) DESC"))
       redirect_to root_path, alert: "Executions for Active Job #{params[:id]} not found" if @executions.empty?

--- a/engine/app/helpers/good_job/application_helper.rb
+++ b/engine/app/helpers/good_job/application_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module GoodJob
   module ApplicationHelper
-    def relative_time(timestamp)
-      text = timestamp.future? ? "in #{time_ago_in_words(timestamp)}" : "#{time_ago_in_words(timestamp)} ago"
+    def relative_time(timestamp, **args)
+      text = timestamp.future? ? "in #{time_ago_in_words(timestamp, **args)}" : "#{time_ago_in_words(timestamp, **args)} ago"
       tag.time(text, datetime: timestamp, title: timestamp)
     end
 

--- a/engine/app/views/good_job/jobs/show.html.erb
+++ b/engine/app/views/good_job/jobs/show.html.erb
@@ -1,3 +1,72 @@
-<h1 class="mb-3">ActiveJob ID: <code><%= @executions.first.id %></code></h1>
+<div class="break-out bg-light border-bottom py-2 mb-3">
+  <div class="container-fluid pt-2">
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb small mb-0">
+        <li class="breadcrumb-item"><%= link_to "Jobs", jobs_path %></li>
+        <li class="breadcrumb-item active" aria-current="page">ActiveJob ID: <code><%= @job.id %></code></li>
+      </ol>
+    </nav>
+    <h2 class="mb-1"><code><%= @job.job_class %></code></h2>
+    <div>
+      <%= status_badge @job.status %>
+      <span class="small text-muted">
+        <% if @job.finished_at %>
+          <%= relative_time @job.finished_at, include_seconds: true %>
+          <% if @job.runtime %>
+            • <%= @job.runtime.round(2) %>s runtime
+          <% end %>
+        <% elsif @job.performed_at %>
+          <%= relative_time @job.performed_at, include_seconds: true if @job.performed_at %>
+          <% if @job.runtime %>
+            <span class="small text-muted">(<%= @job.runtime.round(2) %>s runtime)</span>
+          <% end %>
+        <% elsif @job.scheduled_at %>
+          <%= relative_time @job.scheduled_at, include_seconds: true %>
+        <% else %>
+          <%= relative_time @job.created_at, include_seconds: true %>
+        <% end %>
+
+        <% if @job.executions_count > 1 %>
+          • <%= pluralize @job.executions_count, 'attempt' %>
+        <% end %>
+      </span>
+    </div>
+  </div>
+</div>
+
+<table class="table">
+  <tr>
+    <th class="col-1">Queue</th>
+    <td>
+      <%= @job.queue_name %>
+        <% if @job.latency %>
+          <span class="text-muted small">(<%= @job.latency.round(2) %>s latency)</span>
+        <% end %>
+    </td>
+  </tr>
+  <tr>
+    <th>Priority</th>
+    <td><%= @job.priority %></td>
+  </tr>
+
+  <tr>
+    <th>Arguments</th>
+    <td><code><%= @job.serialized_params["arguments"].map(&:inspect).join(', ') %></code></td>
+  </tr>
+
+  <% if @job.recent_error %>
+    <tr>
+      <th>Error</th>
+      <td><pre class="text-danger my-0"><%= @job.recent_error %></pre></td>
+    </tr>
+  <% end %>
+
+  <tr>
+    <th>Params</th>
+    <td><%= tag.pre JSON.pretty_generate(@job.serialized_params) %></td>
+  </tr>
+</table>
+
+
 
 <%= render 'good_job/executions/table', executions: @executions %>

--- a/lib/good_job/active_job_job.rb
+++ b/lib/good_job/active_job_job.rb
@@ -104,6 +104,17 @@ module GoodJob
       end
     end
 
+    # Time between when this job was queued and when it started running
+    def latency
+      now = DateTime.current
+      (performed_at || now) - (scheduled_at || created_at) unless (scheduled_at || created_at) > now
+    end
+
+    # Time between when this job whas scheduled and when it started running
+    def runtime
+      finished_at - performed_at if finished_at
+    end
+
     # This job's most recent {Execution}
     # @param reload [Booelan] whether to reload executions
     # @return [Execution]


### PR DESCRIPTION
This fixes #547 by updating `jobs#show` page to include status and other details about the job. 

To Do:
- [ ] Tests

## Scheduled

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/173/164162133-89c2fd03-f53c-4019-822a-960a3963e0ec.png">

## Queued

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/173/164162654-0b8b2ad1-bc9d-4fa5-96ea-d9377da2537b.png">

## Running

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/173/164161915-0d61e9b3-5474-49dd-918f-8eec558ec415.png">

## Discarded

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/173/164161953-8f5b7dad-992e-44e9-94fa-c7a84b41413d.png">

## Finished

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/173/164161362-10bf0509-9d87-4cc8-b9fd-7d7f40aef7b2.png">
