### PR TITLE
Dashboard: Use toasts to show notices and alerts

### DIFF
--- a/engine/app/assets/scripts.js
+++ b/engine/app/assets/scripts.js
@@ -17,6 +17,7 @@ const GoodJob = {
     GoodJob.addListeners();
     GoodJob.pollUpdates();
     GoodJob.renderCharts(true);
+    GoodJob.showToasts();
   },
 
   addListeners: () => {
@@ -127,6 +128,15 @@ const GoodJob = {
 
   setStorage: (key, value) => {
     localStorage.setItem('good_job-' + key, value);
+  },
+
+  showToasts() {
+    const toasts = document.querySelectorAll('.toast');
+
+    for (let i = 0; i < toasts.length; i++) {
+      var toast = new bootstrap.Toast(toasts[i])
+      toast.show()
+    }
   }
 };
 

--- a/engine/app/assets/style.css
+++ b/engine/app/assets/style.css
@@ -30,3 +30,7 @@
   position:relative;
   left:calc(-1 * (100vw - 100%)/2);
 }
+
+.toast-container {
+  z-index: 1;
+}

--- a/engine/app/views/good_job/shared/_alert.erb
+++ b/engine/app/views/good_job/shared/_alert.erb
@@ -1,13 +1,20 @@
-<% if notice %>
-  <div class="alert alert-success alert-dismissible fade show d-flex align-items-center offset-md-3 col-6" role="alert">
-    <%= render "good_job/shared/icons/check", class: "flex-shrink-0 me-2" %>
-    <div><%= notice %></div>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  </div>
-<% elsif alert %>
-  <div class="alert alert-warning alert-dismissible fade show d-flex align-items-center offset-md-3 col-6" role="alert">
-    <%= render "good_job/shared/icons/exclamation", class: "flex-shrink-0 me-2" %>
-    <div><%= alert %></div>
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-  </div>
-<% end %>
+<div class="toast-container position-fixed p-3 start-50 translate-middle-x">
+  <% if notice %>
+    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast-body d-flex align-items-center gap-2">
+        <%= render "good_job/shared/icons/check", class: "flex-shrink-0 text-success" %>
+        <div class="flex-fill"><%= notice %></div>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  <% end %>
+  <% if alert %>
+    <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="toast-body d-flex align-items-center gap-2">
+        <%= render "good_job/shared/icons/exclamation", class: "flex-shrink-0 text-danger" %>
+        <div class="flex-fill"><%= alert %></div>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/engine/app/views/layouts/good_job/application.html.erb
+++ b/engine/app/views/layouts/good_job/application.html.erb
@@ -21,7 +21,7 @@
   <div class="d-flex flex-column min-vh-100">
     <%= render "good_job/shared/navbar" %>
 
-    <div class="container-fluid flex-grow-1">
+    <div class="container-fluid flex-grow-1 relative">
       <%= render "good_job/shared/alert" %>
 
       <%= yield %>


### PR DESCRIPTION
The dashboard changes in #572 and coming up in #575 are a little awkward with alerts. This switches to using [toasts](https://getbootstrap.com/docs/5.1/components/toasts/) instead of [alerts](https://getbootstrap.com/docs/5.1/components/alerts/).

## Before

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/173/164504964-c8765691-3a9a-4124-afe9-1dca16e7f20d.png">

## After

![good_job toast](https://user-images.githubusercontent.com/173/164505800-dfaa5fba-58d9-4d06-bcf6-721e7340296f.gif)

