### PR TITLE
Track down incompatibility/race condition between JRuby and RSpec mocks in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: gemfiles/vendor/bundle
-          key: v1-bundler-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: v1-bundler-${{ runner.os }}-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock', 'gemfiles/*.gemfile.lock') }}
           restore-keys: |
             v1-bundler-${{ runner.os }}-${{ matrix.ruby }}-
       - name: Install Appraisal gems
@@ -106,6 +106,7 @@ jobs:
                                       --require ./spec/support/pre_documentation_formatter.rb \
                                       --format PreDocumentationFormatter
       - name: Run System tests
+        if: ${{ !contains(matrix.ruby, 'jruby') }}
         run: |
           bundle exec appraisal rspec --require ./spec/support/pre_documentation_formatter.rb \
                                       --format PreDocumentationFormatter \

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -64,6 +64,9 @@ describe GoodJob do
       described_class.cleanup_preserved_jobs
 
       expect(ActiveSupport::Notifications).to have_received(:instrument).at_least(:once)
+
+      # Manually remove the stub to prevent the instrumentation from affecting multi-threaded teardown
+      ::RSpec::Mocks.space.proxy_for(ActiveSupport::Notifications).remove_stub(:instrument)
     end
   end
 end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -13,7 +13,7 @@ RSpec.configure do |config|
     THREAD_ERRORS.clear
     Thread.current.name = "RSpec: #{example.description}"
     GoodJob.on_thread_error = lambda do |exception|
-      THREAD_ERRORS << [Thread.current.name, exception]
+      THREAD_ERRORS << [Thread.current.name, exception, exception.backtrace]
     end
 
     example.run


### PR DESCRIPTION
Stubbing a class method, in this case `ActiveSupport::Notifications.instrument` seems to introduce some kind of multi-threaded race condition.

- Include backtrace in thread error message
- explicitly unstub class method stub inside of example
- skip ignored System tests inside of Action runner too to save ~1 min of run time. 

<img width="926" alt="Screen Shot 2022-04-25 at 10 17 02 AM" src="https://user-images.githubusercontent.com/47554/165141259-95273774-7b87-42bb-a6f3-e832838e85ea.png">
