### PR TITLE
Temporarily disable Mass Action "Apply to all" because the action is badly scoped

### DIFF
--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -36,16 +36,6 @@
                 <% end %>
               </div>
           </tr>
-          <tr class="d-none" data-checkbox-toggle-show="job_ids">
-            <td class="text-center table-warning" colspan="10">
-              <% all_jobs_count = local_assigns[:all_jobs_count] %>
-              <label>
-                <%= check_box_tag "all_job_ids", 1, false, disabled: true, data: { "checkbox-toggle-show": "job_ids"} %>
-                Apply to all <%= all_jobs_count.present? ? number_with_delimiter(all_jobs_count) : "" %> <%= "job".pluralize(all_jobs_count || 99) %>.
-                <em>This could be a lot.</em>
-              </label>
-            </td>
-          </tr>
         </thead>
         <tbody>
           <% if jobs.present? %>

--- a/spec/system/dashboard_spec.rb
+++ b/spec/system/dashboard_spec.rb
@@ -160,13 +160,13 @@ describe 'Dashboard', type: :system, js: true do
         expect(page).to have_selector('input[type=checkbox]:checked', count: 0)
       end.to change { GoodJob::ActiveJobJob.discarded.count }.from(2).to(0)
 
-      visit good_job.jobs_path(limit: 1)
-      expect do
-        check "toggle_job_ids"
-        check "Apply to all 2 jobs"
-        within("table thead") { accept_confirm { click_on "Discard all" } }
-        expect(page).to have_selector('input[type=checkbox]:checked', count: 0)
-      end.to change { GoodJob::ActiveJobJob.discarded.count }.from(0).to(2)
+      # visit good_job.jobs_path(limit: 1)
+      # expect do
+      #   check "toggle_job_ids"
+      #   check "Apply to all 2 jobs"
+      #   within("table thead") { accept_confirm { click_on "Discard all" } }
+      #   expect(page).to have_selector('input[type=checkbox]:checked', count: 0)
+      # end.to change { GoodJob::ActiveJobJob.discarded.count }.from(0).to(2)
     end
   end
 


### PR DESCRIPTION
This should be scoped to the current filter:

https://github.com/bensheldon/good_job/blob/528045e798f12469110d02641e413764c730b63d/engine/app/controllers/good_job/jobs_controller.rb#L24-L25

Noted in https://github.com/bensheldon/good_job/pull/578#issuecomment-1109923968
