### PR TITLE
Reintroduce fixed "Apply to all" mass action

### DIFF
--- a/engine/app/controllers/good_job/cron_entries_controller.rb
+++ b/engine/app/controllers/good_job/cron_entries_controller.rb
@@ -6,12 +6,12 @@ module GoodJob
     end
 
     def show
-      @cron_entry = CronEntry.find(params[:id])
+      @cron_entry = CronEntry.find(params[:cron_key])
       @jobs_filter = JobsFilter.new(params, @cron_entry.jobs)
     end
 
     def enqueue
-      @cron_entry = CronEntry.find(params[:id])
+      @cron_entry = CronEntry.find(params[:cron_key])
       @cron_entry.enqueue(Time.current)
       redirect_back(fallback_location: cron_entries_path, notice: "Cron entry has been enqueued.")
     end

--- a/engine/app/controllers/good_job/jobs_controller.rb
+++ b/engine/app/controllers/good_job/jobs_controller.rb
@@ -22,7 +22,7 @@ module GoodJob
       raise ActionController::BadRequest, "#{mass_action} is not a valid mass action" unless mass_action.in?(ACTIONS.keys)
 
       jobs = if params[:all_job_ids]
-               ActiveJobJob.all
+               JobsFilter.new(params).filtered_query
              else
                job_ids = params.fetch(:job_ids, [])
                ActiveJobJob.where(active_job_id: job_ids)
@@ -49,7 +49,7 @@ module GoodJob
                  "No jobs were #{ACTIONS[mass_action]}"
                end
 
-      redirect_to jobs_path, notice: notice
+      redirect_back(fallback_location: jobs_path, notice: notice)
     end
 
     def show

--- a/engine/app/filters/good_job/base_filter.rb
+++ b/engine/app/filters/good_job/base_filter.rb
@@ -47,6 +47,7 @@ module GoodJob
         queue_name: params[:queue_name],
         query: params[:query],
         state: params[:state],
+        cron_key: params[:cron_key],
       }.merge(override).delete_if { |_, v| v.blank? }
     end
 
@@ -54,8 +55,9 @@ module GoodJob
       raise NotImplementedError
     end
 
-    # def filtered_query_count
-    delegate :count, to: :filtered_query, prefix: true
+    def filtered_count
+      filtered_query.count
+    end
 
     private
 

--- a/engine/app/filters/good_job/jobs_filter.rb
+++ b/engine/app/filters/good_job/jobs_filter.rb
@@ -18,6 +18,7 @@ module GoodJob
       query = query.job_class(params[:job_class]) if params[:job_class].present?
       query = query.where(queue_name: params[:queue_name]) if params[:queue_name].present?
       query = query.search_text(params[:query]) if params[:query].present?
+      query = query.where(cron_key: params[:cron_key]) if params[:cron_key].present?
 
       if params[:state]
         case params[:state]
@@ -39,7 +40,7 @@ module GoodJob
       query
     end
 
-    def filtered_query_count
+    def filtered_count
       filtered_query.unscope(:select).count
     end
 

--- a/engine/app/views/good_job/cron_entries/show.html.erb
+++ b/engine/app/views/good_job/cron_entries/show.html.erb
@@ -3,4 +3,4 @@
 <% end %>
 
 <%= render 'good_job/shared/filter', title: title, filter: @jobs_filter %>
-<%= render 'good_job/jobs/table', jobs: @jobs_filter.records %>
+<%= render 'good_job/jobs/table', jobs: @jobs_filter.records, filter: @jobs_filter %>

--- a/engine/app/views/good_job/jobs/_table.erb
+++ b/engine/app/views/good_job/jobs/_table.erb
@@ -1,6 +1,6 @@
 <div class="my-3">
   <div class="table-responsive">
-    <%= form_with(url: mass_update_jobs_path, method: :put, local: true, data: { "checkbox-toggle": "job_ids" }) do |form| %>
+    <%= form_with(url: mass_update_jobs_path(filter.to_params), method: :put, local: true, data: { "checkbox-toggle": "job_ids" }) do |form| %>
       <table class="table table-hover table-sm mb-0 table-jobs">
         <thead>
           <tr>
@@ -35,6 +35,15 @@
                   <%= render_icon "arrow_clockwise" %> All
                 <% end %>
               </div>
+            </th>
+          </tr>
+          <tr class="d-none" data-checkbox-toggle-show="job_ids">
+            <td class="text-center table-warning" colspan="10">
+              <label>
+                <%= check_box_tag "all_job_ids", 1, false, disabled: true, data: { "checkbox-toggle-show": "job_ids"} %>
+                Apply to all <%= filter.filtered_count %> <%= "job".pluralize(filter.filtered_count) %>.
+              </label>
+            </td>
           </tr>
         </thead>
         <tbody>

--- a/engine/app/views/good_job/jobs/index.html.erb
+++ b/engine/app/views/good_job/jobs/index.html.erb
@@ -2,7 +2,7 @@
 <%= render 'good_job/shared/chart', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
 
 <div data-live-poll-region="jobs-table">
-  <%= render 'good_job/jobs/table', jobs: @filter.records, all_jobs_count: @filter.filtered_query_count %>
+  <%= render 'good_job/jobs/table', jobs: @filter.records, filter: @filter %>
   <% if @filter.records.present? %>
     <nav aria-label="Job pagination" class="mt-3">
       <ul class="pagination">

--- a/engine/config/routes.rb
+++ b/engine/config/routes.rb
@@ -17,7 +17,7 @@ GoodJob::Engine.routes.draw do
     end
   end
 
-  resources :cron_entries, only: %i[index show] do
+  resources :cron_entries, only: %i[index show], param: :cron_key do
     member do
       post :enqueue
     end

--- a/spec/support/reset_rails_queue_adapter.rb
+++ b/spec/support/reset_rails_queue_adapter.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
+  config.prepend_before do
+    # https://github.com/rails/rails/issues/37270
+    descendants = ActiveJob::Base.descendants + [ActiveJob::Base]
+    descendants.each(&:disable_test_adapter)
+  end
+
   config.around do |example|
     original_adapter = ActiveJob::Base.queue_adapter
+
     example.run
+
     ActiveJob::Base.queue_adapter = original_adapter
   end
 end

--- a/spec/system/i18n_spec.rb
+++ b/spec/system/i18n_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'I18n Internationalization', type: :system, js: true do
+  describe "when changing language" do
+    it "changes wording from English to Spanish" do
+      visit good_job_path(locale: :en)
+
+      expect(page).to have_content "Processes"
+      find("#localeOptions").click
+      within ".navbar" do
+        click_on "es"
+      end
+      expect(page).to have_content "Procesos"
+    end
+  end
+end


### PR DESCRIPTION
- Fixes issues when I yanked the functionality in #583
- Passes through filter options to mass action
- Turns `cron_key` into a filter option so the feature is functional on the cron-entries page too (aside: maybe `cron_key` should simply be a filter on the jobs page, rather than an alternative jobs page)
- Still does nothing about performance