### PR TITLE
Fix Concurrency extension to not break `perform_now`

### DIFF
--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -61,6 +61,11 @@ module GoodJob
           key = job.good_job_concurrency_key
           next if key.blank?
 
+          if CurrentThread.execution.blank?
+            logger.debug("Ignoring concurrency limits because the job is executed with `perform_now`.")
+            next
+          end
+
           GoodJob::Execution.advisory_lock_key(key, function: "pg_advisory_lock") do
             allowed_active_job_ids = GoodJob::Execution.unfinished.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
             # The current job has already been locked and will appear in the previous query

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -61,15 +61,17 @@ module GoodJob
           key = job.good_job_concurrency_key
           next if key.blank?
 
-          if CurrentThread.execution.blank?
-            logger.debug("Ignoring concurrency limits because the job is executed with `perform_now`.")
-            next
-          end
-
           GoodJob::Execution.advisory_lock_key(key, function: "pg_advisory_lock") do
             allowed_active_job_ids = GoodJob::Execution.unfinished.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
-            # The current job has already been locked and will appear in the previous query
-            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.include? job.job_id
+
+            concurrency_exceeded = if CurrentThread.execution.present?
+                                     allowed_active_job_ids.exclude?(job.job_id)
+                                   else
+                                     # executed with `perform_now`
+                                     allowed_active_job_ids.size + 1 > perform_limit
+                                   end
+
+            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError if concurrency_exceeded
           end
         end
       end

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -61,17 +61,15 @@ module GoodJob
           key = job.good_job_concurrency_key
           next if key.blank?
 
+          if CurrentThread.execution.blank?
+            logger.debug("Ignoring concurrency limits because the job is executed with `perform_now`.")
+            next
+          end
+
           GoodJob::Execution.advisory_lock_key(key, function: "pg_advisory_lock") do
             allowed_active_job_ids = GoodJob::Execution.unfinished.where(concurrency_key: key).advisory_locked.order(Arel.sql("COALESCE(performed_at, scheduled_at, created_at) ASC")).limit(perform_limit).pluck(:active_job_id)
-
-            concurrency_exceeded = if CurrentThread.execution.present?
-                                     allowed_active_job_ids.exclude?(job.job_id)
-                                   else
-                                     # executed with `perform_now`
-                                     allowed_active_job_ids.size + 1 > perform_limit
-                                   end
-
-            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError if concurrency_exceeded
+            # The current job has already been locked and will appear in the previous query
+            raise GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError unless allowed_active_job_ids.include? job.job_id
           end
         end
       end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -99,13 +99,9 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(GoodJob::Execution.where("error LIKE '%GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError%'")).to be_present
       end
 
-      context 'when run with perform_now' do
-        it 'error and enqueue the job when concurrency is exceeded' do
-          TestJob.perform_now(name: "Alice")
-
-          expect(GoodJob::Job.count).to eq 1
-          expect(JOB_PERFORMED).to be_false
-        end
+      it 'is ignored with the job is executed via perform_now' do
+        TestJob.perform_now(name: "Alice")
+        expect(JOB_PERFORMED).to be_true
       end
     end
   end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -99,9 +99,13 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(GoodJob::Execution.where("error LIKE '%GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError%'")).to be_present
       end
 
-      it 'is ignored with the job is executed via perform_now' do
-        TestJob.perform_now(name: "Alice")
-        expect(JOB_PERFORMED).to be_true
+      context 'when run with perform_now' do
+        it 'error and enqueue the job when concurrency is exceeded' do
+          TestJob.perform_now(name: "Alice")
+
+          expect(GoodJob::Job.count).to eq 1
+          expect(JOB_PERFORMED).to be_false
+        end
       end
     end
   end


### PR DESCRIPTION
As reported in #591, previously running a job with concurrency control via `perform_now` would _always_ raise and retry. 

~This change allows the job to execute immediately if concurrency limits have not been exceeded, otherwise it will be enqueued.~

Concurrency limits are only enforced for `perform_later`.