### PR TITLE
Bind probe server to all interfaces

### DIFF
--- a/lib/good_job/probe_server.rb
+++ b/lib/good_job/probe_server.rb
@@ -17,7 +17,7 @@ module GoodJob
     def start
       @handler = Rack::Handler.get(RACK_SERVER)
       @future = Concurrent::Future.new(args: [@handler, @port, GoodJob.logger]) do |thr_handler, thr_port, thr_logger|
-        thr_handler.run(self, Port: thr_port, Logger: thr_logger, AccessLog: [])
+        thr_handler.run(self, Port: thr_port, Host: '0.0.0.0', Logger: thr_logger, AccessLog: [])
       end
       @future.add_observer(self.class, :task_observer)
       @future.execute


### PR DESCRIPTION
Closes #592

The probe server was only reachable under `localhost` and `127.0.0.1`, but not by the local ip address of the system, which causes problem if e.g. the Kubernetes probes try to connect via that ip address.

This PR fixes this by adding a `Host: '0.0.0.0'`-argument to the Rack/Webrick-Server, which means "bind to all interfaces".