### PR TITLE
Disable ActiveRecord Connection Reaper in test

### DIFF
--- a/spec/test_app/config/database.yml
+++ b/spec/test_app/config/database.yml
@@ -59,6 +59,7 @@ development:
 test:
   <<: *default
   database: good_job_test
+  reaping_frequency: 0
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
Solution described in https://github.com/DatabaseCleaner/database_cleaner/issues/570

Hope it fixes this flaky behavior:

<img width="803" alt="Screen Shot 2022-05-18 at 7 10 40 AM" src="https://user-images.githubusercontent.com/47554/169062042-0d639bdf-7fa8-4b5c-b160-ef57f9f95b20.png">

