### PR TITLE
Fix/i18n status scopes

### DIFF
--- a/engine/app/assets/good_job/style.css
+++ b/engine/app/assets/good_job/style.css
@@ -34,3 +34,8 @@
 .toast-container {
   z-index: 1;
 }
+
+.translation_missing {
+  background-color: red;
+  color: white;
+}

--- a/engine/app/helpers/good_job/application_helper.rb
+++ b/engine/app/helpers/good_job/application_helper.rb
@@ -41,7 +41,7 @@ module GoodJob
     }.freeze
 
     def status_badge(status)
-      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: '.good_job.status'),
+      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: 'good_job.status'),
                   class: "badge rounded-pill bg-#{STATUS_COLOR.fetch(status)} d-inline-flex gap-2 ps-1 pe-3 align-items-center"
     end
 

--- a/engine/app/helpers/good_job/application_helper.rb
+++ b/engine/app/helpers/good_job/application_helper.rb
@@ -41,7 +41,7 @@ module GoodJob
     }.freeze
 
     def status_badge(status)
-      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: '.status'),
+      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: '.good_job.status'),
                   class: "badge rounded-pill bg-#{STATUS_COLOR.fetch(status)} d-inline-flex gap-2 ps-1 pe-3 align-items-center"
     end
 

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -10,7 +10,7 @@
       <% filter.states.each do |name, count| %>
         <li class="nav-item">
           <%= link_to url_for({state: name}), class: "nav-link #{"active" if params[:state] == name}" do %>
-            <%= t(name, scope: '.good_job.status') %>
+            <%= t(name, scope: 'good_job.status') %>
             <span class="badge bg-primary rounded-pill <%= "bg-secondary" if count == 0 %>"><%= count %></span>
           <% end %>
         </li>

--- a/engine/app/views/good_job/shared/_filter.erb
+++ b/engine/app/views/good_job/shared/_filter.erb
@@ -10,7 +10,7 @@
       <% filter.states.each do |name, count| %>
         <li class="nav-item">
           <%= link_to url_for({state: name}), class: "nav-link #{"active" if params[:state] == name}" do %>
-            <%= t(name, scope: '.status') %>
+            <%= t(name, scope: '.good_job.status') %>
             <span class="badge bg-primary rounded-pill <%= "bg-secondary" if count == 0 %>"><%= count %></span>
           <% end %>
         </li>

--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   # config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -54,11 +54,7 @@ Rails.application.configure do
   # config.assets.quiet = true
 
   # Raises error for missing translations.
-  if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')
-    config.action_view.raise_on_missing_translations = true
-  else
-    config.i18n.raise_on_missing_translations = true
-  end
+  # config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -54,7 +54,11 @@ Rails.application.configure do
   # config.assets.quiet = true
 
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')
+    config.action_view.raise_on_missing_translations = true
+  else
+    config.i18n.raise_on_missing_translations = true
+  end
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/spec/test_app/config/environments/test.rb
+++ b/spec/test_app/config/environments/test.rb
@@ -8,7 +8,11 @@ Rails.application.configure do
   config.eager_load = false
 
   # Raises error for missing translations.
-  config.action_view.raise_on_missing_translations = true
+  if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')
+    config.action_view.raise_on_missing_translations = true
+  else
+    config.i18n.raise_on_missing_translations = true
+  end
 
   if ActiveModel::Type::Boolean.new.cast(ENV['RAILS_LOG_TO_STDOUT'])
     logger = ActiveSupport::Logger.new(STDOUT)

--- a/spec/test_app/config/environments/test.rb
+++ b/spec/test_app/config/environments/test.rb
@@ -7,6 +7,9 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
 
+  # Raises error for missing translations.
+  config.action_view.raise_on_missing_translations = true
+
   if ActiveModel::Type::Boolean.new.cast(ENV['RAILS_LOG_TO_STDOUT'])
     logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter


### PR DESCRIPTION
As suggested in #605 I enabled the config setting `action_view.raise_on_missing_translations` for the test_app in development and test. This way mistakes as the mentioned mismatch of translation nesting and usage should become apparent.

Also this PR fixes the bug described in #605 by using the correct scope for status translations.

Sadly I had slight issues running the tests locally (with certain rails versions) and so I hope Github Actions is happy anyways.

I can confirm though, that the config adjustment in 5b4ee61 detects the wrong translations. The output is not perfect because the exception is not properly shown in the rspec output but instead the server seems to render a ` "We're sorry, but something went wrong."` 500-page.