### PR TITLE
Do not enforce perform_limit concurrency controls on inline adapter

### DIFF
--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -51,6 +51,8 @@ module GoodJob
         before_perform do |job|
           # Don't attempt to enforce concurrency limits with other queue adapters.
           next unless job.class.queue_adapter.is_a?(GoodJob::Adapter)
+          # ...or GoodJob's inline adapter.
+          next if job.class.queue_adapter.execute_inline?
 
           perform_limit = job.class.good_job_concurrency_config[:perform_limit] ||
                           job.class.good_job_concurrency_config[:total_limit]

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -103,6 +103,15 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         TestJob.perform_now(name: "Alice")
         expect(JOB_PERFORMED).to be_true
       end
+
+      it 'is ignored if the adapter is inline' do
+        TestJob.perform_later(name: "Alice")
+        GoodJob::Execution.first.with_advisory_lock do
+          allow(TestJob.queue_adapter).to receive(:execute_inline?).and_return(true)
+          TestJob.perform_later(name: "Alice")
+          expect(JOB_PERFORMED).to be_true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The inline adapter does not support incremental back-off, and the job is re-enqueued recursively until it reaches stack-level too deep.

Fixes #609 