### PR TITLE
Fix `:inline` mode with future behavior to run unscheduled jobs immediately

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -65,7 +65,7 @@ module GoodJob
       scheduled_at = timestamp ? Time.zone.at(timestamp) : nil
 
       if execute_inline?
-        future_scheduled = (scheduled_at.nil? || scheduled_at > Time.current)
+        future_scheduled = scheduled_at && scheduled_at > Time.current
         will_execute_inline = !future_scheduled || (future_scheduled && !@configuration.inline_execution_respects_schedule?)
       end
 

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -111,9 +111,19 @@ RSpec.describe 'Adapter Integration' do
       end)
     end
 
+    it 'executes unscheduled jobs immediately' do
+      TestJob.perform_later
+      expect(PERFORMED.size).to eq 1
+    end
+
     it 'raises unhandled exceptions' do
       expect do
         TestJob.perform_later
+        5.times do
+          travel(5.minutes)
+          GoodJob.perform_inline
+        end
+        travel_back
       end.to raise_error JobError
       expect(PERFORMED.size).to eq 3
     end

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -33,8 +33,13 @@ describe 'Jobs', type: :system, js: true do
     end
 
     let(:discarded_job) do
+      travel_to 1.hour.ago
       ExampleJob.set(queue: :elephants).perform_later(ExampleJob::DEAD_TYPE)
-    rescue StandardError
+      5.times do
+        travel 5.minutes
+        GoodJob.perform_inline
+      end
+      travel_back
       GoodJob::ActiveJobJob.order(created_at: :asc).last
     end
 

--- a/spec/test_app/app/jobs/example_job.rb
+++ b/spec/test_app/app/jobs/example_job.rb
@@ -9,8 +9,8 @@ class ExampleJob < ApplicationJob
     DEAD_TYPE = 'dead',
     SLOW_TYPE = 'slow',
   ]
-  
-  retry_on DeadError, attempts: 3
+
+  retry_on(DeadError, attempts: 3) { nil }
 
   def perform(type = SUCCESS_TYPE)
     if type == SUCCESS_TYPE

--- a/spec/test_app/config/initializers/good_job.rb
+++ b/spec/test_app/config/initializers/good_job.rb
@@ -1,4 +1,7 @@
 Rails.application.configure do
+  # TODO: Remove on GoodJob 3.0 release
+  config.good_job.inline_execution_respects_schedule = true
+
   config.good_job.cron = {
     example: {
       cron: '*/5 * * * * *', # every 5 seconds


### PR DESCRIPTION
Also addresses the inline deprecations in the test suite.