### PR TITLE
Clarify README on default in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
     YourJob.set(queue: :some_queue, wait: 5.minutes, priority: 10).perform_later
     ```
 
-1. In development, GoodJob executes jobs immediately. In production, GoodJob provides different options:
+1. In development, GoodJob executes jobs immediately in a separate thread (async mode). In production, GoodJob provides different options:
 
     - By default, GoodJob separates job enqueuing from job execution so that jobs can be scaled independently of the web server.  Use the GoodJob command-line tool to execute jobs:
 


### PR DESCRIPTION
I believe default in development is [actually async mode](https://github.com/bensheldon/good_job/blob/main/lib/good_job/configuration.rb#L67-L68), as asalso mentioned later in the README around text "By default, GoodJob configures the following execution modes per environment."

But in this earlier getting started part of the README, I read "In development, GoodJob executes jobs immediately" to mean :inline not :async. Tried to add some language to clarify :async.

If you don't find this helpful, just close the PR, no problem! 