### PR TITLE
Remove nonexistant `engine/lib` from $LOAD_PATH

### DIFF
--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require_paths = ["lib", "engine/lib"]
+require_paths = ["lib"]
 require_paths.each do |require_path|
   $LOAD_PATH.push File.expand_path(require_path, __dir__)
 end


### PR DESCRIPTION
Follow-up to #554.

Originally introduced in #134 