### PR TITLE
Add Configuration.total_estimated_threads to report number of threads consumed by GoodJob

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -37,6 +37,34 @@ module GoodJob
     # @return [Hash]
     attr_reader :env
 
+    # Returns the maximum number of threads GoodJob might consume
+    # @param warn [Boolean] whether to print a warning when over the limit
+    # @return [Integer]
+    def self.total_estimated_threads(warn: false)
+      configuration = new({})
+
+      cron_threads = configuration.enable_cron? ? 2 : 0
+      notifier_threads = 1
+      scheduler_threads = GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats[:max_threads] }
+
+      good_job_threads = cron_threads + notifier_threads + scheduler_threads
+      puma_threads = (Puma::Server.current&.max_threads if defined?(Puma::Server)) || 0
+
+      total_threads = good_job_threads + puma_threads
+      activerecord_pool_size = ActiveRecord::Base.connection_pool&.size
+
+      if warn && activerecord_pool_size && total_threads > activerecord_pool_size
+        message = "GoodJob is using #{good_job_threads} threads, " \
+                  "#{" and Puma is using #{puma_threads} threads, " if puma_threads.positive?}" \
+                  "which is #{total_threads - activerecord_pool_size} thread(s) more than ActiveRecord's database connection pool size of #{activerecord_pool_size}. " \
+                  "Consider increasing ActiveRecord's database connection pool size in config/database.yml."
+
+        GoodJob.logger.warn message
+      end
+
+      good_job_threads
+    end
+
     # @param options [Hash] Any explicitly specified configuration options to
     #   use. Keys are symbols that match the various methods on this class.
     # @param env [Hash] A +Hash+ from which to read environment variables that

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -2,6 +2,25 @@
 require 'rails_helper'
 
 RSpec.describe GoodJob::Configuration do
+  describe '.total_estimated_threads' do
+    before do
+      allow(ActiveRecord::Base.connection_pool).to receive(:size).and_return(2)
+    end
+
+    it 'counts up the total estimated threads' do
+      expect(described_class.total_estimated_threads).to eq 1
+    end
+
+    it 'outputs a warning message' do
+      allow(ActiveRecord::Base.connection_pool).to receive(:size).and_return(0)
+      allow(GoodJob.logger).to receive(:warn)
+
+      described_class.total_estimated_threads(warn: true)
+
+      expect(GoodJob.logger).to have_received(:warn).with(/GoodJob is using \d+ threads/)
+    end
+  end
+
   describe '#execution_mode' do
     context 'when in development' do
       before do


### PR DESCRIPTION
- [x] Rename to `total_estimated_threads`
- [x] When running async, also warn when the sum of goodjob _and puma threads_ exceed the pool
- [x] Fix the tests