### PR TITLE
Dequeing should be first-in first-out

### DIFF
--- a/scripts/benchmark_job_throughput.rb
+++ b/scripts/benchmark_job_throughput.rb
@@ -31,11 +31,11 @@ puts "Inserting seed records into the database...\n"
 GoodJob::Execution.insert_all(executions_data)
 
 # ActiveRecord::Base.connection.execute('SET enable_seqscan = OFF')
-# puts GoodJob::Execution.unfinished.priority_ordered.only_scheduled(use_coalesce: true).limit(1).advisory_lock.explain(analyze: true)
+# puts GoodJob::Execution.unfinished.dequeue_ordered.only_scheduled(use_coalesce: true).limit(1).advisory_lock.explain(analyze: true)
 # exit!
 
 Benchmark.ips do |x|
-  x.report("with priority") do
+  x.report("with priority only") do
     GoodJob::Execution.unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
       # executions.first&.destroy!
     end
@@ -43,6 +43,12 @@ Benchmark.ips do |x|
 
   x.report("without priority") do
     GoodJob::Execution.unfinished.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("with priority and FIFO") do
+    GoodJob::Execution.unfinished.dequeue_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
       # executions.first&.destroy!
     end
   end

--- a/spec/lib/models/good_job/execution_spec.rb
+++ b/spec/lib/models/good_job/execution_spec.rb
@@ -56,31 +56,57 @@ RSpec.describe GoodJob::Execution do
   end
 
   describe '.perform_with_advisory_lock' do
-    let(:active_job) { TestJob.new('a string') }
-    let!(:good_job) { described_class.enqueue(active_job) }
+    context 'one job' do
+      let(:active_job) { TestJob.new('a string') }
+      let!(:good_job) { described_class.enqueue(active_job) }
 
-    it 'performs one job' do
-      good_job_2 = described_class.create!(serialized_params: {})
+      it 'performs one job' do
+        good_job_2 = described_class.create!(serialized_params: {})
 
-      described_class.all.perform_with_advisory_lock
+        described_class.perform_with_advisory_lock
 
-      expect(good_job.reload.finished_at).to be_present
-      expect(good_job_2.reload.finished_at).to be_blank
+        expect(good_job.reload.finished_at).to be_present
+        expect(good_job_2.reload.finished_at).to be_blank
+      end
+
+      it 'returns the result or nil if not' do
+        result = described_class.perform_with_advisory_lock
+
+        expect(result).to be_a GoodJob::ExecutionResult
+        expect(result.value).to eq 'a string'
+        expect(result.unhandled_error).to be_nil
+
+        described_class.enqueue(TestJob.new(true, raise_error: true))
+        errored_result = described_class.all.perform_with_advisory_lock
+
+        expect(result).to be_a GoodJob::ExecutionResult
+        expect(errored_result.value).to be_nil
+        expect(errored_result.unhandled_error).to be_an TestJob::ExpectedError
+      end
     end
 
-    it 'returns the result or nil if not' do
-      result = described_class.all.perform_with_advisory_lock
+    context 'dequeue ordering' do
+      def job_params
+        { active_job_id: SecureRandom.uuid, queue_name: "default", priority: 0, serialized_params: { job_class: "TestJob" } }
+      end
 
-      expect(result).to be_a GoodJob::ExecutionResult
-      expect(result.value).to eq 'a string'
-      expect(result.unhandled_error).to be_nil
+      let!(:older_job) { described_class.create!(job_params.merge(created_at: 10.minutes.ago)) }
+      let!(:newer_job) { described_class.create!(job_params.merge(created_at: 5.minutes.ago)) }
+      let!(:low_priority_job) { described_class.create!(job_params.merge(priority: 5)) }
+      let!(:high_priority_job) { described_class.create!(job_params.merge(priority: 100)) }
 
-      described_class.enqueue(TestJob.new(true, raise_error: true))
-      errored_result = described_class.all.perform_with_advisory_lock
+      it "orders by priority ascending and creation descending" do
+        4.times do
+          described_class.perform_with_advisory_lock
+        end
 
-      expect(result).to be_a GoodJob::ExecutionResult
-      expect(errored_result.value).to be_nil
-      expect(errored_result.unhandled_error).to be_an TestJob::ExpectedError
+        expect(described_class.all.order(finished_at: :asc).to_a).to eq([
+                                                                          high_priority_job,
+                                                                          low_priority_job,
+                                                                          older_job,
+                                                                          newer_job,
+                                                                        ])
+      end
     end
   end
 

--- a/spec/lib/models/good_job/execution_spec.rb
+++ b/spec/lib/models/good_job/execution_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe GoodJob::Execution do
   end
 
   describe '.perform_with_advisory_lock' do
-    context 'one job' do
+    context 'with one job' do
       let(:active_job) { TestJob.new('a string') }
       let!(:good_job) { described_class.enqueue(active_job) }
 
@@ -85,7 +85,7 @@ RSpec.describe GoodJob::Execution do
       end
     end
 
-    context 'dequeue ordering' do
+    context 'with multiple jobs' do
       def job_params
         { active_job_id: SecureRandom.uuid, queue_name: "default", priority: 0, serialized_params: { job_class: "TestJob" } }
       end


### PR DESCRIPTION
Connects to #624.

For the sake of having something concrete to discuss!

Secondarily to priority, within a given priority (including null priority), dequeue respecting first-in first-out, by sorting on created_at

FIFO is how all other ActiveJob queues perform (so far as I know), and is kind of implied by the very word "queue".  It will be less surprising to those coming from other ActiveJob queues, and that this is how every other queue performs is probably a signal that there are good reasons for it. (I can definitely think of many desirable things in my own use cases). 

* This PR does not yet include any tests.  Any advice about the best place/way to do a test on ordering of dequeue? I looked for an existing test on ordering of dequeue based on `priority` to use as a model, but didn't find one of those. If one of those doesn't exist yet, would be good to add that too.  I think we do want tests on dequeue ordering. 

* I tried to enhance the existing benchmark script for this case. It does seem to suggest that including this sort is a bit slower?  That's surprising to me, I wasn't really expecting it. I'm not sure to what extent speed to dequeue is really a bottleneck in most real use cases though -- it may depend on how many jobs you have in queue of course. If we do want to speed it up, perhaps there is a way to do so with indexing... but there's already a `created_at` index, although maybe it can't be used in this particular sort, I'm not really a pg index expert. 

Ideally I think FIFO would just be standard always, as here, because I think of it as table stakes for an ActiveJob queue. But if we do need to make it configurable because of perf reasons... perhaps make paying attention to priority configurable too? Not sure. 
