### PR TITLE
Preserve initial concurrency key when retrying jobs

### DIFF
--- a/lib/models/good_job/execution.rb
+++ b/lib/models/good_job/execution.rb
@@ -330,6 +330,7 @@ module GoodJob
       serialized_params.deep_dup
                        .tap do |job_data|
         job_data["provider_job_id"] = id
+        job_data["good_job_concurrency_key"] = concurrency_key if concurrency_key
       end
     end
 


### PR DESCRIPTION
Closes #622 