### PR TITLE
Don't delegate `GoodJob::Job#status` to executions to avoid race condition

### DIFF
--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -56,7 +56,7 @@ module GoodJob
     end
 
     def show
-      @job = Job.find(params[:id])
+      @job = Job.includes_advisory_locks.find(params[:id])
     end
 
     def discard

--- a/app/views/good_job/jobs/show.html.erb
+++ b/app/views/good_job/jobs/show.html.erb
@@ -54,4 +54,4 @@
   <%= tag.pre @job.serialized_params["arguments"].map(&:inspect).join(', ') %>
 </div>
 
-<%= render 'executions', executions: @job.executions.reverse %>
+<%= render 'executions', executions: @job.executions.includes_advisory_locks.reverse %>

--- a/spec/lib/models/good_job/job_spec.rb
+++ b/spec/lib/models/good_job/job_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe GoodJob::Job do
   end
 
   describe '#retry_job' do
-    context 'when job is discarded' do
+    context 'when job is retried' do
       before do
         head_execution.update!(
           finished_at: Time.current,


### PR DESCRIPTION
Closes #656.

Connects to #650 because this changes the running status to only check for the presence of an Advisory Lock.