### PR TITLE
Ordered queue handling by workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,10 +683,10 @@ By default, GoodJob creates a single thread execution pool that will execute job
     - `-transactional_messages,batch_processing`: execute jobs enqueued on _any_ queue _excluding_ `transactional_messages` or `batch_processing`, with up to 2 threads.
     - `*`: execute jobs on any queue, with up to 5 threads (as configured by `--max-threads=5`).
 
-    When a pool is taking jobs from multiple queues, jobs can be taken from specified queues in any order with equal weight, according to priority and/or creation time. To instead pull from queues in the order given, use the `+` modifier. In this example, any job in `batch_processing` will be processed only when there are no jobs in `transactional_messages`:
+    When a pool is performing jobs from multiple queues, jobs will be performed from specified queues, ordered by priority and creation time. To perform jobs from queues in the queues' given order, use the `+` modifier. In this example, jobs in `batch_processing` will be performed only when there are no jobs in `transactional_messages`:
 
     ```bash
-    $ bundle exed good_job --queues="+transactional_messages,batch_processing"
+    bundle exec good_job --queues="+transactional_messages,batch_processing"
     ```
 
     Configuration can be injected by environment variables too:

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ By default, GoodJob creates a single thread execution pool that will execute job
 
     A pool is configured with the following syntax `<participating_queues>:<thread_count>`:
 
-    - `<participating_queues>`: either `queue1,queue2` (only those queues), `*` (all) or `-queue1,queue2` (all except those queues).
+    - `<participating_queues>`: either `queue1,queue2` (only those queues), `+queue1,queue2` (only those queues, and processed in order), `*` (all) or `-queue1,queue2` (all except those queues).
     - `<thread_count>`: a count overriding for this specific pool the global `max-threads`.
 
     Pool configurations are separated with a semicolon (;) in the `queues` configuration
@@ -682,6 +682,12 @@ By default, GoodJob creates a single thread execution pool that will execute job
     - `batch_processing:1` execute jobs enqueued on `batch_processing`, with a single thread.
     - `-transactional_messages,batch_processing`: execute jobs enqueued on _any_ queue _excluding_ `transactional_messages` or `batch_processing`, with up to 2 threads.
     - `*`: execute jobs on any queue, with up to 5 threads (as configured by `--max-threads=5`).
+
+    When a pool is taking jobs from multiple queues, jobs can be taken from specified queues in any order with equal weight, according to priority and/or creation time. To instead pull from queues in the order given, use the `+` modifier. In this example, any job in `batch_processing` will be processed only when there are no jobs in `transactional_messages`:
+
+    ```bash
+    $ bundle exed good_job --queues="+transactional_messages,batch_processing"
+    ```
 
     Configuration can be injected by environment variables too:
 

--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -24,7 +24,7 @@ module GoodJob
     # Perform the next eligible job
     # @return [Object, nil] Returns job result or +nil+ if no job was found
     def next
-      job_query.perform_with_advisory_lock
+      job_query.perform_with_advisory_lock(parsed_queues: parsed_queues)
     end
 
     # Tests whether this performer should be used in GoodJob's current state.

--- a/lib/models/good_job/execution.rb
+++ b/lib/models/good_job/execution.rb
@@ -106,13 +106,13 @@ module GoodJob
     scope :creation_ordered, -> { order('created_at ASC') }
 
     # Order jobs for de-queueing
-    # @!method dequeue_ordered
+    # @!method dequeueing_ordered
     # @!scope class
     # @param parsed_queues [Hash]
     #   optional output of .queue_parser, parsed queues, will be used for
     #   ordered queues.
     # @return [ActiveRecord::Relation]
-    scope :dequeue_ordered, (lambda do |parsed_queues|
+    scope :dequeueing_ordered, (lambda do |parsed_queues|
       relation = self
       relation = relation.queue_ordered(parsed_queues[:include]) if parsed_queues && parsed_queues[:ordered_queues] && parsed_queues[:include]
       relation = relation.priority_ordered.creation_ordered
@@ -201,7 +201,7 @@ module GoodJob
     #   raised, if any (if the job raised, then the second array entry will be
     #   +nil+). If there were no jobs to execute, returns +nil+.
     def self.perform_with_advisory_lock(parsed_queues: nil)
-      unfinished.dequeue_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true) do |executions|
+      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true) do |executions|
         execution = executions.first
         break if execution.blank?
         break :unlocked unless execution&.executable?

--- a/lib/models/good_job/execution.rb
+++ b/lib/models/good_job/execution.rb
@@ -29,14 +29,20 @@ module GoodJob
     #     not match.
     #   - +{ include: Array<String> }+ indicates the listed queue names should
     #     match.
+    #   - +{ include: Array<String>, ordered_queues: true }+ indicates the listed
+    #     queue names should match, and dequeue should respect queue order.
     # @example
     #   GoodJob::Execution.queue_parser('-queue1,queue2')
     #   => { exclude: [ 'queue1', 'queue2' ] }
     def self.queue_parser(string)
       string = string.presence || '*'
 
-      if string.first == '-'
+      case string.first
+      when '-'
         exclude_queues = true
+        string = string[1..-1]
+      when '+'
+        ordered_queues = true
         string = string[1..-1]
       end
 
@@ -46,6 +52,11 @@ module GoodJob
         { all: true }
       elsif exclude_queues
         { exclude: queues }
+      elsif ordered_queues
+        {
+          include: queues,
+          ordered_queues: true,
+        }
       else
         { include: queues }
       end

--- a/lib/models/good_job/execution.rb
+++ b/lib/models/good_job/execution.rb
@@ -114,9 +114,7 @@ module GoodJob
     # @return [ActiveRecord::Relation]
     scope :dequeue_ordered, (lambda do |parsed_queues|
       relation = self
-      if parsed_queues && parsed_queues[:ordered_queues] && parsed_queues[:include]
-        relation = relation.queue_ordered(parsed_queues[:include])
-      end
+      relation = relation.queue_ordered(parsed_queues[:include]) if parsed_queues && parsed_queues[:ordered_queues] && parsed_queues[:include]
       relation = relation.priority_ordered.creation_ordered
 
       relation

--- a/scripts/benchmark_job_throughput.rb
+++ b/scripts/benchmark_job_throughput.rb
@@ -1,5 +1,5 @@
 # To run:
-# bundle exec ruby scripts/benchmark_example.rb
+# bundle exec ruby scripts/benchmark_job_throughput.rb
 #
 
 ENV['GOOD_JOB_EXECUTION_MODE'] = 'external'
@@ -12,13 +12,14 @@ require 'pry'
 booleans = [true, false]
 priorities = (1..10).to_a
 scheduled_minutes = (-60..60).to_a
+queue_names = ["one", "two", "three"]
 
 GoodJob::Execution.delete_all
 puts "Seeding database"
 executions_data = Array.new(10_000) do |i|
   puts "Initializing seed record ##{i}" if (i % 1_000).zero?
   {
-    queue_name: 'default',
+    queue_name: queue_names.sample,
     priority: priorities.sample,
     scheduled_at: booleans.sample ? scheduled_minutes.sample.minutes.ago : nil,
     created_at: 90.minutes.ago,
@@ -31,24 +32,46 @@ puts "Inserting seed records into the database...\n"
 GoodJob::Execution.insert_all(executions_data)
 
 # ActiveRecord::Base.connection.execute('SET enable_seqscan = OFF')
-# puts GoodJob::Execution.unfinished.dequeue_ordered.only_scheduled(use_coalesce: true).limit(1).advisory_lock.explain(analyze: true)
-# exit!
 
 Benchmark.ips do |x|
-  x.report("with priority only") do
-    GoodJob::Execution.unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
-      # executions.first&.destroy!
-    end
-  end
-
-  x.report("without priority") do
+x.report("without sorts") do
     GoodJob::Execution.unfinished.only_scheduled.limit(1).with_advisory_lock do |executions|
       # executions.first&.destroy!
     end
   end
 
-  x.report("with priority and FIFO") do
-    GoodJob::Execution.unfinished.dequeue_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+  x.report("sort by priority only") do
+    GoodJob::Execution.unfinished.priority_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("sort by creation only") do
+    GoodJob::Execution.unfinished.creation_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("sort by priority and creation") do
+    GoodJob::Execution.unfinished.priority_ordered.creation_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("sort by ordered queues only") do
+    GoodJob::Execution.unfinished.queue_ordered(%w{one two three}).creation_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("sort by ordered queues and creation") do
+    GoodJob::Execution.unfinished.queue_ordered(%w{one two three}).creation_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
+      # executions.first&.destroy!
+    end
+  end
+
+  x.report("sort by ordered queues, priority, and creation") do
+    GoodJob::Execution.unfinished.queue_ordered(%w{one two three}).priority_ordered.creation_ordered.only_scheduled.limit(1).with_advisory_lock do |executions|
       # executions.first&.destroy!
     end
   end

--- a/spec/lib/models/good_job/execution_spec.rb
+++ b/spec/lib/models/good_job/execution_spec.rb
@@ -126,6 +126,11 @@ RSpec.describe GoodJob::Execution do
       expect(result).to eq({
                              all: true,
                            })
+      result = described_class.queue_parser('+first,second')
+      expect(result).to eq({
+                             include: %w[first second],
+                             ordered_queues: true,
+                           })
     end
   end
 

--- a/spec/lib/models/good_job/execution_spec.rb
+++ b/spec/lib/models/good_job/execution_spec.rb
@@ -99,12 +99,31 @@ RSpec.describe GoodJob::Execution do
         4.times do
           described_class.perform_with_advisory_lock
         end
-
         expect(described_class.all.order(finished_at: :asc).to_a).to eq([
                                                                           high_priority_job,
                                                                           low_priority_job,
                                                                           older_job,
                                                                           newer_job,
+                                                                        ])
+      end
+    end
+
+    context "with multiple jobs and ordered queues" do
+      def job_params
+        { active_job_id: SecureRandom.uuid, queue_name: "default", priority: 0, serialized_params: { job_class: "TestJob" } }
+      end
+
+      let(:parsed_queues) { { include: %w{one two}, ordered_queues: true } }
+      let!(:queue_two_job) { described_class.create!(job_params.merge(queue_name: "two", created_at: 10.minutes.ago, priority: 100)) }
+      let!(:queue_one_job) { described_class.create!(job_params.merge(queue_name: "one", created_at: 1.minute.ago, priority: 1)) }
+
+      it "orders by queue order" do
+        2.times do
+          described_class.perform_with_advisory_lock(parsed_queues: parsed_queues)
+        end
+        expect(described_class.all.order(finished_at: :asc).to_a).to eq([
+                                                                          queue_one_job,
+                                                                          queue_two_job,
                                                                         ])
       end
     end
@@ -148,6 +167,15 @@ RSpec.describe GoodJob::Execution do
     it 'accepts empty strings' do
       query = described_class.queue_string('')
       expect(query.to_sql).to eq described_class.all.to_sql
+    end
+  end
+
+  describe '.queue_ordered' do
+    it "produces SQL to order by queue order" do
+      query_sql = described_class.queue_ordered(%w{one two three}).to_sql
+      expect(query_sql).to include(
+        "ORDER BY (CASE WHEN queue_name = 'one' THEN 0 WHEN queue_name = 'two' THEN 1 WHEN queue_name = 'three' THEN 2 ELSE 3 END)"
+      )
     end
   end
 

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_02_200139) do
+ActiveRecord::Schema.define(version: 2022_06_30_200758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
Just an experiment, to have some concrete code to talk about, and to give me an exersize. 

See: https://github.com/bensheldon/good_job/discussions/624

Although I'm interested in it, I also understand if you ultimately  think this feature is not necessary and would like to avoid it bloating the codebase.  Abstractly, you can do the same thing with priorities, although it can be less convenient to do so (in some cases extremely cumbersome), and priorities don't allow you to re-shuffle how an existing queue of jobs is handled like ordered queue workers do. 

I updated the benchmarking with more clear combinations of different sorting. Using the ordered queue feature does have some slowdown; I suspect it won't matter for good_job-scale loads, and also any performance hit from this feature will only be if you _use_ the feature, it shouldn't effect you if you don't. 

If I run the benchmark multiple times, sometimes I get some differences between examples that other times `same-ish` for. Here are two examples. 

```
Comparison:
sort by priority only:      337.0 i/s
       without sorts:      327.9 i/s - same-ish: difference falls within error
sort by creation only:      312.0 i/s - same-ish: difference falls within error
sort by priority and creation:      303.1 i/s - same-ish: difference falls within error
sort by ordered queues and creation:      269.9 i/s - same-ish: difference falls within error
sort by ordered queues only:      268.1 i/s - same-ish: difference falls within error
sort by ordered queues, priority, and creation:      209.1 i/s - 1.61x  (± 0.00) slower
```

```
Comparison:
sort by creation only:      386.7 i/s
sort by priority only:      364.7 i/s - same-ish: difference falls within error
       without sorts:      352.3 i/s - same-ish: difference falls within error
sort by priority and creation:      293.8 i/s - same-ish: difference falls within error
sort by ordered queues only:      284.3 i/s - 1.36x  (± 0.00) slower
sort by ordered queues and creation:      276.8 i/s - 1.40x  (± 0.00) slower
sort by ordered queues, priority, and creation:      226.2 i/s - 1.71x  (± 0.00) slower
```