### PR TITLE
Replace "timestamp" column-type in migrations with "datetime"

### DIFF
--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -7,9 +7,9 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :queue_name
       t.integer :priority
       t.jsonb :serialized_params
-      t.timestamp :scheduled_at
-      t.timestamp :performed_at
-      t.timestamp :finished_at
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
       t.text :error
 
       t.timestamps
@@ -18,7 +18,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :concurrency_key
       t.text :cron_key
       t.uuid :retried_good_job_id
-      t.timestamp :cron_at
+      t.datetime :cron_at
     end
 
     create_table :good_job_processes, id: :uuid do |t|

--- a/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
@@ -7,9 +7,9 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :queue_name
       t.integer :priority
       t.jsonb :serialized_params
-      t.timestamp :scheduled_at
-      t.timestamp :performed_at
-      t.timestamp :finished_at
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
       t.text :error
 
       t.timestamps
@@ -18,7 +18,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :concurrency_key
       t.text :cron_key
       t.uuid :retried_good_job_id
-      t.timestamp :cron_at
+      t.datetime :cron_at
     end
 
     create_table :good_job_processes, id: :uuid do |t|

--- a/spec/test_app/db/migrate/20200224015928_create_good_jobs.rb
+++ b/spec/test_app/db/migrate/20200224015928_create_good_jobs.rb
@@ -7,9 +7,9 @@ class CreateGoodJobs < ActiveRecord::Migration[5.2]
       t.text :queue_name
       t.integer :priority
       t.jsonb :serialized_params
-      t.timestamp :scheduled_at
-      t.timestamp :performed_at
-      t.timestamp :finished_at
+      t.datetime :scheduled_at
+      t.datetime :performed_at
+      t.datetime :finished_at
       t.text :error
 
       t.timestamps

--- a/spec/test_app/db/migrate/20211011221037_add_cron_at_to_good_jobs.rb
+++ b/spec/test_app/db/migrate/20211011221037_add_cron_at_to_good_jobs.rb
@@ -9,6 +9,6 @@ class AddCronAtToGoodJobs < ActiveRecord::Migration[5.2]
       end
     end
 
-    add_column :good_jobs, :cron_at, :timestamp
+    add_column :good_jobs, :cron_at, :datetime
   end
 end


### PR DESCRIPTION
Connects to #668 