### PR TITLE
Show basename of proctitle

### DIFF
--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -25,10 +25,10 @@
       <div id="<%= dom_id(process) %>" class="<%= dom_class(process) %> list-group-item py-3" role="row">
         <div class="row align-items-center">
           <div class="col">
-            <code class="font-monospace">
+            <%= tag.code title: process.state['proctitle'], class: "font-monospace" do %>
               <span class="text-muted opacity-50">$</span>
               <%= process.basename %>
-            </code>
+            <% end %>
             <div>
               <span class="text-muted small">PID</span>
               <span class="badge rounded-pill bg-light text-dark"><%= process.state["pid"] %></span>

--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -27,7 +27,7 @@
           <div class="col">
             <code class="font-monospace">
               <span class="text-muted opacity-50">$</span>
-              <%= process.state["proctitle"] %>
+              <%= process.basename %>
             </code>
             <div>
               <span class="text-muted small">PID</span>

--- a/lib/models/good_job/process.rb
+++ b/lib/models/good_job/process.rb
@@ -71,5 +71,9 @@ module GoodJob # :nodoc:
       destroy!
       advisory_unlock
     end
+
+    def basename
+      File.basename(state["proctitle"])
+    end
   end
 end

--- a/spec/lib/models/good_job/process_spec.rb
+++ b/spec/lib/models/good_job/process_spec.rb
@@ -48,16 +48,16 @@ RSpec.describe GoodJob::Process do
   end
 
   describe '#basename' do
-    subject { described_class.new state: {} }
+    let(:process) { described_class.new state: {} }
 
     it 'splits proctitle on dir and program name' do
-      subject.state['proctitle'] = '/app/bin/good_job'
-      expect(subject.basename).to eq('good_job')
+      process.state['proctitle'] = '/app/bin/good_job'
+      expect(process.basename).to eq('good_job')
     end
 
     it 'preserves program arguments' do
-      subject.state['proctitle'] = '/Users/me/projects/good_job/bin/bundle exec rails start'
-      expect(subject.basename).to eq('bundle exec rails start')
+      process.state['proctitle'] = '/Users/me/projects/good_job/bin/bundle exec rails start'
+      expect(process.basename).to eq('bundle exec rails start')
     end
   end
 end

--- a/spec/lib/models/good_job/process_spec.rb
+++ b/spec/lib/models/good_job/process_spec.rb
@@ -46,4 +46,18 @@ RSpec.describe GoodJob::Process do
       expect { process.deregister }.to change(described_class, :count).by(-1)
     end
   end
+
+  describe '#basename' do
+    subject { described_class.new state: {} }
+
+    it 'splits proctitle on dir and program name' do
+      subject.state['proctitle'] = '/app/bin/good_job'
+      expect(subject.basename).to eq('good_job')
+    end
+
+    it 'preserves program arguments' do
+      subject.state['proctitle'] = '/Users/me/projects/good_job/bin/bundle exec rails start'
+      expect(subject.basename).to eq('bundle exec rails start')
+    end
+  end
 end


### PR DESCRIPTION
This is just a quick tweak to the processes page to shorter the `proctitle` to just the basename.

## Before

<img width="688" alt="image" src="https://user-images.githubusercontent.com/173/180782641-c317ff31-16e8-4a31-9945-d0acc22c502f.png">

## After

<img width="441" alt="image" src="https://user-images.githubusercontent.com/173/180782685-ec953611-5393-4588-b7f1-b40f6a9d705c.png">
