### PR TITLE
Defer setting Adapter's execution mode until Rails initializes

### DIFF
--- a/spec/test_app/config/secrets.yml
+++ b/spec/test_app/config/secrets.yml
@@ -7,5 +7,8 @@ development:
 test:
   <<: *defaults
 
+demo:
+  <<: *defaults
+
 production:
   <<: *defaults


### PR DESCRIPTION
Fixes a bug in which an Adapter may be initialized with an execution mode before all Rails config/initializers have run. 

Introduced by #681.