### PR TITLE
Allow concurrency limits to be configured dynamically with lambda/proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,15 +406,18 @@ class MyJob < ApplicationJob
 
   good_job_control_concurrency_with(
     # Maximum number of unfinished jobs to allow with the concurrency key
+    # Can be an Integer or Lambda/Proc that is invoked in the context of the job
     total_limit: 1,
 
     # Or, if more control is needed:
     # Maximum number of jobs with the concurrency key to be
     # concurrently enqueued (excludes performing jobs)
+    # Can be an Integer or Lambda/Proc that is invoked in the context of the job
     enqueue_limit: 2,
 
     # Maximum number of jobs with the concurrency key to be
     # concurrently performed (excludes enqueued jobs)
+    # Can be an Integer or Lambda/Proc that is invoked in the context of the job
     perform_limit: 1,
 
     # Note: Under heavy load, the total number of jobs may exceed the

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
     describe 'total_limit:', skip_rails_5: true do
       before do
         TestJob.good_job_control_concurrency_with(
-          total_limit: 1,
+          total_limit: -> { 1 },
           key: -> { arguments.first[:name] }
         )
       end
@@ -42,7 +42,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
     describe 'enqueue_limit:', skip_rails_5: true do
       before do
         TestJob.good_job_control_concurrency_with(
-          enqueue_limit: 2,
+          enqueue_limit: -> { 2 },
           key: -> { arguments.first[:name] }
         )
       end
@@ -78,7 +78,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         allow(GoodJob).to receive(:preserve_job_records).and_return(true)
 
         TestJob.good_job_control_concurrency_with(
-          perform_limit: 0,
+          perform_limit: -> { 0 },
           key: -> { arguments.first[:name] }
         )
       end


### PR DESCRIPTION
Adds the ability to set dynamic concurrency limits (i.e. `total_limit`, `enqueue_limit`, and `perform_limit`) via a proc similar to how a key can be set via a proc. Discussed in issue https://github.com/bensheldon/good_job/issues/684.