### PR TITLE
Dashboard: Remove translation_missing red highlighting; remove number_to_human.hundreds; add form labels

### DIFF
--- a/app/assets/good_job/style.css
+++ b/app/assets/good_job/style.css
@@ -35,11 +35,6 @@
   z-index: 1;
 }
 
-.translation_missing {
-  background-color: red;
-  color: white;
-}
-
 .btn-outline-secondary {
   border-color: #ced4da; /* $gray-400 */
 }

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -4,6 +4,7 @@
     <header class="list-group-item bg-light">
       <div class="row small text-muted text-uppercase align-items-center">
         <div class="col-auto">
+          <%= label_tag('toggle_job_ids', "Toggle all jobs", class: "visually-hidden") %>
           <%= check_box_tag('toggle_job_ids', "1", false, data: { "checkbox-toggle-all": "job_ids" }) %>
         </div>
         <div class="col-4">

--- a/app/views/good_job/shared/_filter.erb
+++ b/app/views/good_job/shared/_filter.erb
@@ -8,6 +8,7 @@
       <%= hidden_field_tag :locale, params[:locale] if params[:locale] %>
       <div class="d-flex flex-row w-100">
         <div class="me-2">
+          <%= label_tag "job_queue_filter", "Queue name", class: "visually-hidden" %>
           <select name="queue_name" id="job_queue_filter" class="form-select form-select-sm">
             <option value="" <%= "selected='selected'" if params[:queue_name].blank? %>>All queues</option>
 
@@ -18,6 +19,7 @@
         </div>
 
         <div class="me-2">
+          <%= label_tag "job_class_filter", "Job name", class: "visually-hidden" %>
           <select name="job_class" id="job_class_filter" class="form-select form-select-sm">
             <option value="" <%= "selected='selected'" if params[:job_class].blank? %>>All jobs</option>
 
@@ -28,6 +30,7 @@
         </div>
 
         <div class="me-2 flex-fill">
+          <%= label_tag "query", "Search", class: "visually-hidden" %>
           <%= search_field_tag "query", params[:query], class: "form-control form-control-sm", placeholder: "Search by class, job id, job params, and error text." %>
         </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,6 @@ en:
         format: "%n%u"
         units:
           billion: B
-          hundred: ''
           million: M
           quadrillion: Q
           thousand: K

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -72,7 +72,6 @@ es:
         format: "%n%u"
         units:
           billion: B
-          hundred: ''
           million: M
           quadrillion: q
           thousand: k

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -72,7 +72,6 @@ nl:
         format: "%n%u"
         units:
           billion: B
-          hundred: ''
           million: M
           quadrillion: Q
           thousand: K

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -96,7 +96,6 @@ ru:
         format: "%n%u"
         units:
           billion: Б
-          hundred: ''
           million: М
           quadrillion: Q
           thousand: К


### PR DESCRIPTION
Some small Dashboard improvements:

- Remove red highlighting of mission translations. Problematic in #707 
- Remove the `number_to_human` key for hundreds because it led to weird output like (`2,04` for 204)
- Add missing form labels to input fields