### PR TITLE
Sentry integration Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Rails.application.configure do
   # Configure options individually...
   config.good_job.preserve_job_records = true
   config.good_job.retry_on_unhandled_error = false
-  config.good_job.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+  config.good_job.on_thread_error = -> (exception) { Sentry.capture_exception(exception) }
   config.good_job.execution_mode = :async
   config.good_job.queues = '*'
   config.good_job.max_threads = 5
@@ -245,7 +245,7 @@ Rails.application.configure do
   config.good_job = {
     preserve_job_records: true,
     retry_on_unhandled_error: false,
-    on_thread_error: -> (exception) { Raven.capture_exception(exception) },
+    on_thread_error: -> (exception) { Sentry.capture_exception(exception) },
     execution_mode: :async,
     queues: '*',
     max_threads: 5,
@@ -287,7 +287,7 @@ Available configuration options are:
 - `on_thread_error` (proc, lambda, or callable) will be called when an Exception. It can be useful for logging errors to bug tracking services, like Sentry or Airbrake. Example:
 
     ```ruby
-    config.good_job.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+    config.good_job.on_thread_error = -> (exception) { Sentry.capture_exception(exception) }
     ```
 
 By default, GoodJob configures the following execution modes per environment:
@@ -567,7 +567,7 @@ If errors do reach GoodJob, you can assign a callable to `GoodJob.on_thread_erro
 
 ```ruby
 # config/initializers/good_job.rb
-GoodJob.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+GoodJob.on_thread_error = -> (exception) { Sentry.capture_exception(exception) }
 ```
 
 #### Retries
@@ -601,13 +601,13 @@ class ApplicationJob < ActiveJob::Base
   retry_on StandardError, wait: :exponentially_longer, attempts: Float::INFINITY
 
   retry_on SpecialError, attempts: 5 do |_job, exception|
-    Raven.capture_exception(exception)
+    Sentry.capture_exception(exception)
   end
 
   around_perform do |_job, block|
     block.call
   rescue StandardError => e
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     raise
   end
   # ...
@@ -630,7 +630,7 @@ ActionMailer::MailDeliveryJob.retry_on StandardError, wait: :exponentially_longe
 ActionMailer::MailDeliveryJob.around_perform do |_job, block|
   block.call
 rescue StandardError => e
-  Raven.capture_exception(e)
+  Sentry.capture_exception(e)
   raise
 end
 ```


### PR DESCRIPTION
`sentry-raven` was outdated and `Raven` was renamed to `Sentry`.