### PR TITLE
Support SemanticLogger logging with improve stdout logic and tagged logs

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -156,7 +156,7 @@ module GoodJob
       # Rails or from the application can be set up here.
       def set_up_application!
         require RAILS_ENVIRONMENT_RB
-        return unless GoodJob::CLI.log_to_stdout? && !ActiveSupport::Logger.logger_outputs_to?(GoodJob.logger, $stdout)
+        return if !GoodJob::CLI.log_to_stdout? || ActiveSupport::Logger.logger_outputs_to?(GoodJob.logger, $stdout)
 
         GoodJob::LogSubscriber.loggers << ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
         GoodJob::LogSubscriber.reset_logger

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -206,7 +206,7 @@ module GoodJob
       good_job_tag = ["ActiveJob"].freeze
 
       self.class.loggers.inject(block) do |inner, each_logger|
-        if each_logger.respond_to?(:tagged) && each_logger.formatter
+        if each_logger.respond_to?(:tagged) && each_logger.try(:formatter).try(:current_tags).respond_to?(:include?)
           tags_for_logger = if each_logger.formatter.current_tags.include?("ActiveJob")
                               good_job_tag + tags
                             else


### PR DESCRIPTION
Closes #667.

- Semantic logger overrides `ActiveSupport::Logger.logger_outputs_to?` to [always return true](https://github.com/reidmorrison/rails_semantic_logger/blob/1d49b514cf26d9c2f2b683fa6c207d8437ffd1f6/lib/rails_semantic_logger/extensions/active_support/logger.rb#L11-L13)
- Being extra defensive with the tagged logging construction; at expense of performance (but probably fine).