### PR TITLE
When not preserving job records, ensure all prior executions are deleted after successful retry

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -66,7 +66,7 @@ module GoodJob
     end
 
     belongs_to :job, class_name: 'GoodJob::Job', foreign_key: 'active_job_id', primary_key: 'active_job_id', optional: true, inverse_of: :executions
-    after_destroy -> { self.class.active_job_id(active_job_id).delete_all }
+    after_destroy -> { self.class.active_job_id(active_job_id).delete_all }, if: -> { @_destroy_job }
 
     # Get Jobs with given ActiveJob ID
     # @!method active_job_id
@@ -299,11 +299,11 @@ module GoodJob
 
       if result.unhandled_error && GoodJob.retry_on_unhandled_error
         save!
-      elsif GoodJob.preserve_job_records == true || (result.unhandled_error && GoodJob.preserve_job_records == :on_unhandled_error)
+      elsif GoodJob.preserve_job_records == true || result.retried? || (result.unhandled_error && GoodJob.preserve_job_records == :on_unhandled_error)
         self.finished_at = Time.current
         save!
       else
-        destroy!
+        destroy_job
       end
 
       result
@@ -355,6 +355,14 @@ module GoodJob
       (finished_at || Time.zone.now) - performed_at if performed_at
     end
 
+    # Destroys this execution and all executions within the same job
+    def destroy_job
+      @_destroy_job = true
+      destroy!
+    ensure
+      @_destroy_job = false
+    end
+
     private
 
     def active_job_data
@@ -380,7 +388,7 @@ module GoodJob
           end
           handled_error ||= current_thread.error_on_retry || current_thread.error_on_discard
 
-          ExecutionResult.new(value: value, handled_error: handled_error)
+          ExecutionResult.new(value: value, handled_error: handled_error, retried: current_thread.error_on_retry.present?)
         rescue StandardError => e
           ExecutionResult.new(value: nil, unhandled_error: e)
         end

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -66,6 +66,7 @@ module GoodJob
     end
 
     belongs_to :job, class_name: 'GoodJob::Job', foreign_key: 'active_job_id', primary_key: 'active_job_id', optional: true, inverse_of: :executions
+    after_destroy -> { self.class.active_job_id(active_job_id).delete_all }
 
     # Get Jobs with given ActiveJob ID
     # @!method active_job_id

--- a/app/models/good_job/execution_result.rb
+++ b/app/models/good_job/execution_result.rb
@@ -8,14 +8,18 @@ module GoodJob
     attr_reader :handled_error
     # @return [Exception, nil]
     attr_reader :unhandled_error
+    # @return [Exception, nil]
+    attr_reader :retried
+    alias retried? retried
 
     # @param value [Object, nil]
     # @param handled_error [Exception, nil]
     # @param unhandled_error [Exception, nil]
-    def initialize(value:, handled_error: nil, unhandled_error: nil)
+    def initialize(value:, handled_error: nil, unhandled_error: nil, retried: false)
       @value = value
       @handled_error = handled_error
       @unhandled_error = unhandled_error
+      @retried = retried
     end
   end
 end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -57,7 +57,7 @@ module GoodJob
   #   By default, GoodJob deletes job records after the job is completed successfully.
   #   If you want to preserve jobs for latter inspection, set this to +true+.
   #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_unhandled_error+.
-  #   @return [Boolean, nil]
+  #   @return [Boolean, Symbol, nil]
   mattr_accessor :preserve_job_records, default: true
 
   # @!attribute [rw] retry_on_unhandled_error

--- a/spec/app/models/good_job/execution_spec.rb
+++ b/spec/app/models/good_job/execution_spec.rb
@@ -523,6 +523,19 @@ RSpec.describe GoodJob::Execution do
     end
   end
 
+  describe '#destroy_job' do
+    let!(:execution) { described_class.create! active_job_id: SecureRandom.uuid }
+    let!(:prior_execution) { described_class.create! active_job_id: execution.active_job_id }
+    let!(:other_job) { described_class.create! active_job_id: SecureRandom.uuid }
+
+    it 'destroys all of the job executions' do
+      execution.destroy_job
+      expect { execution.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { prior_execution.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { other_job.reload }.not_to raise_error
+    end
+  end
+
   describe '#queue_latency' do
     let(:execution) { described_class.create! }
 

--- a/spec/test_app/config/environments/test.rb
+++ b/spec/test_app/config/environments/test.rb
@@ -4,8 +4,8 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
-  config.cache_classes = false
-  config.eager_load = false
+  config.cache_classes = true
+  config.eager_load = true
 
   # Raises error for missing translations.
   if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')


### PR DESCRIPTION
When records are configured to be preserved on `on_unhandled_error`, and later retried, the previous executions stay in the database and become "orphaned". I believe they should be deleted on a successful retry. This would bring it inline with the behavior for destroying a failed job (eg. via the UI) which results in previous executions also being deleted.

This is my first contribution to this repo. I took a stab at writing a spec that exposes the issue and a fix via a ActiveRecord callback. I am open to suggestions for improvement.

Thank you for making `good_job` available and open source!