### PR TITLE
Rename Job status of `finished` to `succeeded`; `finished` now means either `succeeded` or `discarded`

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ GoodJob includes a Dashboard as a mountable `Rails::Engine`.
     end
     ```
 
-_To view finished (successful) and discarded (failed) jobs on the Dashboard, GoodJob must be configured to preserve job records. Preservation is enabled by default._
+_To view finished jobs (succeeded and discarded) on the Dashboard, GoodJob must be configured to preserve job records. Preservation is enabled by default._
 
 **Troubleshooting the Dashboard:** Some applications are unable to autoload the Goodjob Engine. To work around this, explicitly require the Engine at the top of your `config/application.rb` file, immediately after Rails is required and before Bundler requires the Rails' groups.
 

--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -8,7 +8,7 @@ module GoodJob
         'retried' => query.retried.count,
         'queued' => query.queued.count,
         'running' => query.running.count,
-        'finished' => query.finished.count,
+        'succeeded' => query.succeeded.count,
         'discarded' => query.discarded.count,
       }
     end
@@ -25,8 +25,8 @@ module GoodJob
         case filter_params[:state]
         when 'discarded'
           query = query.discarded
-        when 'finished'
-          query = query.finished
+        when 'succeeded'
+          query = query.succeeded
         when 'retried'
           query = query.retried
         when 'scheduled'

--- a/app/helpers/good_job/application_helper.rb
+++ b/app/helpers/good_job/application_helper.rb
@@ -24,7 +24,7 @@ module GoodJob
 
     STATUS_ICONS = {
       discarded: "exclamation",
-      finished: "check",
+      succeeded: "check",
       queued: "dash_circle",
       retried: "arrow_clockwise",
       running: "play",
@@ -33,7 +33,7 @@ module GoodJob
 
     STATUS_COLOR = {
       discarded: "danger",
-      finished: "success",
+      succeeded: "success",
       queued: "secondary",
       retried: "warning",
       running: "primary",

--- a/app/models/concerns/good_job/reportable.rb
+++ b/app/models/concerns/good_job/reportable.rb
@@ -8,8 +8,8 @@ module GoodJob
     #     - retried: The job previously errored on execution and will be re-executed in the future.
     #   2. The job is being executed
     #     - running: the job is actively being executed by an execution thread
-    #   3. The job will not execute
-    #     - finished: The job executed successfully
+    #   3. The job has finished
+    #     - succeeded: The job executed successfully
     #     - discarded: The job previously errored on execution and will not be re-executed in the future.
     #
     # @return [Symbol]
@@ -20,7 +20,7 @@ module GoodJob
         elsif error.present? && retried_good_job_id.nil?
           :discarded
         else
-          :finished
+          :succeeded
         end
       elsif (scheduled_at || created_at) > DateTime.current
         if serialized_params.fetch('executions', 0) > 1

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -68,7 +68,7 @@ module GoodJob
     belongs_to :job, class_name: 'GoodJob::Job', foreign_key: 'active_job_id', primary_key: 'active_job_id', optional: true, inverse_of: :executions
     after_destroy -> { self.class.active_job_id(active_job_id).delete_all }, if: -> { @_destroy_job }
 
-    # Get Jobs with given ActiveJob ID
+    # Get executions with given ActiveJob ID
     # @!method active_job_id
     # @!scope class
     # @param active_job_id [String]
@@ -76,7 +76,7 @@ module GoodJob
     # @return [ActiveRecord::Relation]
     scope :active_job_id, ->(active_job_id) { where(active_job_id: active_job_id) }
 
-    # Get Jobs with given class name
+    # Get executions with given class name
     # @!method job_class
     # @!scope class
     # @param string [String]
@@ -84,32 +84,32 @@ module GoodJob
     # @return [ActiveRecord::Relation]
     scope :job_class, ->(job_class) { where("serialized_params->>'job_class' = ?", job_class) }
 
-    # Get Jobs that have not yet been completed.
+    # Get executions that have not yet finished (succeeded or discarded).
     # @!method unfinished
     # @!scope class
     # @return [ActiveRecord::Relation]
     scope :unfinished, -> { where(finished_at: nil) }
 
-    # Get Jobs that are not scheduled for a later time than now (i.e. jobs that
+    # Get executions that are not scheduled for a later time than now (i.e. jobs that
     # are not scheduled or scheduled for earlier than the current time).
     # @!method only_scheduled
     # @!scope class
     # @return [ActiveRecord::Relation]
     scope :only_scheduled, -> { where(arel_table['scheduled_at'].lteq(Time.current)).or(where(scheduled_at: nil)) }
 
-    # Order jobs by priority (highest priority first).
+    # Order executions by priority (highest priority first).
     # @!method priority_ordered
     # @!scope class
     # @return [ActiveRecord::Relation]
     scope :priority_ordered, -> { order('priority DESC NULLS LAST') }
 
-    # Order jobs by created_at, for first-in first-out
+    # Order executions by created_at, for first-in first-out
     # @!method creation_ordered
     # @!scope class
     # @return [ActiveRecord:Relation]
     scope :creation_ordered, -> { order('created_at ASC') }
 
-    # Order jobs for de-queueing
+    # Order executions for de-queueing
     # @!method dequeueing_ordered
     # @!scope class
     # @param parsed_queues [Hash]
@@ -124,7 +124,7 @@ module GoodJob
       relation
     end)
 
-    # Order jobs in order of queues in array param
+    # Order executions in order of queues in array param
     # @!method queue_ordered
     # @!scope class
     # @param queues [Array<string] ordered names of queues

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -75,7 +75,7 @@
               <span class="font-monospace fw-bold"><%= job.priority %></span>
             </div>
             <div class="col-1 text-center">
-              <% if job.executions_count > 0 && job.status != :finished %>
+              <% if job.executions_count > 0 && job.status != :succeeded %>
                 <%= tag.span job.executions_count, class: "badge rounded-pill bg-danger", data: {
                       bs_toggle: "popover",
                       bs_trigger: "hover focus click",
@@ -118,7 +118,7 @@
                     <% end %>
                   </li>
                   <li>
-                    <%= link_to job_path(job.id), method: :delete, class: "dropdown-item #{'disabled' unless job.status.in? [:discarded, :finished]}", title: "Destroy job", data: { confirm: "Confirm destroy", disable: true } do %>
+                    <%= link_to job_path(job.id), method: :delete, class: "dropdown-item #{'disabled' unless job.status.in? [:discarded, :succeeded]}", title: "Destroy job", data: { confirm: "Confirm destroy", disable: true } do %>
                       <%= render_icon "trash" %>
                       Destroy
                     <% end %>

--- a/app/views/good_job/jobs/show.html.erb
+++ b/app/views/good_job/jobs/show.html.erb
@@ -47,7 +47,7 @@
           <% end %>
         <% end %>
 
-        <% if @job.status.in? [:discarded, :finished] %>
+        <% if @job.status.in? [:discarded, :succeeded] %>
           <%= button_to job_path(@job.id), method: :delete, class: "btn btn-sm btn-outline-primary", form_class: "d-inline-block", aria: { label: "Destroy job" }, title: "Destroy job", data: { confirm: "Confirm destroy" } do %>
             <%= render_icon "trash" %>
             Destroy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,11 +58,11 @@ en:
         processes: Processes
     status:
       discarded: Discarded
-      finished: Finished
       queued: Queued
       retried: Retried
       running: Running
       scheduled: Scheduled
+      succeeded: Succeeded
   number:
     format:
       delimiter: ","

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -58,11 +58,11 @@ es:
         processes: Procesos
     status:
       discarded: Descartado
-      finished: Acabado
       queued: Puesto en cola
       retried: reintentado
       running: Corriendo
       scheduled: Programado
+      succeeded: Acierto
   number:
     format:
       delimiter: " "

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -58,11 +58,11 @@ nl:
         processes: Processen
     status:
       discarded: weggegooid
-      finished: Afgewerkt
       queued: In de wachtrij
       retried: Opnieuw geprobeerd
       running: Rennen
       scheduled: Gepland
+      succeeded: Geslaagd
   number:
     format:
       delimiter: "."

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -82,11 +82,11 @@ ru:
         processes: Процессы
     status:
       discarded: Отброшено
-      finished: Законченный
       queued: В очереди
       retried: Повторная попытка
       running: Бег
       scheduled: по расписанию
+      succeeded: удалось
   number:
     format:
       delimiter: " "

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -157,7 +157,7 @@ module GoodJob
 
     ActiveSupport::Notifications.instrument("cleanup_preserved_jobs.good_job", { older_than: older_than, timestamp: timestamp }) do |payload|
       old_jobs = GoodJob::Job.where('finished_at <= ?', timestamp)
-      old_jobs = old_jobs.not_discarded unless include_discarded
+      old_jobs = old_jobs.succeeded unless include_discarded
       old_jobs_count = old_jobs.count
 
       GoodJob::Execution.where(job: old_jobs).delete_all

--- a/spec/app/filters/good_job/jobs_filter_spec.rb
+++ b/spec/app/filters/good_job/jobs_filter_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe GoodJob::JobsFilter do
                                     "retried" => 0,
                                     "queued" => 0,
                                     "running" => 1,
-                                    "finished" => 2,
+                                    "succeeded" => 2,
                                     "discarded" => 1,
                                   })
     end

--- a/spec/requests/good_job/jobs_controller_spec.rb
+++ b/spec/requests/good_job/jobs_controller_spec.rb
@@ -145,7 +145,7 @@ describe GoodJob::JobsController, type: :request do
         put good_job.mass_update_jobs_path, params: {
           mass_action: 'discard',
           all_job_ids: 1,
-          state: 'finished',
+          state: 'succeeded',
         }
 
         expect(response).to have_http_status(:found)


### PR DESCRIPTION
This aligns status names with #712.

Previously, a job was either `finished` or `discarded`.

Now, a job is `finished`, which can be either `succeeded` (run fully once without error) or `discarded` (errored and was not retried)