### PR TITLE
Add index to `good_jobs` to improve querying candidate jobs

### DIFF
--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -41,7 +41,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
     add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
-    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
       where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
   end
 end

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -41,5 +41,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
     add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+   def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_jobs_on_priority_created_at_when_unfinished)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+  end
+end

--- a/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
@@ -11,7 +11,8 @@ class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::M
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
-      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+      algorithm: :concurrently
   end
 end

--- a/spec/test_app/db/migrate/20221019021425_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/spec/test_app/db/migrate/20221019021425_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -11,7 +11,8 @@ class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::M
       end
     end
 
-    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
-      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished,
+      algorithm: :concurrently
   end
 end

--- a/spec/test_app/db/migrate/20221019021425_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
+++ b/spec/test_app/db/migrate/20221019021425_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+   def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_jobs_jobs_on_priority_created_at_when_unfinished)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: {priority: "DESC NULLS LAST", created_at: :asc},
+      where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+  end
+end

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_20_154438) do
+ActiveRecord::Schema.define(version: 2022_10_19_021425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2022_07_20_154438) do
     t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at"
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at", unique: true
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end


### PR DESCRIPTION
I think we might be having the same issue as described in https://github.com/bensheldon/good_job/issues/720 and the index appears to help quite a bit.

I tried to follow the index naming scheme, but the name is a bit wordy, so I wasn't sure 🙂

<details>
<summary>
SQL Explain on a `good_jobs` table with hundreds of thousands of unfinished jobs
</summary>

```sql
EXPLAIN ANALYZE SELECT "good_jobs".* FROM "good_jobs" WHERE "good_jobs"."id" IN (WITH "rows" AS MATERIALIZED ( SELECT "good_jobs"."id", "good_jobs"."active_job_id" FROM "good_jobs" WHERE "good_jobs"."finished_at" IS NULL AND ("good_jobs"."scheduled_at" <= '2022-10-19 01:31:28.921876' OR "good_jobs"."scheduled_at" IS NULL) ORDER BY priority DESC NULLS LAST, created_at ASC ) SELECT "rows"."id" FROM "rows" WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || '-' || "rows"."active_job_id"::text), 1, 16))::bit(64)::bigint) LIMIT 1) ORDER BY priority DESC NULLS LAST, created_at ASC;
```

```
# Before index
 Sort  (cost=106863.51..106863.52 rows=1 width=511) (actual time=1138.681..1138.684 rows=1 loops=1)
   Sort Key: good_jobs.priority DESC NULLS LAST, good_jobs.created_at
   Sort Method: quicksort  Memory: 25kB
   ->  Nested Loop  (cost=106855.47..106863.50 rows=1 width=511) (actual time=1138.661..1138.664 rows=1 loops=1)
         ->  HashAggregate  (cost=106855.05..106855.06 rows=1 width=16) (actual time=1138.620..1138.622 rows=1 loops=1)
               Group Key: rows.id
               Batches: 1  Memory Usage: 24kB
               ->  Limit  (cost=106854.89..106855.04 rows=1 width=16) (actual time=1138.612..1138.613 rows=1 loops=1)
                     CTE rows
                       ->  Sort  (cost=105458.51..106854.89 rows=558553 width=44) (actual time=1138.590..1138.591 rows=1 loops=1)
                             Sort Key: good_jobs_1.priority DESC NULLS LAST, good_jobs_1.created_at
                             Sort Method: external merge  Disk: 31768kB
                             ->  Seq Scan on good_jobs good_jobs_1  (cost=0.00..34955.90 rows=558553 width=44) (actual time=0.056..374.313 rows=558583 loops=1)
                                   Filter: ((finished_at IS NULL) AND ((scheduled_at <= '2022-10-19 01:31:28.921876'::timestamp without time zone) OR (scheduled_at IS NULL)))
                                   Rows Removed by Filter: 488
                     ->  CTE Scan on rows  (cost=0.00..26531.27 rows=186184 width=16) (actual time=1138.610..1138.611 rows=1 loops=1)
                           Filter: pg_try_advisory_lock(((('x'::text || substr(md5(('good_jobs-'::text || (active_job_id)::text)), 1, 16)))::bit(64))::bigint)
         ->  Index Scan using good_jobs_pkey on good_jobs  (cost=0.42..8.44 rows=1 width=511) (actual time=0.035..0.035 rows=1 loops=1)
               Index Cond: (id = rows.id)
 Planning Time: 1.805 ms
 Execution Time: 1156.305 ms
 (21 rows)
```

```
# After index
 Sort  (cost=104596.63..104596.63 rows=1 width=508) (actual time=0.094..0.096 rows=1 loops=1)
   Sort Key: good_jobs.priority DESC NULLS LAST, good_jobs.created_at
   Sort Method: quicksort  Memory: 25kB
   ->  Nested Loop  (cost=104588.59..104596.62 rows=1 width=508) (actual time=0.082..0.084 rows=1 loops=1)
         ->  HashAggregate  (cost=104588.17..104588.18 rows=1 width=16) (actual time=0.064..0.066 rows=1 loops=1)
               Group Key: rows.id
               Batches: 1  Memory Usage: 24kB
               ->  Limit  (cost=104588.01..104588.15 rows=1 width=16) (actual time=0.059..0.060 rows=1 loops=1)
                     CTE rows
                       ->  Index Scan using index_good_jobs_jobs_on_priority_created_at_when_unfinished on good_jobs good_jobs_1  (cost=0.42..104588.01 rows=703427 width=44) (actual time=0.041..0.041 rows=1 loops=1)
                             Filter: ((scheduled_at <= '2022-10-19 01:31:28.921876'::timestamp without time zone) OR (scheduled_at IS NULL))
                     ->  CTE Scan on rows  (cost=0.00..33412.78 rows=234476 width=16) (actual time=0.058..0.058 rows=1 loops=1)
                           Filter: pg_try_advisory_lock(((('x'::text || substr(md5(('good_jobs-'::text || (active_job_id)::text)), 1, 16)))::bit(64))::bigint)
         ->  Index Scan using good_jobs_pkey on good_jobs  (cost=0.42..8.44 rows=1 width=508) (actual time=0.014..0.014 rows=1 loops=1)
               Index Cond: (id = rows.id)
 Planning Time: 0.443 ms
 Execution Time: 0.210 ms
(17 rows)
```