### PR TITLE
Add configurable limit (`queue_select_limit`) when querying candidate jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Options:
   [--daemonize]                # Run as a background daemon (default: false)
   [--pidfile=PIDFILE]          # Path to write daemonized Process ID (env var: GOOD_JOB_PIDFILE, default: tmp/pids/good_job.pid)
   [--probe-port=PORT]          # Port for http health check (env var: GOOD_JOB_PROBE_PORT, default: nil)
+  [--queue-select-limit=COUNT] # The number of queued jobs to select when polling for a job to run. (env var: GOOD_JOB_QUEUE_SELECT_LIMIT, default: nil)"
 
 Executes queued jobs.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
     - [Optimize queues, threads, and processes](#optimize-queues-threads-and-processes)
     - [Database connections](#database-connections)
         - [Production setup](#production-setup)
+        - [Queue performance with Queue Select Limit](#queue-performance-with-queue-select-limit)
     - [Execute jobs async / in-process](#execute-jobs-async--in-process)
     - [Migrate to GoodJob from a different ActiveJob backend](#migrate-to-goodjob-from-a-different-activejob-backend)
     - [Monitor and preserve worked jobs](#monitor-and-preserve-worked-jobs)
@@ -757,6 +758,45 @@ The recommended way to monitor the queue in production is:
 - if possible, run the queue as a dedicated instance and use available HTTP health check probes instead of pid-based monitoring
 - keep an eye on the number of jobs in the queue (abnormal high number of unscheduled jobs means the queue could be underperforming)
 - consider performance monitoring services which support the built-in Rails instrumentation (eg. Sentry, Skylight, etc.)
+
+#### Queue performance with Queue Select Limit
+
+GoodJob’s advisory locking strategy uses a materialized CTE (Common Table Expression). This strategy can be non-performant when querying a very large queue of executable jobs (100,000+) because the database query must materialize all executable jobs before acquiring an advisory lock.
+
+GoodJob offers an optional optimization to limit the number of jobs that are queried: Queue Select Limit.
+
+```none
+# CLI option
+--queue-select-limit=1000
+
+# Rails configuration
+config.good_job.queue_select_limit = 1000
+
+# Environment Variable
+GOOD_JOB_QUEUE_SELECT_LIMIT=1000
+```
+
+The Queue Select Limit value should be set to a rough upper-bound that exceeds all GoodJob execution threads / database connections. `1000` is a number that likely exceeds the available database connections on most PaaS offerings, but still offers a performance boost for GoodJob when executing very large queues.
+
+To explain where this value is used, here is the pseudo-query that GoodJob uses to find executable jobs:
+
+```sql
+  SELECT *
+  FROM good_jobs
+  WHERE id IN (
+    WITH rows AS MATERIALIZED (
+      SELECT id, active_job_id
+      FROM good_jobs
+      WHERE (scheduled_at <= NOW() OR scheduled_at IS NULL) AND finished_at IS NULL
+      ORDER BY priority DESC NULLS LAST, created_at ASC
+      [LIMIT 1000] -- <= introduced when queue_select_limit is set
+    )
+    SELECT id
+    FROM rows
+    WHERE pg_try_advisory_lock(('x' || substr(md5('good_jobs' || '-' || active_job_id::text), 1, 16))::bit(64)::bigint)
+    LIMIT 1
+  )
+```
 
 ### Execute jobs async / in-process
 

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -203,10 +203,10 @@ module GoodJob
     #   return value for the job's +#perform+ method, and the exception the job
     #   raised, if any (if the job raised, then the second array entry will be
     #   +nil+). If there were no jobs to execute, returns +nil+.
-    def self.perform_with_advisory_lock(parsed_queues: nil)
+    def self.perform_with_advisory_lock(parsed_queues: nil, queue_select_limit: nil)
       execution = nil
       result = nil
-      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true) do |executions|
+      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true, queue_select_limit: queue_select_limit) do |executions|
         execution = executions.first
         break if execution.blank?
         break :unlocked unless execution&.executable?

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -206,7 +206,7 @@ module GoodJob
     def self.perform_with_advisory_lock(parsed_queues: nil, queue_select_limit: nil)
       execution = nil
       result = nil
-      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true, queue_select_limit: queue_select_limit) do |executions|
+      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true, select_limit: queue_select_limit) do |executions|
         execution = executions.first
         break if execution.blank?
         break :unlocked unless execution&.executable?

--- a/app/models/good_job/lockable.rb
+++ b/app/models/good_job/lockable.rb
@@ -37,11 +37,14 @@ module GoodJob
       # @param function [String, Symbol]  Postgres Advisory Lock function name to use
       # @return [ActiveRecord::Relation]
       #   A relation selecting only the records that were locked.
-      scope :advisory_lock, (lambda do |column: _advisory_lockable_column, function: advisory_lockable_function|
+      scope :advisory_lock, (lambda do |column: _advisory_lockable_column, function: advisory_lockable_function, queue_select_limit: nil|
         original_query = self
 
         cte_table = Arel::Table.new(:rows)
         cte_query = original_query.select(primary_key, column).except(:limit)
+        if queue_select_limit
+          cte_query = cte_query.limit(queue_select_limit)
+        end
         cte_type = if supports_cte_materialization_specifiers?
                      'MATERIALIZED'
                    else
@@ -154,10 +157,10 @@ module GoodJob
       #   MyLockableRecord.order(created_at: :asc).limit(2).with_advisory_lock do |record|
       #     do_something_with record
       #   end
-      def with_advisory_lock(column: _advisory_lockable_column, function: advisory_lockable_function, unlock_session: false)
+      def with_advisory_lock(column: _advisory_lockable_column, function: advisory_lockable_function, unlock_session: false, queue_select_limit: nil)
         raise ArgumentError, "Must provide a block" unless block_given?
 
-        records = advisory_lock(column: column, function: function).to_a
+        records = advisory_lock(column: column, function: function, queue_select_limit: queue_select_limit).to_a
 
         begin
           unscoped { yield(records) }

--- a/app/models/good_job/lockable.rb
+++ b/app/models/good_job/lockable.rb
@@ -37,14 +37,12 @@ module GoodJob
       # @param function [String, Symbol]  Postgres Advisory Lock function name to use
       # @return [ActiveRecord::Relation]
       #   A relation selecting only the records that were locked.
-      scope :advisory_lock, (lambda do |column: _advisory_lockable_column, function: advisory_lockable_function, queue_select_limit: nil|
+      scope :advisory_lock, (lambda do |column: _advisory_lockable_column, function: advisory_lockable_function, select_limit: nil|
         original_query = self
 
         cte_table = Arel::Table.new(:rows)
         cte_query = original_query.select(primary_key, column).except(:limit)
-        if queue_select_limit
-          cte_query = cte_query.limit(queue_select_limit)
-        end
+        cte_query = cte_query.limit(select_limit) if select_limit
         cte_type = if supports_cte_materialization_specifiers?
                      'MATERIALIZED'
                    else
@@ -157,10 +155,10 @@ module GoodJob
       #   MyLockableRecord.order(created_at: :asc).limit(2).with_advisory_lock do |record|
       #     do_something_with record
       #   end
-      def with_advisory_lock(column: _advisory_lockable_column, function: advisory_lockable_function, unlock_session: false, queue_select_limit: nil)
+      def with_advisory_lock(column: _advisory_lockable_column, function: advisory_lockable_function, unlock_session: false, select_limit: nil)
         raise ArgumentError, "Must provide a block" unless block_given?
 
-        records = advisory_lock(column: column, function: function, queue_select_limit: queue_select_limit).to_a
+        records = advisory_lock(column: column, function: function, select_limit: select_limit).to_a
 
         begin
           unscoped { yield(records) }

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -81,7 +81,12 @@ module GoodJob
                   desc: "Path to write daemonized Process ID (env var: GOOD_JOB_PIDFILE, default: tmp/pids/good_job.pid)"
     method_option :probe_port,
                   type: :numeric,
+                  banner: 'PORT',
                   desc: "Port for http health check (env var: GOOD_JOB_PROBE_PORT, default: nil)"
+    method_option :queue_select_limit,
+                  type: :numeric,
+                  banner: 'COUNT',
+                  desc: "The number of queued jobs to select when polling for a job to run. (env var: GOOD_JOB_QUEUE_SELECT_LIMIT, default: nil)"
 
     def start
       set_up_application!

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -214,12 +214,11 @@ module GoodJob
     # processes to ensure a thread can retrieve an eligible and unlocked job.
     # @return [Integer, nil]
     def queue_select_limit
-      limit =
+      (
         options[:queue_select_limit] ||
         rails_config[:queue_select_limit] ||
         env['GOOD_JOB_QUEUE_SELECT_LIMIT']
-
-      limit.to_i if limit
+      )&.to_i
     end
 
     # Whether to destroy discarded jobs when cleaning up preserved jobs.

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -26,8 +26,6 @@ module GoodJob
     DEFAULT_SHUTDOWN_TIMEOUT = -1
     # Default to not running cron
     DEFAULT_ENABLE_CRON = false
-    # Default to selecting a limit of 1,000 jobs
-    DEFAULT_QUEUE_SELECT_LIMIT = 1_000
 
     def self.validate_execution_mode(execution_mode)
       raise ArgumentError, "GoodJob execution mode must be one of #{EXECUTION_MODES.join(', ')}. It was '#{execution_mode}' which is not valid." unless execution_mode.in?(EXECUTION_MODES)
@@ -216,12 +214,12 @@ module GoodJob
     # processes to ensure a thread can retrieve an eligible and unlocked job.
     # @return [Integer, nil]
     def queue_select_limit
-      (
+      limit =
         options[:queue_select_limit] ||
-          rails_config[:queue_select_limit] ||
-          env['GOOD_JOB_QUEUE_SELECT_LIMIT'] ||
-          DEFAULT_QUEUE_SELECT_LIMIT
-      ).to_i
+        rails_config[:queue_select_limit] ||
+        env['GOOD_JOB_QUEUE_SELECT_LIMIT']
+
+      limit.to_i if limit
     end
 
     # Whether to destroy discarded jobs when cleaning up preserved jobs.

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -217,9 +217,9 @@ module GoodJob
     # @return [Integer, nil]
     def queue_select_limit
       (
-        options[:queue_select_limit ] ||
-          rails_config[:queue_select_limit ] ||
-          env['QUEUE_SELECT_LIMIT'] ||
+        options[:queue_select_limit] ||
+          rails_config[:queue_select_limit] ||
+          env['GOOD_JOB_QUEUE_SELECT_LIMIT'] ||
           DEFAULT_QUEUE_SELECT_LIMIT
       ).to_i
     end

--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -24,7 +24,7 @@ module GoodJob
     # Perform the next eligible job
     # @return [Object, nil] Returns job result or +nil+ if no job was found
     def next
-      job_query.perform_with_advisory_lock(parsed_queues: parsed_queues)
+      job_query.perform_with_advisory_lock(parsed_queues: parsed_queues, queue_select_limit: GoodJob.configuration.queue_select_limit)
     end
 
     # Tests whether this performer should be used in GoodJob's current state.


### PR DESCRIPTION
Partner to #726 and the other part of #720

This piece is also very helpful in scaling the number of processes/threads, particularly when scheduling a bunch of jobs or during times when the queue is backed up.

I wasn't sure on the best place to pass the configuration so I tried to start at the top which ends up passing down through a few layers. I _think_ I understand the reasoning behind configuring it to the maximum number of potential threads across all processes, but I may not have gotten the documentation in the config quite right.

One thing that strikes me as an area to potentially improve is how to know when you may need to bump it up if you're unaware of this limit. Having a high default is good, but if someone is running 10,000 threads of jobs and aren't aware of this configuration, they could be adding a bunch of jobs and only processing 1,000 at a time. I don't have any good ideas at the moment though.

Thanks again for the effort you've put into GoodJob, it's really wonderful and easy to use!