### PR TITLE
Revert "When not preserving job records, ensure all prior executions are deleted after successful retry"

### DIFF
--- a/app/models/good_job/execution_result.rb
+++ b/app/models/good_job/execution_result.rb
@@ -8,18 +8,14 @@ module GoodJob
     attr_reader :handled_error
     # @return [Exception, nil]
     attr_reader :unhandled_error
-    # @return [Exception, nil]
-    attr_reader :retried
-    alias retried? retried
 
     # @param value [Object, nil]
     # @param handled_error [Exception, nil]
     # @param unhandled_error [Exception, nil]
-    def initialize(value:, handled_error: nil, unhandled_error: nil, retried: false)
+    def initialize(value:, handled_error: nil, unhandled_error: nil)
       @value = value
       @handled_error = handled_error
       @unhandled_error = unhandled_error
-      @retried = retried
     end
   end
 end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -57,7 +57,7 @@ module GoodJob
   #   By default, GoodJob deletes job records after the job is completed successfully.
   #   If you want to preserve jobs for latter inspection, set this to +true+.
   #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_unhandled_error+.
-  #   @return [Boolean, Symbol, nil]
+  #   @return [Boolean, nil]
   mattr_accessor :preserve_job_records, default: true
 
   # @!attribute [rw] retry_on_unhandled_error

--- a/spec/app/models/good_job/execution_spec.rb
+++ b/spec/app/models/good_job/execution_spec.rb
@@ -397,25 +397,6 @@ RSpec.describe GoodJob::Execution do
       expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
     end
 
-    context 'when there are prior executions' do
-      let!(:prior_execution) do
-        described_class.enqueue(active_job).tap do |job|
-          job.update!(
-            error: "TestJob::ExpectedError: Raised expected error",
-            performed_at: Time.current,
-            finished_at: Time.current
-          )
-        end
-      end
-
-      it 'destroys the job and prior executions when preserving record only on error' do
-        allow(GoodJob).to receive(:preserve_job_records).and_return(:on_unhandled_error)
-        good_job.perform
-        expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
-        expect { prior_execution.reload }.to raise_error ActiveRecord::RecordNotFound
-      end
-    end
-
     it 'raises an error if the job is attempted to be re-run' do
       good_job.update!(finished_at: Time.current)
       expect { good_job.perform }.to raise_error described_class::PreviouslyPerformedError
@@ -520,19 +501,6 @@ RSpec.describe GoodJob::Execution do
           end
         end
       end
-    end
-  end
-
-  describe '#destroy_job' do
-    let!(:execution) { described_class.create! active_job_id: SecureRandom.uuid }
-    let!(:prior_execution) { described_class.create! active_job_id: execution.active_job_id }
-    let!(:other_job) { described_class.create! active_job_id: SecureRandom.uuid }
-
-    it 'destroys all of the job executions' do
-      execution.destroy_job
-      expect { execution.reload }.to raise_error ActiveRecord::RecordNotFound
-      expect { prior_execution.reload }.to raise_error ActiveRecord::RecordNotFound
-      expect { other_job.reload }.not_to raise_error
     end
   end
 

--- a/spec/test_app/config/environments/test.rb
+++ b/spec/test_app/config/environments/test.rb
@@ -4,8 +4,8 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
-  config.cache_classes = true
-  config.eager_load = true
+  config.cache_classes = false
+  config.eager_load = false
 
   # Raises error for missing translations.
   if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')


### PR DESCRIPTION
Reverts bensheldon/good_job#719 because of https://github.com/bensheldon/good_job/issues/728.