### PR TITLE
Redirect to Jobs path after destroy

### DIFF
--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -80,7 +80,7 @@ module GoodJob
     def destroy
       @job = Job.find(params[:id])
       @job.destroy_job
-      redirect_to jobs_path, notice: "Job has been destroyed"
+      redirect_to jobs_path, notice: "Job has been destroyed" # rubocop:disable Rails/I18nLocaleTexts
     end
 
     private

--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -80,7 +80,7 @@ module GoodJob
     def destroy
       @job = Job.find(params[:id])
       @job.destroy_job
-      redirect_back(fallback_location: jobs_path, notice: "Job has been destroyed")
+      redirect_to jobs_path, notice: "Job has been destroyed"
     end
 
     private


### PR DESCRIPTION
Currently when a job is deleted the controller redirects back to that job page which throws not found error. 

This PR redirects back to the jobs index page which is the expected behaviour.