### PR TITLE
Remove support for Ruby 2.5 and JRuby 9.2; reactivate appraisal tests for Rails HEAD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       # Validate Development Environment
       - name: bin/setup
         run: bin/rails db:test:prepare
-      - name: bin/setup
+      - name: bin/rspec
         run: bin/rspec
 
   test:
@@ -134,6 +134,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          rubygems: latest
       - name: Cache Appraisal gems
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, 3.2, jruby-9.3]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2, jruby-9.3]
         pg: [14]
         include:
           - ruby: "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_mode:
     - Include
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   TargetRailsVersion: 6.0
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/Appraisals
+++ b/Appraisals
@@ -22,10 +22,10 @@ if ruby_27_or_higher && !ruby_31_or_higher && !jruby
     gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
   end
 
-  # https://github.com/rails/rails/issues/43422
-  # appraise "rails-head" do
-  #   gem "rails", github: "rails/rails", branch: "main"
-  # end
+  appraise "rails-head" do
+    gem "rails", github: "rails/rails", branch: "main"
+    gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
+  end
 end
 
 if ruby_31_or_higher && !jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,12 +138,6 @@ GEM
     console (1.16.2)
       fiber-local
     crass (1.0.6)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     date (3.3.3)
     date (3.3.3-java)
     diff-lcs (1.5.0)
@@ -425,7 +419,6 @@ DEPENDENCIES
   appraisal!
   benchmark-ips
   capybara
-  database_cleaner
   dotenv (~> 2.7.6)
   easy_translate
   erb_lint

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
 ## Compatibility
 
 - **Ruby on Rails:** 6.0+
-- **Ruby:** Ruby 2.5+. JRuby 9.2.13+
+- **Ruby:** Ruby 2.6+. JRuby 9.3+
 - **Postgres:** 10.0+
 
 ## Configuration

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -43,10 +43,10 @@ module GoodJob
       case string.first
       when '-'
         exclude_queues = true
-        string = string[1..-1]
+        string = string[1..]
       when '+'
         ordered_queues = true
-        string = string[1..-1]
+        string = string[1..]
       end
 
       queues = string.split(',').map(&:strip)

--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -4,17 +4,20 @@ source "https://rubygems.org"
 
 gem "activerecord-jdbcpostgresql-adapter", platforms: [:jruby]
 gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/appraisal.git"
+gem "matrix"
+gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
+gem "selenium-webdriver", "~> 4.0"
 
 platforms :ruby do
   gem "activerecord-explain-analyze"
-  gem "memory_profiler"
   gem "pry-byebug"
-  gem "rbtrace"
 
   group :lint do
-    gem "erb_lint", ">= 0.0.35"
+    gem "easy_translate"
+    gem "erb_lint"
+    gem "i18n-tasks"
     gem "mdl"
     gem "rubocop"
     gem "rubocop-performance"

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -60,7 +60,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "capybara"
-  spec.add_development_dependency "database_cleaner"
   spec.add_development_dependency "dotenv", "~> 2.7.6" # required for Ruby 2.5 support
   spec.add_development_dependency "foreman"
   spec.add_development_dependency "gem-release"

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
     "--quiet"
   ]
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_dependency "activejob", ">= 6.0.0"
   spec.add_dependency "activerecord", ">= 6.0.0"

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
+require 'uri'
+require 'net/http'
 
 RSpec.describe 'Server modes', skip_if_java: true do
   let(:port) { 3009 }
@@ -17,6 +19,10 @@ RSpec.describe 'Server modes', skip_if_java: true do
         wait_until(max: 30) do
           expect(shell.output).to include(/Listening on/)
           # In development, GoodJob starts up before Puma redirects logs to stdout
+
+          # Ensure Puma starts up and Rails fully bootstraps
+          Net::HTTP.get_response(URI("http://127.0.0.1:#{port}/good_job"))
+          # Cron should be enabled and enqueuing an ExampleJob every 5 seconds (defined in config/initializers/good_job.rb)
           expect(shell.output).to include(/Enqueued ExampleJob/)
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,6 @@ require File.expand_path('test_app/config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
-require 'database_cleaner'
 require 'pry'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -5,13 +5,11 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.clean_with :truncation
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 
   config.around do |example|
-    DatabaseCleaner.cleaning do
-      example.run
-    end
+    example.run
+    ActiveRecord::Tasks::DatabaseTasks.truncate_all
   end
 end


### PR DESCRIPTION
- I'm unable to build either Ruby 2.5 or JRuby 9.2 locally 😞  
- Ruby 2.5 has been EOL since March 31, 2021. 
- JRuby 9.2 is no longer listed on the [JRuby Downloads](https://www.jruby.org/download) page.