### PR TITLE
Remove JRuby 9.2 from testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, jruby-9.2, jruby-9.3]
+        ruby: [2.5, 2.6, 2.7, "3.0", 3.1, jruby-9.3]
         pg: [14]
         include:
           - ruby: "3.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
           bundler-cache: false
       - name: Delete and recreate Gemfile.lock
         run: |
-          rm Gemfile.lock && bundle lock
+          rm Gemfile.lock && bundle lock && cat Gemfile.lock
       - name: Set up Ruby and bundle install
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          rubygems: latest
 
       # Lint
       - name: Run linter
@@ -61,6 +62,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+          rubygems: latest
 
       # Validate Development Environment
       - name: bin/setup


### PR DESCRIPTION
I'm unable to build JRuby 9.2 locally on my M1 Mac, and it seems like development dependencies are starting to move on. I'll do my best to preserve compatibility with Ruby 2.5 (which I also can't build locally) until the next major release of GoodJob (#764).