### PR TITLE
Add GoodJob version to start banner

### DIFF
--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -53,7 +53,7 @@ module GoodJob
       process_id = event.payload[:process_id]
 
       info(tags: [process_id]) do
-        "GoodJob started scheduler with queues=#{performer_name} max_threads=#{max_threads}."
+        "GoodJob #{GoodJob::VERSION} started scheduler with queues=#{performer_name} max_threads=#{max_threads}."
       end
     end
 

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Server modes', skip_if_java: true do
       ShellOut.command("bundle exec rails s -p #{port} -P #{pidfile}", env: env) do |shell|
         wait_until(max: 30) do
           expect(shell.output).to include(/Listening on/)
-          expect(shell.output).to include(/GoodJob started scheduler/)
+          expect(shell.output).to include(/GoodJob [0-9.]+ started scheduler/)
           expect(shell.output).to include(/GoodJob started cron/)
         end
       end
@@ -48,7 +48,7 @@ RSpec.describe 'Server modes', skip_if_java: true do
         wait_until(max: 30) do
           expect(shell.output).to include(/Current version/)
         end
-        expect(shell.output).not_to include(/GoodJob started scheduler/)
+        expect(shell.output).not_to include(/GoodJob [0-9.]+ started scheduler/)
       end
     end
   end

--- a/spec/lib/good_job/log_subscriber_spec.rb
+++ b/spec/lib/good_job/log_subscriber_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GoodJob::LogSubscriber do
       event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", {})
 
       subscriber.scheduler_create_pool(event)
-      expect(logs.string).to include("GoodJob started scheduler with queues= max_threads=")
+      expect(logs.string).to include("GoodJob #{GoodJob::VERSION} started scheduler with queues= max_threads=")
     end
 
     it 'logs output with a tagged logger with missing formatter' do
@@ -34,7 +34,7 @@ RSpec.describe GoodJob::LogSubscriber do
       event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", {})
 
       subscriber.scheduler_create_pool(event)
-      expect(logs.string).to include("GoodJob started scheduler with queues= max_threads=")
+      expect(logs.string).to include("GoodJob #{GoodJob::VERSION} started scheduler with queues= max_threads=")
     end
   end
 end


### PR DESCRIPTION
This PR adds the GoodJob version number to the startup banner. I find this helpful for daemons which start on their own, as GoodJob does in external mode.

Before:
```
GoodJob started scheduler with queues= max_threads=
```
After:
```
GoodJob 3.6.2 started scheduler with queues= max_threads=
```

PS: Appreciate the thoroughness of your instructions and tooling for first-time gem setup and getting tests running. Well done!