### PR TITLE
Always preserve job records created by cron

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,17 +203,10 @@ Usage:
 Options:
   [--before-seconds-ago=SECONDS] # Destroy records finished more than this many seconds ago (env var:  GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO, default: 1209600 (14 days))
 
-Destroys preserved job records.
+Manually destroys preserved job records.
 
-By default, GoodJob destroys job records when the job is performed and this
-command is not necessary.
-
-However, when `GoodJob.preserve_job_records = true`, the jobs will be
-preserved in the database. This is useful when wanting to analyze or
-inspect job performance.
-
-If you are preserving job records this way, use this command regularly
-to destroy old records and preserve space in your database.
+By default, GoodJob automatically destroys job records when the job is performed
+and this command is not required to be used.
 ```
 
 ### Configuration options
@@ -460,7 +453,9 @@ GoodJob's concurrency control strategy for `perform_limit` is "optimistic retry 
 
 GoodJob can enqueue jobs on a recurring basis that can be used as a replacement for cron.
 
-Cron-style jobs are run on every GoodJob process (e.g. CLI or `async` execution mode) when `config.good_job.enable_cron = true`, but GoodJob's cron uses unique indexes to ensure that only a single job is enqueued at the given time interval.
+Cron-style jobs are run on every GoodJob process (e.g. CLI or `async` execution mode) when `config.good_job.enable_cron = true`.
+
+GoodJob's cron uses unique indexes to ensure that only a single job is enqueued at the given time interval. In order for this to work, GoodJob must preserve cron-created job records; these records will be automatically deleted like any other preserved record.
 
 Cron-format is parsed by the [`fugit`](https://github.com/floraison/fugit) gem, which has support for seconds-level resolution (e.g. `* * * * * *`) and natural language parsing (e.g. `every second`).
 

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -300,7 +300,7 @@ module GoodJob
       reenqueued = result.retried? || retried_good_job_id.present?
       if result.unhandled_error && GoodJob.retry_on_unhandled_error
         save!
-      elsif GoodJob.preserve_job_records == true || reenqueued || (result.unhandled_error && GoodJob.preserve_job_records == :on_unhandled_error)
+      elsif GoodJob.preserve_job_records == true || reenqueued || (result.unhandled_error && GoodJob.preserve_job_records == :on_unhandled_error) || cron_key.present?
         self.finished_at = Time.current
         save!
       else

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -54,9 +54,10 @@ module GoodJob
   # @!attribute [rw] preserve_job_records
   #   @!scope class
   #   Whether to preserve job records in the database after they have finished (default: +true+).
-  #   By default, GoodJob deletes job records after the job is completed successfully.
   #   If you want to preserve jobs for latter inspection, set this to +true+.
   #   If you want to preserve only jobs that finished with error for latter inspection, set this to +:on_unhandled_error+.
+  #   If you do not want to preserve jobs, set this to +false+.
+  #   When using GoodJob's cron functionality, job records will be preserved for a brief time to prevent duplicate jobs.
   #   @return [Boolean, Symbol, nil]
   mattr_accessor :preserve_job_records, default: true
 

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -128,17 +128,10 @@ module GoodJob
     # @!macro thor.desc
     desc :cleanup_preserved_jobs, "Destroys preserved job records."
     long_desc <<~DESCRIPTION
-      Destroys preserved job records.
+      Manually destroys preserved job records.
 
-      By default, GoodJob destroys job records when the job is performed and this
-      command is not necessary.
-
-      However, when `GoodJob.preserve_job_records = true`, the jobs will be
-      preserved in the database. This is useful when wanting to analyze or
-      inspect job performance.
-
-      If you are preserving job records this way, use this command regularly
-      to destroy old records and preserve space in your database.
+      By default, GoodJob automatically destroys job records when the job is performed
+      and this command is not required to be used.
 
     DESCRIPTION
     method_option :before_seconds_ago,

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -221,8 +221,7 @@ module GoodJob
       )&.to_i
     end
 
-    # Whether to destroy discarded jobs when cleaning up preserved jobs.
-    # This configuration is only used when {GoodJob.preserve_job_records} is +true+.
+    # Whether to automatically destroy discarded jobs that have been preserved.
     # @return [Boolean]
     def cleanup_discarded_jobs?
       return rails_config[:cleanup_discarded_jobs] unless rails_config[:cleanup_discarded_jobs].nil?
@@ -231,8 +230,7 @@ module GoodJob
       true
     end
 
-    # Number of seconds to preserve jobs when using the +good_job cleanup_preserved_jobs+ CLI command.
-    # This configuration is only used when {GoodJob.preserve_job_records} is +true+.
+    # Number of seconds to preserve jobs before automatic destruction.
     # @return [Integer]
     def cleanup_preserved_jobs_before_seconds_ago
       (
@@ -243,7 +241,7 @@ module GoodJob
       ).to_i
     end
 
-    # Number of jobs a {Scheduler} will execute before cleaning up preserved jobs.
+    # Number of jobs a {Scheduler} will execute before automatically cleaning up preserved jobs.
     # @return [Integer, nil]
     def cleanup_interval_jobs
       value = (
@@ -254,7 +252,7 @@ module GoodJob
       value.present? ? value.to_i : nil
     end
 
-    # Number of seconds a {Scheduler} will wait before cleaning up preserved jobs.
+    # Number of seconds a {Scheduler} will wait before automatically cleaning up preserved jobs.
     # @return [Integer, nil]
     def cleanup_interval_seconds
       value = (


### PR DESCRIPTION
Connects to #71. This is necessary because Cron's duplicate-prevention strategy uses a uniquely indexed column; in order for that to work, jobs can't be immediately deleted because that would allow another process to insert a record again.