### PR TITLE
Fix disabling of interval cleanups

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.10-java)
       racc (~> 1.4)
+    nokogiri (1.13.10-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -399,6 +401,7 @@ PLATFORMS
   ruby
   universal-java-11
   universal-java-17
+  x86_64-darwin
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -273,8 +273,8 @@ Available configuration options are:
 - `cron` (hash) cron configuration. Defaults to `{}`. You can also set this as a JSON string with the environment variable `GOOD_JOB_CRON`
 - `cleanup_discarded_jobs` (boolean) whether to destroy discarded jobs when cleaning up preserved jobs using the `$ good_job cleanup_preserved_jobs` CLI command or calling `GoodJob.cleanup_preserved_jobs`. Defaults to `true`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_DISCARDED_JOBS`. _This configuration is only used when {GoodJob.preserve_job_records} is `true`._
 - `cleanup_preserved_jobs_before_seconds_ago` (integer) number of seconds to preserve jobs when using the `$ good_job cleanup_preserved_jobs` CLI command or calling `GoodJob.cleanup_preserved_jobs`. Defaults to `1209600` (14 days). Can also be set with  the environment variable `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO`.  _This configuration is only used when {GoodJob.preserve_job_records} is `true`._
-- `cleanup_interval_jobs` (integer) Number of jobs a Scheduler will execute before cleaning up preserved jobs. Defaults to `1000`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_JOBS`.
-- `cleanup_interval_seconds` (integer) Number of seconds a Scheduler will wait before cleaning up preserved jobs. Defaults to `600` (10 minutes). Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_SECONDS`.
+- `cleanup_interval_jobs` (integer) Number of jobs a Scheduler will execute before cleaning up preserved jobs. Defaults to `1000`. Disable with `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_JOBS`.
+- `cleanup_interval_seconds` (integer) Number of seconds a Scheduler will wait before cleaning up preserved jobs. Defaults to `600` (10 minutes). Disable with `nil`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_SECONDS`.
 - `inline_execution_respects_schedule` (boolean) Opt-in to future behavior of inline execution respecting scheduled jobs. Defaults to `false`.
 - `logger` ([Rails Logger](https://api.rubyonrails.org/classes/ActiveSupport/Logger.html)) lets you set a custom logger for GoodJob. It should be an instance of a Rails `Logger` (Default: `Rails.logger`).
 - `preserve_job_records` (boolean) keeps job records in your database even after jobs are completed. (Default: `true`)
@@ -926,9 +926,9 @@ config.good_job.preserve_job_records = false # defaults to true; can also be `fa
 GoodJob will automatically delete preserved job records after 14 days. The retention period, as well as the frequency GoodJob checks for deletable records can be configured:
 
 ```ruby
-config.good_job.cleanup_preserved_jobs_before_seconds_ago = 14.days.to_i
+config.good_job.cleanup_preserved_jobs_before_seconds_ago = 14.days
 config.good_job.cleanup_interval_jobs = 1_000 # Number of executed jobs between deletion sweeps.
-config.good_job.cleanup_interval_seconds = 10.minutes.to_i # Number of seconds between deletion sweeps.
+config.good_job.cleanup_interval_seconds = 10.minutes # Number of seconds between deletion sweeps.
 ```
 
 It is also possible to manually trigger a cleanup of preserved job records:

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -137,7 +137,7 @@ module GoodJob
     method_option :before_seconds_ago,
                   type: :numeric,
                   banner: 'SECONDS',
-                  desc: "Destroy records finished more than this many seconds ago (env var: GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO, default: 86400)"
+                  desc: "Destroy records finished more than this many seconds ago (env var: GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO, default: 1209600 (14 days))"
 
     def cleanup_preserved_jobs
       set_up_application!

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -244,22 +244,26 @@ module GoodJob
     # Number of jobs a {Scheduler} will execute before automatically cleaning up preserved jobs.
     # @return [Integer, nil]
     def cleanup_interval_jobs
-      value = (
-        rails_config[:cleanup_interval_jobs] ||
-          env['GOOD_JOB_CLEANUP_INTERVAL_JOBS'] ||
-          DEFAULT_CLEANUP_INTERVAL_JOBS
-      )
+      value = if rails_config.key?(:cleanup_interval_jobs)
+                rails_config[:cleanup_interval_jobs]
+              elsif env.key?('GOOD_JOB_CLEANUP_INTERVAL_JOBS')
+                env['GOOD_JOB_CLEANUP_INTERVAL_JOBS']
+              else
+                DEFAULT_CLEANUP_INTERVAL_JOBS
+              end
       value.present? ? value.to_i : nil
     end
 
     # Number of seconds a {Scheduler} will wait before automatically cleaning up preserved jobs.
     # @return [Integer, nil]
     def cleanup_interval_seconds
-      value = (
-        rails_config[:cleanup_interval_seconds] ||
-          env['GOOD_JOB_CLEANUP_INTERVAL_SECONDS'] ||
-          DEFAULT_CLEANUP_INTERVAL_SECONDS
-      )
+      value = if rails_config.key?(:cleanup_interval_seconds)
+                rails_config[:cleanup_interval_seconds]
+              elsif env.key?('GOOD_JOB_CLEANUP_INTERVAL_SECONDS')
+                env['GOOD_JOB_CLEANUP_INTERVAL_SECONDS']
+              else
+                DEFAULT_CLEANUP_INTERVAL_SECONDS
+              end
       value.present? ? value.to_i : nil
     end
 

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe GoodJob::Configuration do
 
     context 'when environment variable is set' do
       before do
-        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO' => 36000 })
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO' => '36000' })
       end
 
       context 'when option is given' do
@@ -108,6 +108,84 @@ RSpec.describe GoodJob::Configuration do
           configuration = described_class.new({})
           expect(configuration.cleanup_preserved_jobs_before_seconds_ago).to eq 36000
         end
+      end
+    end
+  end
+
+  describe '#cleanup_interval_jobs' do
+    it 'defaults to 1000' do
+      configuration = described_class.new({})
+      expect(configuration.cleanup_interval_jobs).to eq 1000
+    end
+
+    context 'when rails config is set' do
+      it 'uses rails config value' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ cleanup_interval_jobs: 10000 })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_jobs).to eq 10000
+      end
+
+      it 'accepts nil' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ cleanup_interval_jobs: nil })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_jobs).to be_nil
+      end
+    end
+
+    context 'when environment variable is set' do
+      it 'uses environment variable' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_INTERVAL_JOBS' => '50000' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_jobs).to eq 50000
+      end
+
+      it 'accepts an empty value' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_INTERVAL_JOBS' => '' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_jobs).to be_nil
+      end
+    end
+  end
+
+  describe '#cleanup_interval_seconds' do
+    it 'defaults to 10 minutes' do
+      configuration = described_class.new({})
+      expect(configuration.cleanup_interval_seconds).to eq 10.minutes.to_i
+    end
+
+    context 'when rails config is set' do
+      it 'uses rails config value' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ cleanup_interval_seconds: 1.hour })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_seconds).to eq 3600
+      end
+
+      it 'accepts nil' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ cleanup_interval_seconds: nil })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_seconds).to be_nil
+      end
+    end
+
+    context 'when environment variable is set' do
+      it 'uses environment variable' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_INTERVAL_SECONDS' => '7200' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_seconds).to eq 7200
+      end
+
+      it 'accepts an empty value' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_INTERVAL_SECONDS' => '' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_interval_seconds).to be_nil
       end
     end
   end


### PR DESCRIPTION
This PR allows `cleanup_interval_jobs` and `cleanup_interval_seconds` to each be disabled by setting to `nil` or `false`. Since v3.0.0 (see #545), both would fallback to the default values.

Since disabling these worked in v2.x and `CleanupTracker` still allows `nil`, it seems this was an accidental regression. Tests added accordingly.

The ENV variable equivalents may also be disabled by setting to an empty string:
`env GOOD_JOB_CLEANUP_INTERVAL_JOBS=  good_job ...`
This was already true, but is now tested.

The primary use-case is to allow one cleanup interval to be used, with the other disabled (that's the case here).

If both are set to `nil`, then auto cleanup is disabled. In light of the recent change to always preserve cron jobs (#767), that could be bad. However, setting both to `nil` does allow intentionally running cleanup externally, which may be a useful configuration for some. Accordingly, no attempt has been made to prevent both being disabled.

Finally, tagged on an update to ensure macOS on Intel can use precompiled versions of gems like `nokogiri`. I don't know if you prefer having such housekeeping tasks as separate PRs or not. Happy to split off if needed.