### PR TITLE
Avoid including unnecessary pg_locks references when counting jobs

### DIFF
--- a/app/filters/good_job/base_filter.rb
+++ b/app/filters/good_job/base_filter.rb
@@ -14,7 +14,7 @@ module GoodJob
     def records
       after_scheduled_at = params[:after_scheduled_at].present? ? Time.zone.parse(params[:after_scheduled_at]) : nil
 
-      filtered_query.display_all(
+      query_for_records.display_all(
         after_scheduled_at: after_scheduled_at,
         after_id: params[:after_id]
       ).limit(params.fetch(:limit, DEFAULT_LIMIT))
@@ -61,6 +61,10 @@ module GoodJob
     end
 
     private
+
+    def query_for_records
+      raise NotImplementedError
+    end
 
     def default_base_query
       raise NotImplementedError

--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -2,7 +2,7 @@
 module GoodJob
   class JobsFilter < BaseFilter
     def states
-      query = filtered_query(params.except(:state)).unscope(:select)
+      query = filtered_query(params.except(:state))
       {
         'scheduled' =>  query.scheduled.count,
         'retried' => query.retried.count,
@@ -14,7 +14,7 @@ module GoodJob
     end
 
     def filtered_query(filter_params = params)
-      query = base_query.includes(:executions).includes_advisory_locks
+      query = base_query
 
       query = query.job_class(filter_params[:job_class]) if filter_params[:job_class].present?
       query = query.where(queue_name: filter_params[:queue_name]) if filter_params[:queue_name].present?
@@ -46,6 +46,10 @@ module GoodJob
     end
 
     private
+
+    def query_for_records
+      filtered_query.includes(:executions).includes_advisory_locks
+    end
 
     def default_base_query
       GoodJob::Job.all


### PR DESCRIPTION
We've been observing some performance limitations with the GoodJob dashboard. I believe this to be largely a consequence of performing live counts on an insufficiently-pruned table relative to the available database resource, but I noted that the dashboard count queries include a join against `pg_locks`. In the event that there are a substantial number of e.g. `succeeded` jobs, this actually gets quite expensive, and isn't necessary to satisfy counts.

This PR is a bit of an opportunistic approach to avoid that cost.