### PR TITLE
Ensure Concurrency Keys are string-like and return a better error when they cannot be cast to a string

### DIFF
--- a/app/models/good_job/lockable.rb
+++ b/app/models/good_job/lockable.rb
@@ -194,12 +194,7 @@ module GoodJob
           ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
         ]
 
-        begin
-          locked = connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Lock', binds).first['locked']
-        rescue TypeError
-          raise ArgumentError, "Can't cast concurrency key class #{key.class} to String"
-        end
-
+        locked = connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Lock', binds).first['locked']
         return locked unless block_given?
         return nil unless locked
 

--- a/app/models/good_job/lockable.rb
+++ b/app/models/good_job/lockable.rb
@@ -193,7 +193,13 @@ module GoodJob
         binds = [
           ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
         ]
-        locked = connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Lock', binds).first['locked']
+
+        begin
+          locked = connection.exec_query(pg_or_jdbc_query(query), 'GoodJob::Lockable Advisory Lock', binds).first['locked']
+        rescue TypeError
+          raise ArgumentError, "Can't cast concurrency key class #{key.class} to String"
+        end
+
         return locked unless block_given?
         return nil unless locked
 

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -120,7 +120,7 @@ module GoodJob
         return if key.blank?
 
         key = key.respond_to?(:call) ? instance_exec(&key) : key
-        raise TypeError, "#{key.class} is not a valid type of concurrency key" unless VALID_TYPES.any? { |type| key.is_a?(type) }
+        raise TypeError, "Concurrency key must be a String; was a #{key.class}" unless VALID_TYPES.any? { |type| key.is_a?(type) }
 
         key
       end

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -4,6 +4,8 @@ module GoodJob
     module Concurrency
       extend ActiveSupport::Concern
 
+      VALID_TYPES = [String, Symbol, Numeric, Date, Time, TrueClass, FalseClass, NilClass].freeze
+
       class ConcurrencyExceededError < StandardError
         def backtrace
           [] # suppress backtrace
@@ -30,6 +32,11 @@ module GoodJob
           # Always allow jobs to be retried because the current job's execution will complete momentarily
           next(block.call) if CurrentThread.active_job_id == job.job_id
 
+          # Only generate the concurrency key on the initial enqueue in case it is dynamic
+          job.good_job_concurrency_key ||= job._good_job_concurrency_key
+          key = job.good_job_concurrency_key
+          next(block.call) if key.blank?
+
           enqueue_limit = job.class.good_job_concurrency_config[:enqueue_limit]
           enqueue_limit = instance_exec(&enqueue_limit) if enqueue_limit.respond_to?(:call)
           enqueue_limit = nil unless enqueue_limit.present? && (0...Float::INFINITY).cover?(enqueue_limit)
@@ -42,11 +49,6 @@ module GoodJob
 
           limit = enqueue_limit || total_limit
           next(block.call) unless limit
-
-          # Only generate the concurrency key on the initial enqueue in case it is dynamic
-          job.good_job_concurrency_key ||= job._good_job_concurrency_key
-          key = job.good_job_concurrency_key
-          next(block.call) if key.blank?
 
           GoodJob::Execution.advisory_lock_key(key, function: "pg_advisory_lock") do
             enqueue_concurrency = if enqueue_limit
@@ -117,11 +119,10 @@ module GoodJob
         key = self.class.good_job_concurrency_config[:key]
         return if key.blank?
 
-        if key.respond_to? :call
-          instance_exec(&key)
-        else
-          key
-        end
+        key = key.respond_to?(:call) ? instance_exec(&key) : key
+        raise TypeError, "#{key.class} is not a valid type of concurrency key" unless VALID_TYPES.any? { |type| key.is_a?(type) }
+
+        key
       end
     end
   end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -154,10 +154,10 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
 
       it 'raises an error for non-serializable types' do
-        expect { TestJob.perform_later({ key: "value" }) }.to raise_error(ArgumentError)
-        expect { TestJob.perform_later({ key: "value" }.with_indifferent_access) }.to raise_error(ArgumentError)
-        expect { TestJob.perform_later(["key"]) }.to raise_error(ArgumentError)
-        expect { TestJob.perform_later(TestJob) }.to raise_error(ArgumentError)
+        expect { TestJob.perform_later({ key: "value" }) }.to raise_error(TypeError)
+        expect { TestJob.perform_later({ key: "value" }.with_indifferent_access) }.to raise_error(TypeError)
+        expect { TestJob.perform_later(["key"]) }.to raise_error(TypeError)
+        expect { TestJob.perform_later(TestJob) }.to raise_error(TypeError)
       end
     end
   end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -137,5 +137,28 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(retried_execution.concurrency_key).to eq first_execution.concurrency_key
       end
     end
+
+    describe '#perform_later' do
+      before do
+        stub_const 'TestJob', (Class.new(ActiveJob::Base) do
+          include GoodJob::ActiveJobExtensions::Concurrency
+
+          good_job_control_concurrency_with(
+            total_limit: 1,
+            key: -> { arguments.first }
+          )
+
+          def perform(arg)
+          end
+        end)
+      end
+
+      it 'raises an error for non-serializable types' do
+        expect { TestJob.perform_later({ key: "value" }) }.to raise_error(ArgumentError)
+        expect { TestJob.perform_later({ key: "value" }.with_indifferent_access) }.to raise_error(ArgumentError)
+        expect { TestJob.perform_later(["key"]) }.to raise_error(ArgumentError)
+        expect { TestJob.perform_later(TestJob) }.to raise_error(ArgumentError)
+      end
+    end
   end
 end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
 
       it 'raises an error for non-serializable types' do
-        expect { TestJob.perform_later({ key: "value" }) }.to raise_error(TypeError)
+        expect { TestJob.perform_later({ key: "value" }) }.to raise_error(TypeError, "Concurrency key must be a String; was a Hash")
         expect { TestJob.perform_later({ key: "value" }.with_indifferent_access) }.to raise_error(TypeError)
         expect { TestJob.perform_later(["key"]) }.to raise_error(TypeError)
         expect { TestJob.perform_later(TestJob) }.to raise_error(TypeError)


### PR DESCRIPTION
Closes #784 

If you pass something like a Hash or Array as the concurrency key, the resulting stack trace doesn't make it very clear what you did wrong:

```
   TypeError:
     can't cast Hash
   # ./app/models/good_job/lockable.rb:196:in `advisory_lock_key'
   # ./lib/good_job/active_job_extensions/concurrency.rb:51:in `block (2 levels) in <module:Concurrency>'
   # ./spec/lib/good_job/active_job_extensions/concurrency_spec.rb:157:in `block (4 levels) in <top (required)>'
   # ./spec/support/reset_rails_queue_adapter.rb:12:in `block (2 levels) in <top (required)>'
   # ./spec/support/reset_good_job.rb:19:in `block (2 levels) in <top (required)>'
   # ./spec/support/database_cleaner.rb:14:in `block (3 levels) in <top (required)>'
   # /usr/local/rvm/gems/default/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in `cleaning'
   # /usr/local/rvm/gems/default/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in `block (2 levels) in cleaning'
   # /usr/local/rvm/gems/default/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in `cleaning'
   # ./spec/support/database_cleaner.rb:13:in `block (2 levels) in <top (required)>'
```

This made me believe that I'm not allowed to pass a Hash to the job itself. Now the error is much clearer:

```
 ArgumentError:
       Concurrency key must be a String, was Hash
```

This is technically a breaking change. Some types like Number, Time and Symbol were being cast to a String by rails automatically, this now raises an error. The readme says that the concurrency key must be a String, but it would be best for this to go in the next major version if accepted.