### PR TITLE
Fix template for the update migrations 03 index (#851)

### DIFF
--- a/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/03_create_index_good_jobs_jobs_on_priority_created_at_when_unfinished.rb.erb
@@ -2,7 +2,7 @@
 class CreateIndexGoodJobsJobsOnPriorityCreatedAtWhenUnfinished < ActiveRecord::Migration<%= migration_version %>
   disable_ddl_transaction!
 
-   def change
+  def change
     reversible do |dir|
       dir.up do
         # Ensure this incremental update migration is idempotent


### PR DESCRIPTION
Three spaces instead of two generate a rubocop issue.

Fixes #851.