### PR TITLE
Fix bug where notification check does not use configuration

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -234,8 +234,8 @@ module GoodJob
     end
 
     def send_notify?(active_job)
-      return true unless active_job.respond_to?(:good_job_notify)
       return false unless GoodJob.configuration.enable_listen_notify
+      return true unless active_job.respond_to?(:good_job_notify)
 
       !(active_job.good_job_notify == false || (active_job.class.good_job_notify == false && active_job.good_job_notify.nil?))
     end


### PR DESCRIPTION
Thanks again for working with me on this feature. I was testing it just now and realized the early `return true` was causing me to send notifications with the following set in my Rails application:

```ruby
    config.good_job.enable_listen_notify = false
```