### PR TITLE
Extract GoodJob::Capsule

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -15,6 +15,7 @@ require "good_job/active_job_extensions/notify_options"
 
 require "good_job/assignable_connection"
 require "good_job/bulk"
+require "good_job/capsule"
 require "good_job/cleanup_tracker"
 require "good_job/cli"
 require "good_job/configuration"
@@ -91,6 +92,12 @@ module GoodJob
   #   @return [GoodJob::Configuration, nil]
   mattr_accessor :configuration, default: GoodJob::Configuration.new({})
 
+  # @!attribute [rw] capsule
+  #   @!scope class
+  #   Global/default execution capsule for GoodJob.
+  #   @return [GoodJob::Capsule, nil]
+  mattr_accessor :capsule, default: GoodJob::Capsule.new(configuration: configuration)
+
   # Called with exception when a GoodJob thread raises an exception
   # @param exception [Exception] Exception that was raised
   # @return [void]
@@ -108,16 +115,15 @@ module GoodJob
   #   * +-1+, the scheduler will wait until the shutdown is complete.
   #   * +0+, the scheduler will immediately shutdown and stop any active tasks.
   #   * +1..+, the scheduler will wait that many seconds before stopping any remaining active tasks.
-  # @param wait [Boolean] whether to wait for shutdown
   # @return [void]
   def self.shutdown(timeout: -1)
-    _shutdown_all(_executables, timeout: timeout)
+    _shutdown_all(Capsule.instances, timeout: timeout)
   end
 
   # Tests whether jobs have stopped executing.
   # @return [Boolean] whether background threads are shut down
   def self.shutdown?
-    _executables.all?(&:shutdown?)
+    Capsule.instances.all?(&:shutdown?)
   end
 
   # Stops and restarts executing jobs.
@@ -128,7 +134,7 @@ module GoodJob
   # @param timeout [Numeric, nil] Seconds to wait for active threads to finish.
   # @return [void]
   def self.restart(timeout: -1)
-    _shutdown_all(_executables, :restart, timeout: timeout)
+    _shutdown_all(Capsule.instances, :restart, timeout: timeout)
   end
 
   # Sends +#shutdown+ or +#restart+ to executable objects ({GoodJob::Notifier}, {GoodJob::Poller}, {GoodJob::Scheduler}, {GoodJob::MultiScheduler}, {GoodJob::CronManager})
@@ -154,7 +160,7 @@ module GoodJob
   # analyze or inspect job performance.
   # If you are preserving job records this way, use this method regularly to
   # destroy old records and preserve space in your database.
-  # @params older_than [nil,Numeric,ActiveSupport::Duration] Jobs older than this will be destroyed (default: +86400+).
+  # @param older_than [nil,Numeric,ActiveSupport::Duration] Jobs older than this will be destroyed (default: +86400+).
   # @return [Integer] Number of job execution records and batches that were destroyed.
   def self.cleanup_preserved_jobs(older_than: nil)
     older_than ||= GoodJob.configuration.cleanup_preserved_jobs_before_seconds_ago
@@ -192,15 +198,6 @@ module GoodJob
       break unless result
       raise result.unhandled_error if result.unhandled_error
     end
-  end
-
-  def self._executables
-    [].concat(
-      CronManager.instances,
-      Notifier.instances,
-      Poller.instances,
-      Scheduler.instances
-    )
   end
 
   ActiveSupport.run_load_hooks(:good_job, self)

--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+module GoodJob
+  # A GoodJob::Capsule contains the resources necessary to execute jobs, including
+  # a {GoodJob::Scheduler}, {GoodJob::Poller}, {GoodJob::Notifier}, and {GoodJob::CronManager}.
+  # GoodJob creates a default capsule on initialization.
+  class Capsule
+    # @!attribute [r] instances
+    #   @!scope class
+    #   List of all instantiated Capsules in the current process.
+    #   @return [Array<GoodJob::Capsule>, nil]
+    cattr_reader :instances, default: [], instance_reader: false
+
+    # @param configuration [GoodJob::Configuration] Configuration to use for this capsule.
+    def initialize(configuration: GoodJob.configuration)
+      self.class.instances << self
+      @configuration = configuration
+
+      @autostart = true
+      @running = false
+      @mutex = Mutex.new
+    end
+
+    # Start executing jobs (if not already running).
+    def start
+      return if @running
+
+      @mutex.synchronize do
+        return if @running
+
+        @notifier = GoodJob::Notifier.new(enable_listening: @configuration.enable_listen_notify)
+        @poller = GoodJob::Poller.new(poll_interval: @configuration.poll_interval)
+        @scheduler = GoodJob::Scheduler.from_configuration(@configuration, warm_cache_on_initialize: true)
+        @notifier.recipients << [@scheduler, :create_thread]
+        @poller.recipients << [@scheduler, :create_thread]
+
+        @cron_manager = GoodJob::CronManager.new(@configuration.cron_entries, start_on_initialize: true) if @configuration.enable_cron?
+
+        @autostart = false
+        @running = true
+      end
+    end
+
+    # Shut down the thread pool executors.
+    # @param timeout [nil, Numeric, Symbol] Seconds to wait for active threads.
+    #   * +-1+ will wait for all active threads to complete.
+    #   * +0+ will interrupt active threads.
+    #   * +N+ will wait at most N seconds and then interrupt active threads.
+    #   * +nil+ will trigger a shutdown but not wait for it to complete.
+    # @return [void]
+    def shutdown(timeout: :default)
+      timeout = timeout == :default ? @configuration.shutdown_timeout : timeout
+      GoodJob._shutdown_all([@notifier, @poller, @scheduler, @cron_manager].compact, timeout: timeout)
+      @autostart = false
+      @running = false
+    end
+
+    # Shutdown and then start the capsule again.
+    # @param timeout [nil, Numeric, Symbol] Seconds to wait for active threads.
+    # @return [void]
+    def restart(timeout: :default)
+      shutdown(timeout: timeout)
+      start
+    end
+
+    # @return [Boolean] Whether the capsule is currently running.
+    def running?
+      @running
+    end
+
+    # @return [Boolean] Whether the capsule has been shutdown.
+    def shutdown?
+      [@notifier, @poller, @scheduler, @cron_manager].compact.all?(&:shutdown?)
+    end
+
+    # Creates an execution thread(s) with the given attributes.
+    # @param job_state [Hash, nil] See {GoodJob::Scheduler#create_thread}.
+    # @return [Boolean, nil] Whether work was started.
+    def create_thread(job_state = nil)
+      start if !running? && @autostart
+      @scheduler&.create_thread(job_state)
+    end
+  end
+end

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe 'Adapter Integration' do
   end
 
   describe 'Async execution mode' do
-    let(:adapter) { GoodJob::Adapter.new execution_mode: :async_all }
+    let(:capsule) { GoodJob::Capsule.new(configuration: GoodJob::Configuration.new({ max_threads: 5, queue_string: '*' })) }
+    let(:adapter) { GoodJob::Adapter.new(execution_mode: :async_all, _capsule: capsule) }
 
     it 'executes the job', skip_if_java: true do
       elephant_adapter = GoodJob::Adapter.new execution_mode: :async_all

--- a/spec/lib/good_job/capsule_spec.rb
+++ b/spec/lib/good_job/capsule_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe GoodJob::Capsule do
+  describe '#initialize' do
+    it 'does not start' do
+      capsule = described_class.new
+      expect(capsule).not_to be_running
+    end
+  end
+
+  describe '#start' do
+    it 'creates execution objects' do
+      capsule = described_class.new
+      expect { capsule.start }
+        .to change(GoodJob::Notifier.instances, :size).by(1)
+        .and change(GoodJob::Scheduler.instances, :size).by(1)
+        .and change(GoodJob::Poller.instances, :size).by(1)
+        .and change(GoodJob::Poller.instances, :size).by(1)
+      capsule.shutdown
+    end
+
+    it 'is safe to call from multiple threads' do
+      capsule = described_class.new
+      Array.new(100) { Thread.new { capsule.start } }.each(&:join)
+      capsule.shutdown
+      expect(GoodJob::Scheduler.instances.size).to eq 1
+    end
+  end
+
+  describe '#shutdown' do
+    it 'operates if the capsule has not been started' do
+      capsule = described_class.new
+      expect { capsule.shutdown }.not_to raise_error
+    end
+  end
+
+  describe '#create_thread' do
+    it 'passes the job state to the scheduler' do
+      scheduler = instance_double(GoodJob::Scheduler, create_thread: nil, shutdown?: true, shutdown: nil)
+      allow(GoodJob::Scheduler).to receive(:new).and_return(scheduler)
+      job_state = "STATE"
+
+      capsule = described_class.new
+      capsule.start
+      capsule.create_thread(job_state)
+
+      expect(scheduler).to have_received(:create_thread).with(job_state)
+    end
+
+    it 'starts the capsule if it is not running' do
+      capsule = described_class.new
+      expect { capsule.create_thread }.to change(capsule, :running?).from(false).to(true)
+    end
+
+    it 'will not start the capsule if it has been shutdown' do
+      capsule = described_class.new
+      capsule.start
+      capsule.shutdown
+      expect { capsule.create_thread }.not_to change(capsule, :running?).from(false)
+    end
+
+    it 'returns nil if the capsule is not running' do
+      capsule = described_class.new
+      capsule.shutdown
+      expect(capsule.create_thread).to be_nil
+    end
+  end
+end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -22,6 +22,16 @@ RSpec.configure do |config|
   config.after do
     GoodJob.shutdown(timeout: -1)
 
+    executables = [].concat(
+      GoodJob::CronManager.instances,
+      GoodJob::Notifier.instances,
+      GoodJob::Poller.instances,
+      GoodJob::Scheduler.instances,
+      GoodJob::CronManager.instances,
+      GoodJob::Capsule.instances
+    )
+    GoodJob._shutdown_all(executables, timeout: -1)
+
     expect(THREAD_ERRORS).to be_empty
 
     expect(GoodJob::Notifier.instances).to all be_shutdown
@@ -35,6 +45,9 @@ RSpec.configure do |config|
 
     expect(GoodJob::Scheduler.instances).to all be_shutdown
     GoodJob::Scheduler.instances.clear
+
+    expect(GoodJob::Capsule.instances).to all be_shutdown
+    GoodJob::Capsule.instances.clear
 
     expect(PgLock.current_database.advisory_lock.owns.count).to eq(0), "Existing owned advisory locks AFTER test run"
 


### PR DESCRIPTION
Extracts the duplicated instantiation of Scheduler, Poller, CronManager, etc that existed in both the Async Adapter and CLI into a single object.

- Name inspired by Sidekiq: https://ruby.social/@bensheldon/109722709921698011
- Extracted from ProcessManager refactoring, but also tried doing something similar in e4c5cfc7e7ff6c2af9b07f20e9ff8084c162cf1c (archived in #858) last year
- Extracting the thread executors out of the Adapter was long intended after #558

## Observations and Risks

- This creates a global `GoodJob.capsule` that holds the Scheduler (thread executor). It _was_ previously easily possible to create multiple async Adapters, and thus end up with multiple Schedulers. This PR creates a better distinction and symmetry between the Adapter which enqueues, and the Capsule, which dequeues/executes. I think that subtly changes the meaning of the Adapters Async mode, but not a lot:
  - Old: Async Adapter executes in the same process
  - New: Async Adapter will enqueue and attempt to execute the job in an existing Capsule/Scheduler that may be running in the current process.  (That’s a mouthful)
- As always, Rails boot/startup has some risky async orchestration.
- **Where it's going:** The future destination is having a stronger guarantee around the Process record: that the Process record must be present _before_ jobs are executed, the Process record must be present until _after_ the Schedulers are shut down, and Schedulers _must not_ execute jobs if the Process record does not exist or is in a bad state. This makes it easier to get to #831. That also means that eventually “Process Record” will really be “Capsule (Process) Record” but that likely won’t be noticed