### PR TITLE
Don't load all Executions on Jobs Dashboard

### DIFF
--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -2,15 +2,17 @@
 module GoodJob
   class JobsFilter < BaseFilter
     def states
-      query = filtered_query(params.except(:state))
-      {
-        'scheduled' =>  query.scheduled.count,
-        'retried' => query.retried.count,
-        'queued' => query.queued.count,
-        'running' => query.running.count,
-        'succeeded' => query.succeeded.count,
-        'discarded' => query.discarded.count,
-      }
+      @_states ||= begin
+        query = filtered_query(params.except(:state))
+        {
+          'scheduled' =>  query.scheduled.count,
+          'retried' => query.retried.count,
+          'queued' => query.queued.count,
+          'running' => query.running.count,
+          'succeeded' => query.succeeded.count,
+          'discarded' => query.discarded.count,
+        }
+      end
     end
 
     def filtered_query(filter_params = params)
@@ -42,13 +44,13 @@ module GoodJob
     end
 
     def filtered_count
-      filtered_query.unscope(:select).count
+      @_filtered_count ||= filtered_query.unscope(:select).count
     end
 
     private
 
     def query_for_records
-      filtered_query.includes(:executions).includes_advisory_locks
+      filtered_query.includes_advisory_locks
     end
 
     def default_base_query

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -136,6 +136,16 @@ module GoodJob
       error || executions[-2]&.error
     end
 
+    # Errors for the job to be displayed in the Dashboard.
+    # @return [String]
+    def display_error
+      return error if error.present?
+
+      serialized_params.fetch('exception_executions', {}).map do |exception, count|
+        "#{exception}: #{count}"
+      end.join(', ')
+    end
+
     # Return formatted serialized_params for display in the dashboard
     # @return [Hash]
     def display_serialized_params

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -82,7 +82,7 @@
                       bs_toggle: "popover",
                       bs_trigger: "hover focus click",
                       bs_placement: "bottom",
-                      bs_content: job.recent_error
+                      bs_content: job.display_error,
                 } %>
               <% else %>
                 <span class="badge bg-secondary bg-opacity-50 rounded-pill"><%= job.executions_count %></span>

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe GoodJob::Adapter do
     context 'when async' do
       it 'triggers the capsule and the notifier' do
         allow(GoodJob::Execution).to receive(:enqueue).and_return(good_job)
-        allow(GoodJob::Notifier).to receive(:notify).with({ queue_name: 'default' })
+        allow(GoodJob::Notifier).to receive(:notify)
 
         capsule = instance_double(GoodJob::Capsule, start: nil, create_thread: nil)
         allow(GoodJob).to receive(:capsule).and_return(capsule)
@@ -82,7 +82,7 @@ RSpec.describe GoodJob::Adapter do
 
         expect(capsule).to have_received(:start)
         expect(capsule).to have_received(:create_thread)
-        expect(GoodJob::Notifier).to have_received(:notify)
+        expect(GoodJob::Notifier).to have_received(:notify).with({ queue_name: 'default' })
       end
     end
   end

--- a/spec/test_app/config/initializers/rack_mini_profiler.rb
+++ b/spec/test_app/config/initializers/rack_mini_profiler.rb
@@ -1,6 +1,6 @@
 if defined?(Rack::MiniProfiler)
   Rack::MiniProfiler.config.skip_paths.push(
     "/favicon.ico",
-    "/good_job/assets/"
+    "/good_job/frontend/"
   )
 end


### PR DESCRIPTION
Closes #809.

The downside is that the latest-error is slightly less accurate because it shows _all execution errors_ instead of just the most recent error, but as it's currently hidden behind an on-hover, it probably won't be noticed 🤞🏻 

<img width="297" alt="Screenshot 2023-03-08 at 7 22 46 AM" src="https://user-images.githubusercontent.com/47554/223754038-fa7727c2-d526-4e12-af1c-843c3342703a.png">
