### PR TITLE
If logging to STDOUT in CLI set $stdout.sync = true

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -148,7 +148,10 @@ module GoodJob
       # Rails or from the application can be set up here.
       def set_up_application!
         require RAILS_ENVIRONMENT_RB
-        return if !GoodJob::CLI.log_to_stdout? || ActiveSupport::Logger.logger_outputs_to?(GoodJob.logger, $stdout)
+        return unless GoodJob::CLI.log_to_stdout?
+
+        $stdout.sync = true
+        return if ActiveSupport::Logger.logger_outputs_to?(GoodJob.logger, $stdout)
 
         GoodJob::LogSubscriber.loggers << ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
         GoodJob::LogSubscriber.reset_logger


### PR DESCRIPTION
When running the CLI from non-interactive terminals such as foreman or docker, the logs were not being displayed immediatly because ruby sets `$stdout.sync = false` for these types of terminals by default which causes the log messages to be buffered. This leads to inconsistent behaviour between interactive and non-interactive terminals for the CLI application. By explicitly setting $stdout.sync = true when launching the CLI application we can ensure that STDOUT logging is consistent in both types of terminals.

See #879 and #490 for further disscussion.