### PR TITLE
Deprecate definition of job priority, change to "smaller number is higher priority" to align with Active Job definition

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -341,6 +341,10 @@ module GoodJob
       DEFAULT_ENABLE_LISTEN_NOTIFY
     end
 
+    def smaller_number_is_higher_priority
+      rails_config[:smaller_number_is_higher_priority]
+    end
+
     private
 
     def rails_config

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe GoodJob::Configuration do
     end
   end
 
-  describe 'enable_listen_notify' do
+  describe '#enable_listen_notify' do
     it 'defaults to true' do
       configuration = described_class.new({})
       expect(configuration.enable_listen_notify).to be true
@@ -269,6 +269,14 @@ RSpec.describe GoodJob::Configuration do
 
       configuration = described_class.new({})
       expect(configuration.enable_listen_notify).to be false
+    end
+  end
+
+  describe '#smaller_number_is_higher_priority' do
+    it 'delegates to rails configuration' do
+      allow(Rails.application.config).to receive(:good_job).and_return({ smaller_number_is_higher_priority: true })
+      configuration = described_class.new({})
+      expect(configuration.smaller_number_is_higher_priority).to be true
     end
   end
 end

--- a/spec/test_app/config/initializers/good_job.rb
+++ b/spec/test_app/config/initializers/good_job.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
-  # TODO: Remove on GoodJob 3.0 release
-  config.good_job.inline_execution_respects_schedule = true
+  # TODO: Remove on GoodJob 4.0 release
+  config.good_job.smaller_number_is_higher_priority = true
 
   config.good_job.cron = {
     example: {


### PR DESCRIPTION
Reported in https://github.com/bensheldon/good_job/discussions/524#discussioncomment-5233753.

[Active Job describes priority](https://github.com/rails/rails/blob/e17faead4f2aff28da079d50f02ea5b015322d5b/activejob/lib/active_job/core.rb#L22) as "lower is more priority".