### PR TITLE
Add execution_result to event payload for perform_job.good_job

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -345,9 +345,15 @@ module GoodJob
             end
             handled_error ||= current_thread.error_on_retry || current_thread.error_on_discard
 
-            instrument_payload[:execution_result] = ExecutionResult.new(value: value, handled_error: handled_error, retried: current_thread.error_on_retry.present?)
+            instrument_payload.merge!(
+              value: value,
+              handled_error: handled_error,
+              retried: current_thread.error_on_retry.present?
+            )
+            ExecutionResult.new(value: value, handled_error: handled_error, retried: current_thread.error_on_retry.present?)
           rescue StandardError => e
-            instrument_payload[:execution_result] = ExecutionResult.new(value: nil, unhandled_error: e)
+            instrument_payload[:unhandled_error] = e
+            ExecutionResult.new(value: nil, unhandled_error: e)
           end
         end
 


### PR DESCRIPTION
This will enable listeners to log different things depending on the result of execution (in particular, I will use it to log the result as a statsd tag)