### PR TITLE
Allow joining executions to jobs scoped by state

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -23,6 +23,26 @@ module GoodJob
       def table_name=(_value)
         raise NotImplementedError, 'Assign GoodJob::Execution.table_name directly'
       end
+
+      def json_string(json, attr)
+        Arel::Nodes::Grouping.new(Arel::Nodes::InfixOperation.new('->>', json, Arel::Nodes.build_quoted(attr)))
+      end
+
+      def job_class
+        json_string(arel_table['serialized_params'], 'job_class')
+      end
+
+      def scheduled_at_created_at
+        arel_table.coalesce(arel_table['scheduled_at'], arel_table['created_at'])
+      end
+
+      def execution_count
+        Arel::Nodes::InfixOperation.new(
+          '::',
+          json_string(arel_table['serialized_params'], 'executions'),
+          Arel.sql('integer')
+        )
+      end
     end
 
     self.primary_key = 'active_job_id'
@@ -39,7 +59,7 @@ module GoodJob
     # @!scope class
     # @param string [String] Execution class name
     # @return [ActiveRecord::Relation]
-    scope :job_class, ->(job_class) { where("serialized_params->>'job_class' = ?", job_class) }
+    scope :job_class, ->(job_class) { where(job_class.eq(job_class)) }
 
     # Get Jobs finished before the given timestamp.
     # @!method finished_before(timestamp)
@@ -49,11 +69,11 @@ module GoodJob
     scope :finished_before, ->(timestamp) { where(arel_table['finished_at'].lteq(timestamp)) }
 
     # First execution will run in the future
-    scope :scheduled, -> { where(finished_at: nil).where('COALESCE(scheduled_at, created_at) > ?', DateTime.current).where("(serialized_params->>'executions')::integer < 2") }
+    scope :scheduled, -> { where(finished_at: nil).where(scheduled_at_created_at.gt(DateTime.current)).where(execution_count.lt(2)) }
     # Execution errored, will run in the future
-    scope :retried, -> { where(finished_at: nil).where('COALESCE(scheduled_at, created_at) > ?', DateTime.current).where("(serialized_params->>'executions')::integer > 1") }
+    scope :retried, -> { where(finished_at: nil).where(scheduled_at_created_at.gt(DateTime.current)).where(execution_count.gt(1)) }
     # Immediate/Scheduled time to run has passed, waiting for an available thread run
-    scope :queued, -> { where(finished_at: nil).where('COALESCE(scheduled_at, created_at) <= ?', DateTime.current).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
+    scope :queued, -> { where(finished_at: nil).where(scheduled_at_created_at.lteq(DateTime.current)).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
     # Advisory locked and executing
     scope :running, -> { where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
     # Finished executing (succeeded or discarded)

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -28,20 +28,20 @@ module GoodJob
         Arel::Nodes::Grouping.new(Arel::Nodes::InfixOperation.new('->>', json, Arel::Nodes.build_quoted(attr)))
       end
 
-      def job_class
+      def params_job_class
         json_string(arel_table['serialized_params'], 'job_class')
       end
 
-      def scheduled_at_created_at
-        arel_table.coalesce(arel_table['scheduled_at'], arel_table['created_at'])
-      end
-
-      def execution_count
+      def params_execution_count
         Arel::Nodes::InfixOperation.new(
           '::',
           json_string(arel_table['serialized_params'], 'executions'),
           Arel.sql('integer')
         )
+      end
+
+      def coalesce_scheduled_at_created_at
+        arel_table.coalesce(arel_table['scheduled_at'], arel_table['created_at'])
       end
     end
 
@@ -59,7 +59,7 @@ module GoodJob
     # @!scope class
     # @param string [String] Execution class name
     # @return [ActiveRecord::Relation]
-    scope :job_class, ->(job_class) { where(job_class.eq(job_class)) }
+    scope :job_class, ->(name) { where(params_job_class.eq(name)) }
 
     # Get Jobs finished before the given timestamp.
     # @!method finished_before(timestamp)
@@ -69,11 +69,11 @@ module GoodJob
     scope :finished_before, ->(timestamp) { where(arel_table['finished_at'].lteq(timestamp)) }
 
     # First execution will run in the future
-    scope :scheduled, -> { where(finished_at: nil).where(scheduled_at_created_at.gt(DateTime.current)).where(execution_count.lt(2)) }
+    scope :scheduled, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.gt(DateTime.current)).where(params_execution_count.lt(2)) }
     # Execution errored, will run in the future
-    scope :retried, -> { where(finished_at: nil).where(scheduled_at_created_at.gt(DateTime.current)).where(execution_count.gt(1)) }
+    scope :retried, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.gt(DateTime.current)).where(params_execution_count.gt(1)) }
     # Immediate/Scheduled time to run has passed, waiting for an available thread run
-    scope :queued, -> { where(finished_at: nil).where(scheduled_at_created_at.lteq(DateTime.current)).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
+    scope :queued, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(DateTime.current)).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
     # Advisory locked and executing
     scope :running, -> { where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
     # Finished executing (succeeded or discarded)


### PR DESCRIPTION
To do this, we need arel to be able to track the current table name for jobs (otherwise we get ambiguous column errors), so we construct arel nodes instead of using raw sql strings

This allows me to do something like:

```ruby
Filter.new({}).filtered_query(state:)
.joins(:executions).then do |rel|
      rel.pluck(
        *rel.group_values,
        Arel::Nodes::Max.new(
          [Arel::Nodes.build_quoted(now, rel.arel_table[:created_at]) -
            rel.arel_table.coalesce(*rel.send(:arel_columns, %w[executions_good_jobs.performed_at executions_good_jobs.finished_at executions_good_jobs.scheduled_at executions_good_jobs.created_at]))]
        )
      )
        .to_h { |*a, v| [a, v] }
    end
```