### PR TITLE
Add translate_hash to handle missing translation keys that return hashes; only show translatable/available locales in dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ GoodJob's concurrency control strategy for `perform_limit` is "optimistic retry 
 - "Optimistic" meaning that the implementation's performance trade-off assumes that collisions are atypical (e.g. two users enqueue the same job at the same time) rather than regular (e.g. the system enqueues thousands of colliding jobs at the same time). Depending on your concurrency requirements, you may also want to manage concurrency through the number of GoodJob threads and processes that are performing a given queue.
 - "Retry with an incremental backoff" means that when `perform_limit` is exceeded, the job will raise a `GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError` which is caught by a `retry_on` handler which re-schedules the job to execute in the near future with an incremental backoff.
 - First-in-first-out job execution order is not preserved when a job is retried with incremental back-off.
-- For pessimistic usecases that collisions are expected, use number of threads/processes (e.g., `good_job --queue "serial:1;-serial:5"`) to control concurrency. It is also a good idea to use `perform_limit` as backstop.
+- For pessimistic usecases that collisions are expected, use number of threads/processes (e.g., `good_job --queues "serial:1;-serial:5"`) to control concurrency. It is also a good idea to use `perform_limit` as backstop.
 
 ### Cron-style repeating/recurring jobs
 

--- a/app/controllers/good_job/application_controller.rb
+++ b/app/controllers/good_job/application_controller.rb
@@ -47,5 +47,6 @@ module GoodJob
     def good_job_available_locales
       @_good_job_available_locales ||= GoodJob::Engine.root.join("config/locales").glob("*.yml").map { |path| File.basename(path, ".yml").to_sym }.uniq
     end
+    helper_method :good_job_available_locales
   end
 end

--- a/app/helpers/good_job/application_helper.rb
+++ b/app/helpers/good_job/application_helper.rb
@@ -57,5 +57,14 @@ module GoodJob
       partial = lookup_context.find_template("good_job/shared/icons/#{name}", [], true)
       partial.render(self, {})
     end
+
+    def translate_hash(key, **options)
+      translation_exists?(key, **options) ? translate(key, **options) : {}
+    end
+
+    def translation_exists?(key, **options)
+      true if good_job_available_locales.include?(I18n.locale)
+      I18n.exists?(scope_key_by_partial(key), **options)
+    end
   end
 end

--- a/app/views/good_job/shared/_filter.erb
+++ b/app/views/good_job/shared/_filter.erb
@@ -15,7 +15,7 @@
             <option value="" <%= "selected='selected'" if params[:queue_name].blank? %>>All queues</option>
 
             <% filter.queues.each do |name, count| %>
-              <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:queue_name] == name %>><%= name %> (<%= number_with_delimiter(count, t('good_job.number.format')) %>)</option>
+              <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:queue_name] == name %>><%= name %> (<%= number_with_delimiter(count, translate_hash('good_job.number.format')) %>)</option>
             <% end %>
           </select>
         </div>
@@ -26,7 +26,7 @@
             <option value="" <%= "selected='selected'" if params[:job_class].blank? %>>All jobs</option>
 
             <% filter.job_classes.each do |name, count| %>
-              <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:job_class] == name %>><%= name %> (<%= number_with_delimiter(count, t('good_job.number.format')) %>)</option>
+              <option value="<%= name.to_param %>" <%= "selected='selected'" if params[:job_class] == name %>><%= name %> (<%= number_with_delimiter(count, translate_hash('good_job.number.format')) %>)</option>
             <% end %>
           </select>
         </div>
@@ -56,7 +56,7 @@
         <li class="nav-item">
           <%= link_to filter.to_params(state: name), class: "nav-link #{"active" if params[:state] == name}" do %>
             <%= t(name, scope: 'good_job.status') %>
-            <span class="badge bg-primary rounded-pill <%= "bg-secondary" if count == 0 %>"><%= number_with_delimiter(count, t('good_job.number.format')) %></span>
+            <span class="badge bg-primary rounded-pill <%= "bg-secondary" if count == 0 %>"><%= number_with_delimiter(count, translate_hash('good_job.number.format')) %></span>
           <% end %>
         </li>
       <% end %>

--- a/app/views/good_job/shared/_navbar.erb
+++ b/app/views/good_job/shared/_navbar.erb
@@ -11,14 +11,14 @@
           <%= link_to jobs_path, class: ["nav-link", ("active" if controller_name == 'jobs')] do %>
             <%= t(".jobs") %>
             <% jobs_count = GoodJob::Job.count %>
-            <span class="badge bg-secondary rounded-pill"><%= number_to_human(jobs_count, **I18n.t("good_job.number.human.decimal_units")) %></span>
+            <span class="badge bg-secondary rounded-pill"><%= number_to_human(jobs_count, **translate_hash("good_job.number.human.decimal_units")) %></span>
         <% end %>
         </li>
         <li class="nav-item">
           <%= link_to batches_path, class: ["nav-link", ("active" if controller_name == 'batches')] do %>
             <%= "Batches" %>
             <% batches_count = GoodJob::BatchRecord.migrated? ? GoodJob::BatchRecord.all.size : 0 %>
-            <span class="badge bg-secondary rounded-pill"><%= number_to_human(batches_count, units: I18n.t("good_job.number.human.decimal_units.units"), precision: 3) %></span>
+            <span class="badge bg-secondary rounded-pill"><%= number_to_human(batches_count, **translate_hash("good_job.number.human.decimal_units")) %></span>
           <% end %>
         </li>
         <li class="nav-item">
@@ -49,7 +49,8 @@
           </a>
 
           <ul class="dropdown-menu" aria-labelledby="localeOptions">
-            <% I18n.available_locales.reject { |locale| locale == I18n.locale }.each do |locale| %>
+            <% possible_locales = I18n.enforce_available_locales ? (good_job_available_locales & I18n.available_locales) : good_job_available_locales %>
+            <% possible_locales.reject { |locale| locale == I18n.locale }.each do |locale| %>
               <li><%= link_to locale, url_for(locale: locale), class: "dropdown-item" %></li>
             <% end %>
           </ul>

--- a/spec/support/logger.rb
+++ b/spec/support/logger.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.around do |example|
+    Rails.logger.debug { "\n\n---- START EXAMPLE: #{example.full_description} (#{example.location})" }
+    example.run
+    Rails.logger.debug { "---- END EXAMPLE: #{example.full_description} (#{example.location})\n\n" }
+  end
+end


### PR DESCRIPTION
Closes #889 