### PR TITLE
Remove non-ActiveRecord::Base backed association

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -70,7 +70,6 @@ module GoodJob
     end
 
     belongs_to :batch, class_name: 'GoodJob::BatchRecord', optional: true, inverse_of: :executions
-    belongs_to :batch_callback, class_name: 'GoodJob::Batch', optional: true
 
     belongs_to :job, class_name: 'GoodJob::Job', foreign_key: 'active_job_id', primary_key: 'active_job_id', optional: true, inverse_of: :executions
     after_destroy -> { self.class.active_job_id(active_job_id).delete_all }, if: -> { @_destroy_job }


### PR DESCRIPTION
I have a project using GoodJob that I attempted to autogenerate [Sorbet](https://github.com/sorbet/sorbet) types for today. During [`bin/tapioca dsl`](https://github.com/Shopify/tapioca#generating-rbi-files-for-rails-and-other-dsls) I was running into this error:

```
/Users/rick/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4.2/lib/active_record/reflection.rb:436:in `compute_class': ArgumentError: Rails couldn't find a valid model for GoodJob::Batch association. Please provide the :class_name option on the association declaration. If :class_name is already provided, make sure it's an ActiveRecord::Base subclass. (Parallel::UndumpableException)
	from /Users/rick/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4.2/lib/active_record/reflection.rb:382:in `klass'
```

I traced the breaking association to `GoodJob::Execution#batch_callback`. From what I can tell, this association is not referenced anywhere in the code, nor is it valid because it relies on a PORO as its backing class. I was able to reproduce the issue by following the association on one of my execution records:

```
Loading development environment (Rails 7.0.4.2)
irb(main):001:0> GoodJob::Execution.first.batch_callback
  GoodJob::Execution Load (2.0ms)  SELECT "good_jobs".* FROM "good_jobs" ORDER BY "good_jobs"."id" ASC LIMIT $1  [["LIMIT", 1]]
/Users/rick/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/activerecord-7.0.4.2/lib/active_record/reflection.rb:436:in `compute_class': Rails couldn't find a valid model for GoodJob::Batch association. Please provide the :class_name option on the association declaration. If :class_name is already provided, make sure it's an ActiveRecord::Base subclass. (ArgumentError)
```

Seems to me like removing it is probably the best thing to do.

Thanks for all the hard work!