### PR TITLE
 Have cron use `ActiveRecord::EnqueueError` instead of raising and catching ActiveRecord::RecordNotUnique

### DIFF
--- a/app/models/good_job/cron_entry.rb
+++ b/app/models/good_job/cron_entry.rb
@@ -108,10 +108,10 @@ module GoodJob # :nodoc:
         configured_job = job_class.constantize.set(set_value)
         I18n.with_locale(I18n.default_locale) do
           kwargs_value.present? ? configured_job.perform_later(*args_value, **kwargs_value) : configured_job.perform_later(*args_value)
+        rescue ActiveRecord::RecordNotUnique # only raised in Rails < v7.0; Rails 7.0+ uses ActiveJob::EnqueueError
+          false
         end
       end
-    rescue ActiveRecord::RecordNotUnique
-      false
     end
 
     def last_job

--- a/spec/app/models/good_job/cron_entry_spec.rb
+++ b/spec/app/models/good_job/cron_entry_spec.rb
@@ -106,6 +106,14 @@ describe GoodJob::CronEntry do
       I18n.default_locale = :en
     end
 
+    it 'handles job errors if the job has already been inserted' do
+      ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+      cron_at = Time.zone.now.at_midnight
+
+      expect(entry.enqueue(cron_at)).to be_a TestJob
+      expect(entry.enqueue(cron_at)).to be false
+    end
+
     describe 'job execution' do
       it 'executes the job properly' do
         perform_enqueued_jobs do


### PR DESCRIPTION
I'm reluctant to merge this until https://github.com/rails/rails/pull/47865 is accepted. The wrong log message is confusing:

```ruby
[ActiveJob]   TRANSACTION (0.1ms)  BEGIN
[ActiveJob]   GoodJob::Execution Create (0.7ms)  INSERT INTO "good_jobs" ("queue_name", "priority", "serialized_params", "scheduled_at", "performed_at", "finished_at", "error", "created_at", "updated_at", "active_job_id", "concurrency_key", "cron_key", "retried_good_job_id", "cron_at", "batch_id", "batch_callback_id") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) RETURNING "id"  [["queue_name", "test_queue"], ["priority", 0], ["serialized_params", "{\"job_class\":\"TestJob\",\"job_id\":\"6272b9c4-69e3-41cb-b981-ab0077432b13\",\"provider_job_id\":null,\"queue_name\":\"test_queue\",\"priority\":null,\"arguments\":[42,{\"name\":\"Alice\",\"_aj_ruby2_keywords\":[\"name\"]}],\"executions\":0,\"exception_executions\":{},\"locale\":\"en\",\"timezone\":\"UTC\",\"enqueued_at\":\"2023-04-03T15:15:59.605713000Z\"}"], ["scheduled_at", nil], ["performed_at", nil], ["finished_at", nil], ["error", nil], ["created_at", "2023-04-03 15:15:59.607601"], ["updated_at", "2023-04-03 15:15:59.607601"], ["active_job_id", "6272b9c4-69e3-41cb-b981-ab0077432b13"], ["concurrency_key", nil], ["cron_key", "test"], ["retried_good_job_id", nil], ["cron_at", "2023-04-03 00:00:00"], ["batch_id", nil], ["batch_callback_id", nil]]
[ActiveJob]   TRANSACTION (0.1ms)  ROLLBACK
[ActiveJob] Enqueued TestJob (Job ID: 6272b9c4-69e3-41cb-b981-ab0077432b13) to (test_queue) with arguments: 42, {:name=>"Alice"}
```

