### PR TITLE
Switches from Chrome to Chromium to support Apple M1/Arm CPUs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/devcontainers/ruby:2.7-bullseye
 
 # Default value to allow debug server to serve content over GitHub Codespace's port forwarding service
-# The value is a comma-separated list of allowed domains 
+# The value is a comma-separated list of allowed domains
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.app.github.dev"
 
 ARG NODE_VERSION="lts/*"
@@ -15,16 +15,10 @@ RUN wget -q -O /tmp/linux_signing_key.pub https://dl-ssl.google.com/linux/linux_
 # Install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
   && apt-get -y install --no-install-recommends \
-    google-chrome-stable \
+    chromium \
+    chromium-driver \
     postgresql-client \
   && rm -rf /var/lib/apt/lists/*
-
-# Install Chromedriver
-RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` \
-    && wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
-    && unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/ \
-    && rm /tmp/chromedriver.zip \
-    && chmod ugo+rx /usr/local/bin/chromedriver
 
 # Install specific version of Bundler
 RUN gem install bundler:2.3.25


### PR DESCRIPTION
Attempting to build the current devcontainer on `main` yields:

`Unable to locate package google-chrome-stable`.

Switching from `google-chrome-stable` to `chromium` helps to resolve this, but it leaves the chromedriver installation installing chromedriver_linux64.zip which bails with:

`qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory`.   

This PR swaps both over!  This should still be fine on x86, but there may be consequences I'm not aware of from making this swap.


