### PR TITLE
Adds `GoodJob.system_info`

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -200,7 +200,7 @@ module GoodJob
     end
   end
 
-  def self.system_info()
+  def self.system_info
     {
       "VERSION" => VERSION,
       "RUBY_VERSION" => RUBY_VERSION,
@@ -210,7 +210,7 @@ module GoodJob
       "QUEUES" => configuration.queue_string,
       "POLL_INTERVAL" => configuration.poll_interval,
       "NOTIFIER_LISTENING" => configuration.enable_listen_notify,
-      "PROCESSES" => "[" + Process.all.map { |p| p.current_state.to_s }.join(',') + "]",
+      "PROCESSES" => "[#{Process.all.map { |p| p.current_state.to_s }.join(',')}]",
     }
   end
 

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -200,5 +200,19 @@ module GoodJob
     end
   end
 
+  def self.system_info()
+    {
+      "VERSION" => VERSION,
+      "RUBY_VERSION" => RUBY_VERSION,
+      "RAILS_VERSION" => Rails.version,
+      "RAILS_ENV" => Rails.env,
+      "EXECUTION_MODE" => configuration.execution_mode,
+      "QUEUES" => configuration.queue_string,
+      "POLL_INTERVAL" => configuration.poll_interval,
+      "NOTIFIER_LISTENING" => configuration.enable_listen_notify,
+      "PROCESSES" => "[" + Process.all.map { |p| p.current_state.to_s }.join(',') + "]",
+    }
+  end
+
   ActiveSupport.run_load_hooks(:good_job, self)
 end

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -135,7 +135,7 @@ describe GoodJob do
   end
 
   describe '.system_info' do
-    it 'returns expecrted systen information' do
+    it 'returns expected systen information' do
       system_info = described_class.system_info
       expect(system_info.keys).to eq %w[
         VERSION

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -133,4 +133,23 @@ describe GoodJob do
       expect(PERFORMED.size).to eq 1
     end
   end
+
+  describe '.system_info' do
+    it 'returns expecrted systen information' do
+      system_info = GoodJob.system_info
+      expect(system_info.keys).to eq [
+        "VERSION",
+        "RUBY_VERSION",
+        "RAILS_VERSION",
+        "RAILS_ENV",
+        "EXECUTION_MODE",
+        "QUEUES",
+        "POLL_INTERVAL",
+        "NOTIFIER_LISTENING",
+        "PROCESSES",
+      ]
+
+      expect(system_info["EXECUTION_MODE"]).to eq :inline
+    end
+  end
 end

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -136,17 +136,17 @@ describe GoodJob do
 
   describe '.system_info' do
     it 'returns expecrted systen information' do
-      system_info = GoodJob.system_info
-      expect(system_info.keys).to eq [
-        "VERSION",
-        "RUBY_VERSION",
-        "RAILS_VERSION",
-        "RAILS_ENV",
-        "EXECUTION_MODE",
-        "QUEUES",
-        "POLL_INTERVAL",
-        "NOTIFIER_LISTENING",
-        "PROCESSES",
+      system_info = described_class.system_info
+      expect(system_info.keys).to eq %w[
+        VERSION
+        RUBY_VERSION
+        RAILS_VERSION
+        RAILS_ENV
+        EXECUTION_MODE
+        QUEUES
+        POLL_INTERVAL
+        NOTIFIER_LISTENING
+        PROCESSES
       ]
 
       expect(system_info["EXECUTION_MODE"]).to eq :inline


### PR DESCRIPTION
First pass at adding a `GoodJob.system_info` console-able command.  I didn't see a great spot in the README for this, but it might be good to mention in the issue creation template on Github. "Paste the output of `GoodJob.system_info` from a Rails console"?

```ruby
[1] pry(main)> GoodJob.system_info
  GoodJob::Process Load (0.8ms)  SELECT "good_job_processes".* FROM "good_job_processes"
=> {"VERSION"=>"3.15.0",
 "RUBY_VERSION"=>"2.7.7",
 "RAILS_VERSION"=>"7.0.4.3",
 "RAILS_ENV"=>"development",
 "EXECUTION_MODE"=>:async,
 "QUEUES"=>"*",
 "POLL_INTERVAL"=>-1,
 "NOTIFIER_LISTENING"=>true,
 "PROCESSES"=>"[]"}
```

This is a first crack at a real PR here,  before diving into the scheduler stats that I'm really looking for here: https://github.com/bensheldon/good_job/issues/532