### PR TITLE
Use `GoodJob.capsule` in CLI instead of creating a new Capsule

### DIFF
--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -92,10 +92,10 @@ module GoodJob
       set_up_application!
       GoodJob.configuration.options.merge!(options.symbolize_keys)
       configuration = GoodJob.configuration
+      capsule = GoodJob.capsule
 
       Daemon.new(pidfile: configuration.pidfile).daemonize if configuration.daemonize?
 
-      capsule = GoodJob::Capsule.new
       capsule.start
 
       if configuration.probe_port

--- a/spec/lib/good_job/cli_spec.rb
+++ b/spec/lib/good_job/cli_spec.rb
@@ -7,17 +7,18 @@ RSpec.describe GoodJob::CLI do
   before do
     stub_const 'GoodJob::CLI::RAILS_ENVIRONMENT_RB', File.expand_path("spec/test_app/config/environment.rb")
     allow(GoodJob).to receive(:configuration).and_return(GoodJob::Configuration.new({}))
-    allow(GoodJob::Capsule).to receive(:new).and_return capsule_mock
+    allow(GoodJob).to receive(:capsule).and_return capsule_mock
   end
 
   describe '#start' do
-    it 'initializes a capsule' do
+    it 'starts and stops a capsule' do
       allow(Kernel).to receive(:loop)
 
       cli = described_class.new([], {}, {})
       cli.start
 
-      expect(GoodJob::Capsule).to have_received(:new)
+      expect(capsule_mock).to have_received(:start)
+      expect(capsule_mock).to have_received(:shutdown)
     end
 
     it 'can gracefully shut down on INT signal' do
@@ -30,7 +31,6 @@ RSpec.describe GoodJob::CLI do
 
       sleep_until { cli_thread.fulfilled? }
 
-      expect(GoodJob::Capsule).to have_received(:new)
       expect(capsule_mock).to have_received(:shutdown)
     end
 

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -27,7 +27,7 @@ describe GoodJob do
 
   describe '.restart' do
     it 'does nothing when there are no capsule instances' do
-      expect(GoodJob::Capsule.instances).to be_empty
+      GoodJob::Capsule.instances.clear
       expect { described_class.restart }.not_to change(described_class, :shutdown?).from(true)
     end
 

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -49,6 +49,10 @@ RSpec.configure do |config|
     expect(GoodJob::Capsule.instances).to all be_shutdown
     GoodJob::Capsule.instances.clear
 
+    # always make sure there is a capsule; unstub it first if necessary
+    RSpec::Mocks.space.proxy_for(GoodJob::Capsule).reset
+    GoodJob.capsule = GoodJob::Capsule.new
+
     expect(PgLock.current_database.advisory_lock.owns.count).to eq(0), "Existing owned advisory locks AFTER test run"
 
     other_locks = PgLock.current_database.advisory_lock.others


### PR DESCRIPTION
This is a good improvement. I think that extra capsules lingering around may have been a contributor to #849. 

Remembering when I [previously implemented Capsule](https://github.com/bensheldon/good_job/pull/861), I think I believed that it would be necessary to create the separate, self-contained capsule in the CLI because the `GoodJob.capsule` would not be started/running (because the CLI always runs in `:external`) mode. But now I realize I can simply explicitly start the capsule 🤷🏻 