### PR TITLE
Set `successfully_enqueued?` when using `perform_all_later`

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -64,6 +64,7 @@ module GoodJob
         job_id_to_provider_job_id = results.each_with_object({}) { |result, hash| hash[result['active_job_id']] = result['id'] }
         active_jobs.each do |active_job|
           active_job.provider_job_id = job_id_to_provider_job_id[active_job.job_id]
+          active_job.successfully_enqueued = active_job.provider_job_id.present? if active_job.respond_to?(:successfully_enqueued=)
         end
         executions.each do |execution|
           execution.instance_variable_set(:@new_record, false) if job_id_to_provider_job_id[execution.active_job_id]

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -36,6 +36,18 @@ RSpec.describe 'Adapter Integration' do
         expect(enqueued_job.provider_job_id).to eq execution.id
       end
 
+      it 'assigns successfully_enqueued' do
+        ok_job = TestJob.perform_later
+        expect { ok_job.enqueue }.not_to raise_error
+        expect(ok_job.successfully_enqueued?).to be true if ok_job.respond_to?(:successfully_enqueued?)
+
+        allow(TestJob.queue_adapter).to receive(:enqueue).and_raise(StandardError)
+
+        bad_job = TestJob.new
+        expect { bad_job.enqueue }.to raise_error(StandardError)
+        expect(bad_job.successfully_enqueued?).to be false if bad_job.respond_to?(:successfully_enqueued?)
+      end
+
       it 'without a scheduled time' do
         expect do
           TestJob.perform_later('first', 'second', keyword_arg: 'keyword_arg')


### PR DESCRIPTION
Noticed this deficiency via https://github.com/rails/rails/pull/47844#discussion_r1155451273
