### PR TITLE
In tests, directly use `connection.truncate_tables` instead of  `ActiveRecord::Tasks::DatabaseTasks.truncate_all`

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -5,11 +5,16 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+    ApplicationRecord.connection_pool.with_connection do |connection|
+      connection.truncate_tables(*connection.tables)
+    end
   end
 
   config.around do |example|
     example.run
-    ActiveRecord::Tasks::DatabaseTasks.truncate_all
+
+    ApplicationRecord.connection_pool.with_connection do |connection|
+      connection.truncate_tables(*connection.tables)
+    end
   end
 end


### PR DESCRIPTION
Connects to https://github.com/bensheldon/good_job/issues/849#issuecomment-1496641841