### PR TITLE
Fix Lockable's `SELECT 1 AS one` queries missing `LIMIT 1`

### DIFF
--- a/app/models/good_job/lockable.rb
+++ b/app/models/good_job/lockable.rb
@@ -324,6 +324,7 @@ module GoodJob
           AND pg_locks.objsubid = 1
           AND pg_locks.classid = ('x' || substr(md5($1::text), 1, 16))::bit(32)::int
           AND pg_locks.objid = (('x' || substr(md5($2::text), 1, 16))::bit(64) << 32)::bit(32)::int
+        LIMIT 1
       SQL
       binds = [
         ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),
@@ -351,6 +352,7 @@ module GoodJob
           AND pg_locks.classid = ('x' || substr(md5($1::text), 1, 16))::bit(32)::int
           AND pg_locks.objid = (('x' || substr(md5($2::text), 1, 16))::bit(64) << 32)::bit(32)::int
           AND pg_locks.pid = pg_backend_pid()
+        LIMIT 1
       SQL
       binds = [
         ActiveRecord::Relation::QueryAttribute.new('key', key, ActiveRecord::Type::String.new),

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -118,7 +118,12 @@ class PgLock < ActiveRecord::Base
     query = <<~SQL.squish
       SELECT pg_advisory_unlock(($1::bigint << 32) + $2::bigint) AS unlocked
     SQL
-    self.class.connection.exec_query(GoodJob::Execution.pg_or_jdbc_query(query), 'PgLock Advisory Unlock', [[nil, classid], [nil, objid]]).first['unlocked']
+
+    binds = [
+      ActiveRecord::Relation::QueryAttribute.new('classid', classid, ActiveRecord::Type::String.new),
+      ActiveRecord::Relation::QueryAttribute.new('objid', objid, ActiveRecord::Type::String.new),
+    ]
+    self.class.connection.exec_query(GoodJob::Execution.pg_or_jdbc_query(query), 'PgLock Advisory Unlock', binds).first['unlocked']
   end
 
   def unlock!


### PR DESCRIPTION
I don't foresee this having significant performance improvement, but it is a notable omission of these queries.

Connect to #896 