### PR TITLE
Fix hard-coded and duplicated table_name

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -35,7 +35,7 @@ module GoodJob
       end
 
       def discrete_support?
-        if connection.table_exists?('good_job_executions')
+        if connection.table_exists?(DiscreteExecution.table_name)
           true
         else
           migration_pending_warning!


### PR DESCRIPTION
This is a fix for https://github.com/bensheldon/good_job/issues/957.
It simply changes the hard-coded table_name string to a symbolic constant reference.