### PR TITLE
Fix flaky jruby test to widen time-based range

### DIFF
--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe GoodJob::Adapter do
       expect(GoodJob::Job.last).to have_attributes(
         queue_name: 'elephant',
         priority: -55,
-        scheduled_at: be_within(0.1).of(10.minutes.from_now)
+        scheduled_at: be_within(1).of(10.minutes.from_now)
       )
     end
 


### PR DESCRIPTION
Follow-up to #960. I'm reminded that JRuby has a very "in its own time" approach.