### PR TITLE
Ensure migration warning for `DiscreteExecution` constant is in explicit `GoodJob::` namespace

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -35,7 +35,7 @@ module GoodJob
       end
 
       def discrete_support?
-        if connection.table_exists?(DiscreteExecution.table_name)
+        if connection.table_exists?(GoodJob::DiscreteExecution.table_name)
           true
         else
           migration_pending_warning!


### PR DESCRIPTION
Fixes #962.