### PR TITLE
Fix `discrete_executions` job re-enqueueing when `retry_job` is called directly

### DIFF
--- a/lib/good_job/current_thread.rb
+++ b/lib/good_job/current_thread.rb
@@ -13,6 +13,7 @@ module GoodJob
       error_on_retry
       execution
       execution_interrupted
+      execution_retried
     ].freeze
 
     # @!attribute [rw] cron_at
@@ -50,6 +51,12 @@ module GoodJob
     #   Execution Interrupted
     #   @return [Boolean, nil]
     thread_mattr_accessor :execution_interrupted
+
+    # @!attribute [rw] execution_retried
+    #   @!scope class
+    #   Execution Retried
+    #   @return [Boolean, nil]
+    thread_mattr_accessor :execution_retried
 
     # Resets attributes
     # @param [Hash] values to assign

--- a/spec/lib/good_job/current_thread_spec.rb
+++ b/spec/lib/good_job/current_thread_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe GoodJob::CurrentThread do
     :execution,
     :error_on_discard,
     :error_on_retry,
+    :execution,
+    :execution_interrupted,
+    :execution_retried,
   ].each do |accessor|
     describe ".#{accessor}" do
       it 'maintains value across threads' do
@@ -58,6 +61,7 @@ RSpec.describe GoodJob::CurrentThread do
         error_on_retry: false,
         execution: instance_double(GoodJob::Execution),
         execution_interrupted: nil,
+        execution_retried: nil,
       }
 
       described_class.reset(value)


### PR DESCRIPTION
Fixes #972.

Now uses a distinct attribute on `CurrentThread` to track if the job is reenqueued/retried; previously was only using the presence of a job exception to indicate a retry.