### PR TITLE
Do not allow GoodJob to automatically start after Rails initialization if previously shutdown

### DIFF
--- a/spec/lib/good_job/capsule_spec.rb
+++ b/spec/lib/good_job/capsule_spec.rb
@@ -26,9 +26,35 @@ describe GoodJob::Capsule do
       capsule.shutdown
       expect(GoodJob::Scheduler.instances.size).to eq 1
     end
+
+    it 'will not start if previously shutdown' do
+      capsule = described_class.new
+      capsule.shutdown
+
+      expect { capsule.start }.not_to change(capsule, :running?).from(false)
+    end
+  end
+
+  describe '#restart' do
+    it 'can start a previously shutdown capsule' do
+      capsule = described_class.new
+      capsule.shutdown
+
+      expect { capsule.restart }.to change(capsule, :running?).from(false).to(true)
+      expect { capsule.restart }.not_to change(capsule, :running?).from(true)
+      expect { capsule.shutdown }.to change(capsule, :running?).from(true).to(false)
+    end
   end
 
   describe '#shutdown' do
+    it 'shuts down the capsule' do
+      capsule = described_class.new
+      capsule.start
+
+      expect { capsule.shutdown }.to change(capsule, :running?).from(true).to(false)
+      expect(GoodJob::Notifier.instances).to all be_shutdown
+    end
+
     it 'operates if the capsule has not been started' do
       capsule = described_class.new
       expect { capsule.shutdown }.not_to raise_error


### PR DESCRIPTION
This edge case was discovered while trying to set up PhusionPassenger: https://github.com/bensheldon/good_job/discussions/940#discussioncomment-6109244

Passenger recommends putting lifecycle hooks in `config/application.rb`. The "Shut down GoodJob in the App Preloader process," therefore, takes place _before_ Rails fully initializes. This leads to GoodJob being shut down _before_ GoodJob starts, which leads to GoodJob still being started, which is not desired. 

This has not been a problem with Puma because Puma has a nice `before_fork` hook that happens after Rails initializes. 