### PR TITLE
Replace uncached table_exists? with cached table_exists?

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -35,12 +35,7 @@ module GoodJob
       end
 
       def discrete_support?
-        if connection.table_exists?(GoodJob::DiscreteExecution.table_name)
-          true
-        else
-          migration_pending_warning!
-          false
-        end
+        DiscreteExecution.migrated?
       end
     end
 

--- a/app/models/good_job/base_record.rb
+++ b/app/models/good_job/base_record.rb
@@ -21,7 +21,7 @@ module GoodJob
     # Can be overriden by child class.
     # @return [Boolean]
     def self.migrated?
-      return true if connection.table_exists?(table_name)
+      return true if table_exists?
 
       migration_pending_warning!
       false


### PR DESCRIPTION
while trying out GoodJob we noticed lots of calls to `pg_class` catalog tables. 

```SQL
SELECT
	c.relname
FROM
	pg_class c
	LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE
	n.nspname = ANY (current_schemas(false))
	AND c.relname = '<good_job_table_name>'
	AND c.relkind IN('r','p')
```


after some investigation we realized these queries were coming from calls to [ActiveRecord::ConnectionAdapters::SchemaStatements#table_exists?](https://edgeapi.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-table_exists-3F) which hits the database every time. we think these migration checks can be more performantly powered by [ActiveRecord::Base#table_exists?](https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-table_exists-3F) which hits the [schema cache](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaCache.html) on the connection. By default the schema cache gets eagerly loaded on initialization (but can be configured to be loaded lazily). this would mean that if the GJ tables were migrated while the app was already running the migration warning would still get triggered until the schema cache was updated (by a redeploy or some other mechanism), but that seems like a reasonable tradeoff.

this would mean that the `GoodJob.active_record_parent_class` must implement `#table_exists?` which is a consideration.

version details:
good_job (3.15.7)
rails (7.0.4.3)
ruby 2.7.7 