### PR TITLE
Ensure `GoodJob::DiscreteExecution` model is namespaced (again)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - ./spec/rubocop/cop/good_job/explicit_namespace_cop.rb
 
 inherit_mode:
   merge:

--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -35,7 +35,7 @@ module GoodJob
       end
 
       def discrete_support?
-        DiscreteExecution.migrated?
+        GoodJob::DiscreteExecution.migrated?
       end
     end
 

--- a/spec/rubocop/cop/good_job/explicit_namespace_cop.rb
+++ b/spec/rubocop/cop/good_job/explicit_namespace_cop.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module GoodJob
+      class ExplicitNamespaceCop < Base
+        CONSTANTS_TO_CHECK = %w[DiscreteExecution].freeze
+        MSG = 'Use GoodJob::%{constant} instead of %{constant}. See https://github.com/bensheldon/good_job/pull/962'
+
+        CONSTANTS_PATTERN = CONSTANTS_TO_CHECK.map { |constant| ":#{constant}" }.join(' ')
+
+        def_node_matcher :constant_access?, <<~PATTERN
+          (const nil? { #{CONSTANTS_PATTERN} } )
+        PATTERN
+
+        def_node_matcher :class_definition?, <<~PATTERN
+          (class
+            (const nil? { #{CONSTANTS_PATTERN} })
+            ...
+          )
+        PATTERN
+
+        def constants_pattern
+          CONSTANTS_TO_CHECK.map { |c| ":#{c}" }.join(' ')
+        end
+
+        def on_const(node)
+          return if class_definition?(node.parent)
+          return unless constant_access?(node)
+
+          constant_name = node.const_name.to_s
+          add_offense(node, message: format(MSG, constant: constant_name))
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/good_job/explicit_namespace_cop_spec.rb
+++ b/spec/rubocop/cop/good_job/explicit_namespace_cop_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+require_relative './explicit_namespace_cop'
+
+RSpec.describe RuboCop::Cop::GoodJob::ExplicitNamespaceCop do
+  include RuboCop::RSpec::ExpectOffense
+
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers an offense when accessing DiscreteExecution' do
+    expect_offense(<<~RUBY)
+      DiscreteExecution.migrated?
+      ^^^^^^^^^^^^^^^^^ GoodJob/ExplicitNamespaceCop: Use GoodJob::DiscreteExecution instead of DiscreteExecution. See https://github.com/bensheldon/good_job/pull/962
+    RUBY
+  end
+
+  it 'does not register an offense when accessing properly namespaced GoodJob::DiscreteExecution' do
+    expect_no_offenses(<<~RUBY)
+      GoodJob::DiscreteExecution.migrated?
+    RUBY
+  end
+
+  it 'does not register an offense when declaring DiscreteExecution' do
+    expect_no_offenses(<<~RUBY)
+      class DiscreteExecution < GoodJob::BaseRecord
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Fixes #962 (which I think is one person's autoloading being problematic) which regressed in #979 and adds a custom Rubocop Cop which is probably extra extra.