### PR TITLE
Add explicit namespace back to `GoodJob::DiscreteExecution`

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -35,7 +35,7 @@ module GoodJob
       end
 
       def discrete_support?
-        DiscreteExecution.migrated?
+        GoodJob::DiscreteExecution.migrated?
       end
     end
 


### PR DESCRIPTION
Replacement of #982 without the cop.

Fixes #962 (which I think is one person's autoloading being problematic) which regressed in #979 