### PR TITLE
Fix CI: Lock traces version for Ruby 2.6 compatible version

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -6,10 +6,12 @@ jruby = RUBY_PLATFORM.include?('java')
 unless ruby_31_or_higher # https://github.com/rails/rails/issues/44090#issuecomment-1007686519
   appraise "rails-6.0" do
     gem "rails", "~> 6.0.0"
+    gem "traces", "~> 0.9.1"
   end
 
   appraise "rails-6.1" do
     gem "rails", "~> 6.1.0"
+    gem "traces", "~> 0.9.1"
   end
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'appraisal', github: 'thoughtbot/appraisal', branch: 'main'
 gem 'matrix'
 gem 'nokogiri'
 gem 'pg', platforms: [:mri, :mingw, :x64_mingw]
+gem 'rack', '~> 2.0'
 gem 'rails'
 
 platforms :ruby do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,19 +99,19 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    async (2.6.0)
+    async (2.6.2)
       console (~> 1.10)
       fiber-annotation
       io-event (~> 1.1)
       timers (~> 4.1)
-    async-http (0.60.1)
+    async-http (0.60.2)
       async (>= 1.25)
       async-io (>= 1.28)
       async-pool (>= 0.2)
       protocol-http (~> 0.24.0)
       protocol-http1 (~> 0.15.0)
       protocol-http2 (~> 0.15.0)
-      traces (>= 0.8.0)
+      traces (>= 0.10.0)
     async-http-faraday (0.12.0)
       async-http (~> 0.42)
       faraday
@@ -129,7 +129,7 @@ GEM
       smart_properties
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.39.1)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -163,7 +163,7 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
-    faraday (2.7.6)
+    faraday (2.7.7)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-http-cache (2.5.0)
@@ -204,13 +204,14 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
     io-event (1.2.2)
-    jdbc-postgres (42.2.25)
+    jdbc-postgres (42.6.0)
     json (2.6.3)
     json (2.6.3-java)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    language_server-protocol (3.17.0.3)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -230,7 +231,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.0)
+    minitest (5.18.1)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
       tomlrb
@@ -239,7 +240,7 @@ GEM
     msgpack (1.7.1)
     msgpack (1.7.1-java)
     multi_json (1.15.0)
-    net-imap (0.3.4)
+    net-imap (0.3.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -266,11 +267,12 @@ GEM
       sawyer (~> 0.9)
     optimist (3.0.1)
     parallel (1.23.0)
-    parser (3.2.2.1)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
+      racc
     pg (1.5.3)
     protocol-hpack (1.4.2)
-    protocol-http (0.24.2)
+    protocol-http (0.24.3)
     protocol-http1 (0.15.0)
       protocol-http (~> 0.22)
     protocol-http2 (0.15.1)
@@ -289,13 +291,13 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.1)
-    puma (5.6.5)
+    puma (5.6.6)
       nio4r (~> 2.0)
-    puma (5.6.5-java)
+    puma (5.6.6-java)
       nio4r (~> 2.0)
     raabro (1.4.0)
-    racc (1.6.2)
-    racc (1.6.2-java)
+    racc (1.7.1)
+    racc (1.7.1-java)
     rack (2.2.7)
     rack-mini-profiler (3.1.0)
       rack (>= 1.2.0)
@@ -337,7 +339,7 @@ GEM
       ffi (>= 1.0.6)
       msgpack (>= 0.4.3)
       optimist (>= 3.0.0)
-    regexp_parser (2.8.0)
+    regexp_parser (2.8.1)
     rexml (3.2.5)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -356,10 +358,11 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.0)
-    rubocop (1.52.0)
+    rubocop (1.53.0)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
@@ -375,7 +378,7 @@ GEM
     rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.19.1)
+    rubocop-rails (2.20.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
@@ -403,10 +406,10 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
-    timeout (0.3.2)
+    timeout (0.4.0)
     timers (4.3.5)
     tomlrb (2.0.3)
-    traces (0.9.1)
+    traces (0.10.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -459,6 +462,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.6)
+  rack (~> 2.0)
   rack-mini-profiler
   rails
   rbtrace
@@ -473,4 +477,4 @@ DEPENDENCIES
   yard-activesupport-concern
 
 BUNDLED WITH
-   2.4.12
+   2.4.14

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -7,7 +7,9 @@ gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/a
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
+gem "rack", "~> 2.0"
 gem "rails", "~> 6.0.0"
+gem "traces", "~> 0.9.1"
 
 platforms :ruby do
   gem "activerecord-explain-analyze"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -7,7 +7,9 @@ gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/a
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
+gem "rack", "~> 2.0"
 gem "rails", "~> 6.1.0"
+gem "traces", "~> 0.9.1"
 
 platforms :ruby do
   gem "activerecord-explain-analyze"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,6 +7,7 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
+gem "rack", "~> 2.0"
 gem "rails", "~> 7.0.0"
 gem "selenium-webdriver", "~> 4.0"
 

--- a/gemfiles/rails_7.0_ruby_3.1.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.1.gemfile
@@ -7,6 +7,7 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
+gem "rack", "~> 2.0"
 gem "rails", "~> 7.0.1"
 gem "capybara", "~> 3.36"
 gem "selenium-webdriver", "~> 4.0"

--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -7,6 +7,7 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
+gem "rack", "~> 2.0"
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
 gem "capybara", "~> 3.36"
 gem "selenium-webdriver", "~> 4.0"

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -92,7 +92,7 @@ module GoodJob
         key = self.class.good_job_concurrency_config[:key]
         return if key.blank?
 
-        key = key.respond_to?(:call) ? instance_exec(&key) : key
+        key = instance_exec(&key) if key.respond_to?(:call)
         raise TypeError, "Concurrency key must be a String; was a #{key.class}" unless VALID_TYPES.any? { |type| key.is_a?(type) }
 
         key

--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -49,7 +49,7 @@ module GoodJob
     #   * +nil+ will trigger a shutdown but not wait for it to complete.
     # @return [void]
     def shutdown(timeout: :default)
-      timeout = timeout == :default ? @configuration.shutdown_timeout : timeout
+      timeout = @configuration.shutdown_timeout if timeout == :default
       GoodJob._shutdown_all([@notifier, @poller, @scheduler, @cron_manager].compact, timeout: timeout)
       @startable = false
       @running = false


### PR DESCRIPTION
Connects to https://github.com/socketry/traces/pull/10