### PR TITLE
Change `is_discrete` to default to `false`

### DIFF
--- a/lib/generators/good_job/templates/install/migrations/add_default_false_to_is_discrete_on_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/add_default_false_to_is_discrete_on_good_jobs.rb.erb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultFalseToIsDiscreteOnGoodJobs < ActiveRecord::Migration<%= migration_version %>
+  def change
+    change_column_default :good_jobs, :is_discrete, from: nil, to: false
+  end
+end

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
   def change
     enable_extension 'pgcrypto'


### PR DESCRIPTION
I got this RuboCop error when I ran `bin/rails g good_job:install` and thought how I could contribute with a simple fix.

Few hours later and I still cannot get the tests to green. :)

Here's the last error:

```
Selenium::WebDriver::Error::SessionNotCreatedError:
  session not created: This version of ChromeDriver only supports Chrome version 94
  Current browser version is 114.0.5735.198 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
```

I opened Chrome to check the browser version and it just updated from 114.0.5735.133 to 114.0.5735.198.
I went to download the chromedriver but, believe it or not, that version is 404-ing. :)
https://googlechromelabs.github.io/chrome-for-testing/#stable

![Screenshot 2023-06-29 at 18 04 23](https://github.com/bensheldon/good_job/assets/67437/ec2618ed-e6d2-49d2-a51a-273c9d2ad737)

At least I have Ruby 3.2.2 installed now. That took at least an hour... :/

I hope there's some value in this. I decided to create another migration so that people who already have the gem installed can run `bin/rails g good_job:install` again and get Rails will only add the new migration to their project.