### PR TITLE
Add association between Process and Jobs, and add a heartbeat to the Process record

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -84,6 +84,13 @@ module GoodJob
         migration_pending_warning!
         false
       end
+
+      def process_lock_migrated?
+        return true if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+
+        migration_pending_warning!
+        false
+      end
     end
 
     # The ActiveJob job class, as a string

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -29,6 +29,7 @@ module GoodJob
     self.implicit_order_column = 'created_at'
 
     belongs_to :batch, class_name: 'GoodJob::BatchRecord', inverse_of: :jobs, optional: true
+    belongs_to :locked_by_process, class_name: "GoodJob::Process", foreign_key: :locked_by_id, inverse_of: :locked_jobs, optional: true
     has_many :executions, -> { order(created_at: :asc) }, class_name: 'GoodJob::Execution', foreign_key: 'active_job_id', inverse_of: :job # rubocop:disable Rails/HasManyOrHasOneDependent
     has_many :discrete_executions, -> { order(created_at: :asc) }, class_name: 'GoodJob::DiscreteExecution', foreign_key: 'active_job_id', primary_key: :active_job_id, inverse_of: :job # rubocop:disable Rails/HasManyOrHasOneDependent
 

--- a/demo/db/migrate/20240518175057_create_good_job_process_lock_ids.rb
+++ b/demo/db/migrate/20240518175057_create_good_job_process_lock_ids.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end

--- a/demo/db/migrate/20240518175058_create_good_job_process_lock_indexes.rb
+++ b/demo/db/migrate/20240518175058_create_good_job_process_lock_indexes.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, [:priority, :scheduled_at],
+                    order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                    where: "finished_at IS NULL AND locked_by_id IS NULL",
+                    name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+                    where: "locked_by_id IS NOT NULL",
+                    name: :index_good_jobs_on_locked_by_id,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, [:process_id, :created_at],
+                    name: :index_good_job_executions_on_process_id_and_created_at,
+                    algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+        remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at) if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+      end
+    end
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_04_17_093204) do
+ActiveRecord::Schema.define(version: 2024_05_18_175058) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -25,9 +25,9 @@ ActiveRecord::Schema.define(version: 2024_04_17_093204) do
     t.text "on_discard"
     t.text "callback_queue_name"
     t.integer "callback_priority"
-    t.datetime "enqueued_at", precision: nil
-    t.datetime "discarded_at", precision: nil
-    t.datetime "finished_at", precision: nil
+    t.datetime "enqueued_at"
+    t.datetime "discarded_at"
+    t.datetime "finished_at"
   end
 
   create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -42,13 +42,16 @@ ActiveRecord::Schema.define(version: 2024_04_17_093204) do
     t.text "error"
     t.integer "error_event", limit: 2
     t.text "error_backtrace", array: true
+    t.uuid "process_id"
     t.index ["active_job_id", "created_at"], name: "index_good_job_executions_on_active_job_id_and_created_at"
+    t.index ["process_id", "created_at"], name: "index_good_job_executions_on_process_id_and_created_at"
   end
 
   create_table "good_job_processes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "state"
+    t.integer "lock_type", limit: 2
   end
 
   create_table "good_job_settings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -81,6 +84,8 @@ ActiveRecord::Schema.define(version: 2024_04_17_093204) do
     t.text "job_class"
     t.integer "error_event", limit: 2
     t.text "labels", array: true
+    t.uuid "locked_by_id"
+    t.datetime "locked_at"
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
@@ -89,8 +94,10 @@ ActiveRecord::Schema.define(version: 2024_04_17_093204) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
     t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -30,6 +30,8 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :job_class
       t.integer :error_event, limit: 2
       t.text :labels, array: true
+      t.uuid :locked_by_id
+      t.datetime :locked_at
     end
 
     create_table :good_job_batches, id: :uuid do |t|
@@ -58,11 +60,13 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.text :error
       t.integer :error_event, limit: 2
       t.text :error_backtrace, array: true
+      t.uuid :process_id
     end
 
     create_table :good_job_processes, id: :uuid do |t|
       t.timestamps
       t.jsonb :state
+      t.integer :lock_type, limit: 2
     end
 
     create_table :good_job_settings, id: :uuid do |t|
@@ -88,5 +92,10 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels
 
     add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+    add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    add_index :good_jobs, :locked_by_id,
+      where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
+    add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/13_create_good_job_process_lock_ids.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/13_create_good_job_process_lock_ids.rb.erb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class CreateGoodJobProcessLockIds < ActiveRecord::Migration<%= migration_version %>
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_jobs, :locked_by_id)
+      end
+    end
+
+    add_column :good_jobs, :locked_by_id, :uuid
+    add_column :good_jobs, :locked_at, :datetime
+    add_column :good_job_executions, :process_id, :uuid
+    add_column :good_job_processes, :lock_type, :integer, limit: 2
+  end
+end

--- a/lib/generators/good_job/templates/update/migrations/14_create_good_job_process_lock_indexes.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/14_create_good_job_process_lock_indexes.rb.erb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+          add_index :good_jobs, [:priority, :scheduled_at],
+                    order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                    where: "finished_at IS NULL AND locked_by_id IS NULL",
+                    name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+          add_index :good_jobs, :locked_by_id,
+                    where: "locked_by_id IS NOT NULL",
+                    name: :index_good_jobs_on_locked_by_id,
+                    algorithm: :concurrently
+        end
+
+        unless connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+          add_index :good_job_executions, [:process_id, :created_at],
+                    name: :index_good_job_executions_on_process_id_and_created_at,
+                    algorithm: :concurrently
+        end
+      end
+
+      dir.down do
+        remove_index(:good_jobs, name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked)
+        remove_index(:good_jobs, name: :index_good_jobs_on_locked_by_id) if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_locked_by_id)
+        remove_index(:good_job_executions, name: :index_good_job_executions_on_process_id_and_created_at) if connection.index_name_exists?(:good_job_executions, :index_good_job_executions_on_process_id_and_created_at)
+      end
+    end
+  end
+end

--- a/lib/good_job/capsule_tracker.rb
+++ b/lib/good_job/capsule_tracker.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+module GoodJob # :nodoc:
+  # CapsuleTracker save a record in the database and periodically refreshes it. The intention is to
+  # create a heartbeat that can be used to determine whether a capsule/process is still active
+  # and use that to lock (or unlock) jobs.
+  class CapsuleTracker
+    # The database record used for tracking.
+    # @return [GoodJob::Process, nil]
+    attr_reader :record
+
+    # Number of tracked job executions.
+    attr_reader :locks
+
+    # Number of tracked job executions with advisory locks.
+    # @return [Integer]
+    attr_reader :advisory_locks
+
+    # @!attribute [r] instances
+    #   @!scope class
+    #   List of all instantiated CapsuleTrackers in the current process.
+    #   @return [Array<GoodJob::CapsuleTracker>, nil]
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
+
+    # @param executor [Concurrent::AbstractExecutorService] The executor to use for refreshing the process record.
+    def initialize(executor: Concurrent.global_io_executor)
+      @executor = executor
+      @mutex = Mutex.new
+      @locks = 0
+      @advisory_locked_connection = nil
+      @record_id = SecureRandom.uuid
+      @record = nil
+      @refresh_task = nil
+
+      # AS::ForkTracker is only present on Rails v6.1+.
+      # Fall back to PID checking if ForkTracker is not available
+      if defined?(ActiveSupport::ForkTracker)
+        ActiveSupport::ForkTracker.after_fork { reset }
+        @forktracker = true
+      else
+        @ruby_pid = ::Process.pid
+        @forktracker = false
+      end
+
+      self.class.instances << self
+    end
+
+    # The UUID to use for locking. May be nil if the process is not registered or is unusable/expired.
+    # If UUID has not yet been persisted to the database, this method will make a query to insert or update it.
+    # @return [String, nil]
+    def id_for_lock
+      value = nil
+      synchronize do
+        next if @locks.zero?
+
+        reset_on_fork
+        if @record
+          @record.refresh_if_stale
+        else
+          @record = GoodJob::Process.create_record(id: @record_id)
+          create_refresh_task
+        end
+        value = @record&.id
+      end
+      value
+    end
+
+    # The expected UUID of the process for use in inspection.
+    # Use {#id_for_lock} if using this as a lock key.
+    # @return [String]
+    def process_id
+      @record_id
+    end
+
+    # Registers the current process around a job execution site.
+    # +register+ is expected to be called multiple times in a process, but should be advisory locked only once (in a single thread).
+    # @param with_advisory_lock [Boolean] Whether the lock strategy should us an advisory lock; the connection must be retained to support advisory locks.
+    # @yield [void] If a block is given, the process will be unregistered after the block completes.
+    # @return [void]
+    def register(with_advisory_lock: false)
+      synchronize do
+        if with_advisory_lock
+          if @record
+            if !advisory_locked? || !advisory_locked_connection?
+              @record.class.transaction do
+                @record.advisory_lock!
+                @record.update(lock_type: GoodJob::Process::LOCK_TYPE_ADVISORY)
+              end
+              @advisory_locked_connection = WeakRef.new(@record.class.connection)
+            end
+          else
+            @record = GoodJob::Process.create_record(id: @record_id, with_advisory_lock: true)
+            @advisory_locked_connection = WeakRef.new(@record.class.connection)
+            create_refresh_task
+          end
+        end
+
+        @locks += 1
+      end
+      return unless block_given?
+
+      begin
+        yield
+      ensure
+        unregister(with_advisory_lock: with_advisory_lock)
+      end
+    end
+
+    # Unregisters the current process from the database.
+    # @param with_advisory_lock [Boolean] Whether the lock strategy should unlock an advisory lock; the connection must be able to support advisory locks.
+    # @return [void]
+    def unregister(with_advisory_lock: false)
+      synchronize do
+        if @locks.zero?
+          return
+        elsif @locks == 1
+          if @record
+            if with_advisory_lock && advisory_locked? && advisory_locked_connection?
+              @record.class.transaction do
+                @record.advisory_unlock
+                @record.destroy
+              end
+              @advisory_locked_connection = nil
+            else
+              @record.destroy
+            end
+            @record = nil
+          end
+          cancel_refresh_task
+        elsif with_advisory_lock && advisory_locked? && advisory_locked_connection?
+          @record.class.transaction do
+            @record.advisory_unlock
+            @record.update(lock_type: nil)
+          end
+          @advisory_locked_connection = nil
+        end
+
+        @locks -= 1 unless @locks.zero?
+      end
+    end
+
+    # Refreshes the process record in the database.
+    # @param silent [Boolean] Whether to silence logging.
+    # @return [void]
+    def renew(silent: false)
+      GoodJob::Process.with_logger_silenced(silent: silent) do
+        @record&.refresh_if_stale(cleanup: true)
+      end
+    end
+
+    # Tests whether an active advisory lock has been taken on the record.
+    # @return [Boolean]
+    def advisory_locked?
+      @advisory_locked_connection&.weakref_alive? && @advisory_locked_connection&.active?
+    end
+
+    # @!visibility private
+    def task_observer(_time, _output, thread_error)
+      GoodJob._on_thread_error(thread_error) if thread_error && !thread_error.is_a?(Concurrent::CancelledOperationError)
+    end
+
+    private
+
+    def advisory_locked_connection?
+      @record&.class&.connection && @advisory_locked_connection&.weakref_alive? && @advisory_locked_connection.eql?(@record.class.connection)
+    end
+
+    def task_interval
+      GoodJob::Process::STALE_INTERVAL + jitter
+    end
+
+    def jitter
+      GoodJob::Process::STALE_INTERVAL * 0.1 * Kernel.rand
+    end
+
+    def create_refresh_task(delay: nil)
+      return if @refresh_task
+      return unless @executor
+
+      delay ||= task_interval
+      @refresh_task = Concurrent::ScheduledTask.new(delay.to_f, executor: @executor) do
+        Rails.application.executor.wrap do
+          synchronize do
+            next unless @locks.positive?
+
+            @refresh_task = nil
+            create_refresh_task
+            renew(silent: true)
+          end
+        end
+      end
+      @refresh_task.add_observer(self, :task_observer)
+      @refresh_task.execute
+    end
+
+    def cancel_refresh_task
+      @refresh_task&.cancel
+      @refresh_task = nil
+    end
+
+    def reset
+      synchronize { ns_reset }
+    end
+
+    def reset_on_fork
+      return if Concurrent.on_jruby?
+      return if @forktracker || ::Process.pid == @ruby_pid
+
+      @ruby_pid = ::Process.pid
+      ns_reset
+    end
+
+    def ns_reset
+      @record_id = SecureRandom.uuid
+      @record = nil
+    end
+
+    # Synchronize must always be called from within a Rails Executor; it may deadlock if the order is reversed.
+    def synchronize(&block)
+      if @mutex.owned?
+        yield
+      else
+        @mutex.synchronize(&block)
+      end
+    end
+  end
+end

--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -14,8 +14,9 @@ module GoodJob
     cattr_accessor :performing_active_job_ids, default: Concurrent::Set.new
 
     # @param queue_string [String] Queues to execute jobs from
-    def initialize(queue_string)
+    def initialize(queue_string, capsule: GoodJob.capsule)
       @queue_string = queue_string
+      @capsule = capsule
       @metrics = Metrics.new
     end
 
@@ -30,20 +31,22 @@ module GoodJob
     # @return [Object, nil] Returns job result or +nil+ if no job was found
     def next
       active_job_id = nil
-      job_query.perform_with_advisory_lock(parsed_queues: parsed_queues, queue_select_limit: GoodJob.configuration.queue_select_limit) do |execution|
-        @metrics.touch_check_queue_at
+      @capsule.tracker.register do
+        job_query.perform_with_advisory_lock(lock_id: @capsule.tracker.id_for_lock, parsed_queues: parsed_queues, queue_select_limit: GoodJob.configuration.queue_select_limit) do |execution|
+          @metrics.touch_check_queue_at
 
-        if execution
-          active_job_id = execution.active_job_id
-          performing_active_job_ids << active_job_id
-          @metrics.touch_execution_at
-          yield(execution) if block_given?
-        else
-          @metrics.increment_empty_executions
-        end
-      end.tap do |result|
-        if result
-          result.succeeded? ? @metrics.increment_succeeded_executions : @metrics.increment_errored_executions
+          if execution
+            active_job_id = execution.active_job_id
+            performing_active_job_ids << active_job_id
+            @metrics.touch_execution_at
+            yield(execution) if block_given?
+          else
+            @metrics.increment_empty_executions
+          end
+        end.tap do |result|
+          if result
+            result.succeeded? ? @metrics.increment_succeeded_executions : @metrics.increment_errored_executions
+          end
         end
       end
     ensure

--- a/lib/good_job/multi_scheduler.rb
+++ b/lib/good_job/multi_scheduler.rb
@@ -7,12 +7,12 @@ module GoodJob
     # @param configuration [GoodJob::Configuration]
     # @param warm_cache_on_initialize [Boolean]
     # @return [GoodJob::MultiScheduler]
-    def self.from_configuration(configuration, warm_cache_on_initialize: false)
+    def self.from_configuration(configuration, capsule: GoodJob.capsule, warm_cache_on_initialize: false)
       schedulers = configuration.queue_string.split(';').map(&:strip).map do |queue_string_and_max_threads|
         queue_string, max_threads = queue_string_and_max_threads.split(':').map { |str| str.strip.presence }
         max_threads = (max_threads || configuration.max_threads).to_i
 
-        job_performer = GoodJob::JobPerformer.new(queue_string)
+        job_performer = GoodJob::JobPerformer.new(queue_string, capsule: capsule)
         GoodJob::Scheduler.new(
           job_performer,
           max_threads: max_threads,

--- a/lib/good_job/notifier/process_heartbeat.rb
+++ b/lib/good_job/notifier/process_heartbeat.rb
@@ -16,7 +16,7 @@ module GoodJob # :nodoc:
       def register_process
         GoodJob::Process.override_connection(connection) do
           GoodJob::Process.cleanup
-          @process = GoodJob::Process.register
+          @capsule.tracker.register(with_advisory_lock: true)
         end
       end
 
@@ -24,7 +24,7 @@ module GoodJob # :nodoc:
         Rails.application.executor.wrap do
           GoodJob::Process.override_connection(connection) do
             GoodJob::Process.with_logger_silenced do
-              @process&.refresh_if_stale(cleanup: true)
+              @capsule.tracker.renew
             end
           end
         end
@@ -33,7 +33,7 @@ module GoodJob # :nodoc:
       # Deregisters the current process.
       def deregister_process
         GoodJob::Process.override_connection(connection) do
-          @process&.deregister
+          @capsule.tracker.unregister(with_advisory_lock: true)
         end
       end
     end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -18,6 +18,10 @@ module ::JobError; end
 module ::LATCH; end
 module ::MemoryProfiler; end
 module ::PERFORMED; end
+module ::POLL_COUNT; end
+module ::PROCESS_IDS; end
+module ::RECEIVED_MESSAGE; end
+module ::REFRESH_IF_STALE_CALLED; end
 module ::RESULTS; end
 module ::RUN_JOBS; end
 module ::RecursiveJob; end

--- a/spec/app/models/good_job/batch_spec.rb
+++ b/spec/app/models/good_job/batch_spec.rb
@@ -147,7 +147,7 @@ describe GoodJob::Batch do
     before do
       stub_const 'CallbackJob', (Class.new(ActiveJob::Base) do
         def perform(_batch, _options)
-          puts "HERE"
+          nil
         end
       end)
     end

--- a/spec/app/models/good_job/process_spec.rb
+++ b/spec/app/models/good_job/process_spec.rb
@@ -3,23 +3,17 @@
 require 'rails_helper'
 
 RSpec.describe GoodJob::Process do
-  describe '.current_id' do
-    it 'returns a uuid that does not change' do
-      value = described_class.current_id
-      expect(value).to be_present
-
-      expect(described_class.current_id).to eq value
+  describe 'Scopes' do
+    describe '.active' do
+      it 'returns active processes' do
+        expect(described_class.active.count).to eq 0
+      end
     end
 
-    it 'changes when the PID changes' do
-      allow(Process).to receive(:pid).and_return(1)
-      original_value = described_class.current_id
-
-      allow(Process).to receive(:pid).and_return(2)
-      expect(described_class.current_id).not_to eq original_value
-
-      # Unstub the pid or RSpec/DatabaseCleaner may fail
-      RSpec::Mocks.space.proxy_for(Process).reset
+    describe '.inactive' do
+      it 'returns inactive processes' do
+        expect(described_class.inactive.count).to eq 0
+      end
     end
   end
 
@@ -38,37 +32,12 @@ RSpec.describe GoodJob::Process do
 
   describe '.ns_current_state' do
     it 'contains information about the process' do
-      expect(described_class.ns_current_state).to include(
+      expect(described_class.process_state).to include(
         database_connection_pool: include(
           size: be_an(Integer),
           active: be_an(Integer)
         )
       )
-    end
-  end
-
-  describe '.register' do
-    it 'registers the process' do
-      process = nil
-      expect do
-        process = described_class.register
-      end.to change(described_class, :count).by(1)
-
-      process.deregister
-    end
-
-    context 'when there is already an existing record' do
-      it 'returns the existing record' do
-        described_class.create!(id: described_class.current_id)
-        expect(described_class.register).to be_a described_class
-      end
-    end
-  end
-
-  describe '#deregister' do
-    it 'deregisters the record' do
-      process = described_class.register
-      expect { process.deregister }.to change(described_class, :count).by(-1)
     end
   end
 
@@ -95,11 +64,11 @@ RSpec.describe GoodJob::Process do
     end
 
     context 'when the record has been deleted elsewhere' do
-      it 'returns false' do
+      it 'creates a new record' do
         process = described_class.create! state: {}, updated_at: 1.day.ago
         described_class.where(id: process.id).delete_all
 
-        expect(process.refresh).to be false
+        expect { process.refresh }.to change(described_class, :count).from(0).to(1)
       end
     end
   end

--- a/spec/integration/process_locks_spec.rb
+++ b/spec/integration/process_locks_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Process Locks' do
+  let(:capsule) { GoodJob::Capsule.new }
+  let(:inline_adapter) { GoodJob::Adapter.new(execution_mode: :inline, _capsule: capsule) }
+  let(:async_adapter) { GoodJob::Adapter.new(execution_mode: :async, _capsule: capsule) }
+
+  before do
+    capsule.start
+
+    stub_const("PROCESS_IDS", Concurrent::Array.new)
+    stub_const "TestJob", (Class.new(ActiveJob::Base) do
+      def perform
+        PROCESS_IDS << GoodJob::Job.where(id: provider_job_id).pick(:locked_by_id)
+      end
+    end)
+  end
+
+  after do
+    capsule.shutdown
+  end
+
+  it 'stores process_id in inline job' do
+    TestJob.queue_adapter = inline_adapter
+    TestJob.perform_later
+
+    wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+    expect(PROCESS_IDS.size).to eq 1
+    expect(PROCESS_IDS.first).to be_a_uuid
+    expect(PROCESS_IDS.first).to eq capsule.process_id
+    expect(GoodJob::Job.last.locked_by_id).to be_nil
+  end
+
+  it 'stores process_id in async job' do
+    TestJob.queue_adapter = async_adapter
+    TestJob.perform_later
+
+    wait_until { expect(GoodJob::Job.pick(:finished_at)).to be_present }
+    expect(PROCESS_IDS.size).to eq 1
+    expect(PROCESS_IDS.first).to be_a_uuid
+    expect(PROCESS_IDS.first).to eq capsule.process_id
+    expect(GoodJob::Job.last.locked_by_id).to be_nil
+  end
+end

--- a/spec/lib/good_job/capsule_tracker_spec.rb
+++ b/spec/lib/good_job/capsule_tracker_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GoodJob::CapsuleTracker do
+  let(:tracker) { described_class.new }
+
+  describe '#register' do
+    context 'when used with an advisory lock' do
+      it 'creates a Process and sets the lock_type' do
+        expect do
+          tracker.register(with_advisory_lock: true)
+        end.to change(GoodJob::Process, :count).by(1)
+
+        process = GoodJob::Process.last
+        expect(process.lock_type).to eq('advisory')
+
+        tracker.unregister(with_advisory_lock: true)
+
+        expect(GoodJob::Process.count).to eq 0
+
+        Rails.logger.warn("DONE WITH TEST")
+      end
+
+      it 'takes an advisory lock even when process already exists' do
+        tracker.register do
+          expect(GoodJob::Process.count).to eq 0
+
+          tracker.id_for_lock
+
+          process = GoodJob::Process.last
+          expect(process).to be_present
+          expect(process).not_to be_advisory_locked
+          expect(process.lock_type).to eq(nil)
+
+          tracker.register(with_advisory_lock: true) do
+            process.reload
+            expect(process).to be_advisory_locked
+            expect(process.lock_type).to eq('advisory')
+          end
+
+          process.reload
+          expect(process).not_to be_advisory_locked
+          expect(process.lock_type).to eq(nil)
+        end
+
+        expect(GoodJob::Process.count).to eq 0
+      end
+
+      it 'increments the number of locks when not used with a block' do
+        expect do
+          tracker.register(with_advisory_lock: true)
+        end.to change(tracker, :locks).by(1)
+        tracker.unregister(with_advisory_lock: true)
+      end
+
+      it 'tracks multiple locks and advisory locks' do
+        tracker.register(with_advisory_lock: true)
+        tracker.register
+        tracker.register(with_advisory_lock: true)
+        tracker.register(with_advisory_lock: true)
+
+        expect(GoodJob::Process.count).to eq 1
+        expect(tracker.record.lock_type).to eq('advisory')
+        expect(tracker.locks).to eq(4)
+        expect(tracker).to be_advisory_locked
+
+        tracker.unregister(with_advisory_lock: true)
+
+        expect(GoodJob::Process.count).to eq 1
+        expect(tracker.record.lock_type).to eq(nil)
+        expect(tracker.locks).to eq(3)
+        expect(tracker).not_to be_advisory_locked
+
+        tracker.unregister(with_advisory_lock: true)
+        tracker.unregister
+        tracker.unregister(with_advisory_lock: true)
+
+        expect(GoodJob::Process.count).to eq 0
+        expect(tracker.locks).to eq(0)
+        expect(tracker).not_to be_advisory_locked
+      end
+    end
+
+    context 'when NOT used with an advisory lock' do
+      it 'does not create a Process' do
+        expect do
+          tracker.register
+        end.not_to change(GoodJob::Process, :count)
+
+        tracker.unregister
+      end
+
+      it 'increments the number of locks when not used with a block' do
+        expect do
+          tracker.register
+        end.to change(tracker, :locks).by(1)
+        tracker.unregister
+      end
+    end
+
+    it 'creates a ScheduledTask that refreshes the process in the background' do
+      stub_const("GoodJob::Process::STALE_INTERVAL", 0.1.seconds)
+
+      tracker.register do
+        tracker.id_for_lock
+        updated_at = GoodJob::Process.first.updated_at
+        wait_until(max: 1) { expect(GoodJob::Process.first.updated_at).to be > updated_at }
+      end
+
+      tracker.register(with_advisory_lock: true) do
+        tracker.id_for_lock
+        updated_at = GoodJob::Process.first.updated_at
+        wait_until(max: 1) { expect(GoodJob::Process.first.updated_at).to be > updated_at }
+      end
+    end
+
+    it 'resets the number of locks when used with a block' do
+      called_block = nil
+      tracker.register do
+        called_block = true
+        expect(tracker.locks).to eq 1
+      end
+
+      expect(called_block).to be true
+      expect(tracker.locks).to eq 0
+    end
+
+    it 'removes the process when locks are zero' do
+      inner_block_called = nil
+      tracker.register do
+        lock_id = tracker.id_for_lock
+        expect(lock_id).to be_present
+
+        expect(GoodJob::Process.count).to eq 1
+        tracker.register do
+          inner_block_called = true
+          expect(tracker.id_for_lock).to eq(lock_id)
+          expect(GoodJob::Process.count).to eq 1
+        end
+        expect(GoodJob::Process.count).to eq 1
+        expect(tracker.id_for_lock).to eq(lock_id)
+      end
+      expect(GoodJob::Process.count).to eq 0
+      expect(tracker.id_for_lock).to be_nil
+
+      expect(inner_block_called).to be true
+    end
+  end
+
+  describe '#process_id' do
+    it 'is a UUID' do
+      expect(tracker.process_id).to be_a_uuid
+    end
+  end
+
+  describe '.id_for_lock' do
+    it 'is available if the process has been registered' do
+      expect(GoodJob::Process.count).to eq 0
+      expect(tracker.id_for_lock).to be_nil
+
+      tracker.register do
+        expect(tracker.id_for_lock).to be_present
+      end
+
+      expect(GoodJob::Process.count).to eq 0
+      expect(tracker.id_for_lock).to be_nil
+    end
+
+    describe "on fork" do
+      it 'when reset via ForkTracker' do
+        skip("AS::ForkTracker is not defined") unless defined?(ActiveSupport::ForkTracker)
+
+        tracker.register do
+          original_value = tracker.id_for_lock
+
+          tracker.send(:reset)
+
+          expect(tracker.id_for_lock).not_to eq original_value
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/good_job/notifier_spec.rb
+++ b/spec/lib/good_job/notifier_spec.rb
@@ -184,25 +184,11 @@ RSpec.describe GoodJob::Notifier do
       wait_until { expect(GoodJob::Process.count).to eq 1 }
 
       process = GoodJob::Process.first
-      expect(process.id).to eq GoodJob::Process.current_id
+      expect(process.id).to eq GoodJob.capsule.tracker.id_for_lock
       expect(process).to be_advisory_locked
 
       notifier.shutdown
       expect { process.reload }.to raise_error ActiveRecord::RecordNotFound
-    end
-
-    context 'when, for some reason, the process already exists' do
-      it 'does not create a new process' do
-        process = GoodJob::Process.register
-        notifier = described_class.new(enable_listening: true)
-
-        wait_until { expect(notifier).to be_listening }
-        expect(GoodJob::Process.count).to eq 1
-
-        notifier.shutdown
-        expect(process.reload).to eq process
-        process.advisory_unlock
-      end
     end
   end
 end

--- a/spec/lib/good_job/scheduler_spec.rb
+++ b/spec/lib/good_job/scheduler_spec.rb
@@ -5,10 +5,6 @@ require 'rails_helper'
 RSpec.describe GoodJob::Scheduler do
   let(:performer) { GoodJob::JobPerformer.new('*') }
 
-  after do
-    described_class.instances.each(&:shutdown)
-  end
-
   describe '#name' do
     it 'is human readable and contains configuration values' do
       scheduler = described_class.new(performer)

--- a/spec/lib/good_job/shared_executor_spec.rb
+++ b/spec/lib/good_job/shared_executor_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GoodJob::SharedExecutor do
 
       expect do
         shared_executor.restart
-      end.to change(shared_executor, :running?).from(false).to(true)
+      end.to change(shared_executor, :running?).from(nil).to(true)
     end
   end
 end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -45,6 +45,11 @@ RSpec.configure do |config|
     )
     GoodJob._shutdown_all(executables, timeout: -1)
 
+    GoodJob::CapsuleTracker.instances.each do |tracker|
+      expect(tracker.locks).to eq 0
+    end
+    GoodJob::CapsuleTracker.instances.clear
+
     expect(GoodJob::Notifier.instances).to all be_shutdown
     GoodJob::Notifier.instances.clear
 


### PR DESCRIPTION
Connects to #831 / #985.

- Adds `locked_by_id` and `locked_at` columns to Jobs which is updated when the job is executed with the `GoodJob::Process.id` and then unset after executing.
- Creates a `ProcessTracker` which is responsible for creating and destroying `GoodJob::Process` records when locks are taken, and also refreshing the record in the background on a regular cadence (a heartbeart)

Goal here is to have all of the database migrations in place for the major GoodJob 4.0 release (#764) so that developers can safely opt into new behavior (like using row-level-locks+heartbeat instead of advisory locks)