### PR TITLE
Configure `dashboard_default_locale` using custom subclass of `I18n::Config` to isolate I18n configuration from parent application

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Rails.application.configure do
   config.good_job.shutdown_timeout = 25 # seconds
   config.good_job.enable_cron = true
   config.good_job.cron = { example: { cron: '0 * * * *', class: 'ExampleJob'  } }
+  config.good_job.dashboard_default_locale = :en
 
   # ...or all at once.
   config.good_job = {
@@ -262,6 +263,7 @@ Rails.application.configure do
         class: 'ExampleJob'
       },
     },
+    dashboard_default_locale: :en,
   }
 end
 ```

--- a/app/controllers/good_job/cron_entries_controller.rb
+++ b/app/controllers/good_job/cron_entries_controller.rb
@@ -15,7 +15,7 @@ module GoodJob
 
     def enqueue
       @cron_entry = CronEntry.find(params[:cron_key])
-      @cron_entry.enqueue(Time.current)
+      use_original_locale { @cron_entry.enqueue(Time.current) }
       redirect_back(fallback_location: cron_entries_path, notice: t(".notice"))
     end
 

--- a/app/helpers/good_job/application_helper.rb
+++ b/app/helpers/good_job/application_helper.rb
@@ -64,7 +64,6 @@ module GoodJob
     end
 
     def translation_exists?(key, **options)
-      true if good_job_available_locales.include?(I18n.locale)
       I18n.exists?(scope_key_by_partial(key), **options)
     end
   end

--- a/app/models/good_job/i18n_config.rb
+++ b/app/models/good_job/i18n_config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GoodJob
+  class I18nConfig < ::I18n::Config
+    BACKEND = I18n::Backend::Simple.new
+    AVAILABLE_LOCALES = GoodJob::Engine.root.join("config/locales").glob("*.yml").map { |path| File.basename(path, ".yml").to_sym }.uniq
+    AVAILABLE_LOCALES_SET = AVAILABLE_LOCALES.inject(Set.new) { |set, locale| set << locale.to_s << locale.to_sym }
+
+    def backend
+      BACKEND
+    end
+
+    def available_locales
+      AVAILABLE_LOCALES
+    end
+
+    def available_locales_set
+      AVAILABLE_LOCALES_SET
+    end
+
+    def default_locale
+      GoodJob.configuration.dashboard_default_locale
+    end
+  end
+end

--- a/app/views/good_job/shared/_navbar.erb
+++ b/app/views/good_job/shared/_navbar.erb
@@ -49,7 +49,7 @@
           </a>
 
           <ul class="dropdown-menu" aria-labelledby="localeOptions">
-            <% possible_locales = I18n.enforce_available_locales ? (good_job_available_locales & I18n.available_locales) : good_job_available_locales %>
+            <% possible_locales = I18n.available_locales %>
             <% possible_locales.reject { |locale| locale == I18n.locale }.each do |locale| %>
               <li><%= link_to locale, url_for(locale: locale), class: "dropdown-item" %></li>
             <% end %>

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -29,6 +29,8 @@ module GoodJob
     DEFAULT_ENABLE_CRON = false
     # Default to enabling LISTEN/NOTIFY
     DEFAULT_ENABLE_LISTEN_NOTIFY = true
+    # Default Dashboard I18n locale
+    DEFAULT_DASHBOARD_DEFAULT_LOCALE = :en
 
     def self.validate_execution_mode(execution_mode)
       raise ArgumentError, "GoodJob execution mode must be one of #{EXECUTION_MODES.join(', ')}. It was '#{execution_mode}' which is not valid." unless execution_mode.in?(EXECUTION_MODES)
@@ -344,6 +346,10 @@ module GoodJob
 
     def smaller_number_is_higher_priority
       rails_config[:smaller_number_is_higher_priority]
+    end
+
+    def dashboard_default_locale
+      rails_config[:dashboard_default_locale] || DEFAULT_DASHBOARD_DEFAULT_LOCALE
     end
 
     private

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -280,4 +280,12 @@ RSpec.describe GoodJob::Configuration do
       expect(configuration.smaller_number_is_higher_priority).to be true
     end
   end
+
+  describe '#dashboard_default_locale' do
+    it 'delegates to rails configuration' do
+      allow(Rails.application.config).to receive(:good_job).and_return({ dashboard_default_locale: :de })
+      configuration = described_class.new({})
+      expect(configuration.dashboard_default_locale).to eq :de
+    end
+  end
 end

--- a/spec/requests/good_job/cron_entries_controller_spec.rb
+++ b/spec/requests/good_job/cron_entries_controller_spec.rb
@@ -30,4 +30,27 @@ describe GoodJob::CronEntriesController do
       expect(response).to have_http_status(:found)
     end
   end
+
+  describe 'POST #enqueue' do
+    before do
+      allow(ExampleJob).to receive(:queue_adapter).and_return(GoodJob::Adapter.new(execution_mode: :external))
+    end
+
+    it 'enqueues a job' do
+      expect do
+        post good_job.enqueue_cron_entry_path(cron_key: 'example')
+      end.to change(GoodJob::Job, :count).by(1)
+      expect(response).to have_http_status(:found)
+    end
+
+    it 'uses the application I18n.default_locale' do
+      original_locale = I18n.default_locale
+      I18n.default_locale = :de
+
+      post good_job.enqueue_cron_entry_path(cron_key: 'example')
+      expect(GoodJob::Job.last.serialized_params).to include("locale" => "de")
+    ensure
+      I18n.default_locale = original_locale
+    end
+  end
 end

--- a/spec/test_app/config/application.rb
+++ b/spec/test_app/config/application.rb
@@ -23,5 +23,9 @@ module TestApp
     config.log_level = :debug
 
     config.action_controller.include_all_helpers = false
+
+    # Set default locale to something not yet translated for GoodJob
+    # config.i18n.available_locales = [:pt]
+    # config.i18n.default_locale = :pt
   end
 end


### PR DESCRIPTION
Connects to #921 