### PR TITLE
Use Concurrent::Array for class `instances` to avoid JRuby synchronization errors

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -8,7 +8,7 @@ module GoodJob
     #   @!scope class
     #   List of all instantiated Adapters in the current process.
     #   @return [Array<GoodJob::Adapter>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # @param execution_mode [Symbol, nil] specifies how and where jobs should be executed. You can also set this with the environment variable +GOOD_JOB_EXECUTION_MODE+.
     #

--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -8,7 +8,7 @@ module GoodJob
     #   @!scope class
     #   List of all instantiated Capsules in the current process.
     #   @return [Array<GoodJob::Capsule>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # @param configuration [GoodJob::Configuration] Configuration to use for this capsule.
     def initialize(configuration: GoodJob.configuration)

--- a/lib/good_job/cron_manager.rb
+++ b/lib/good_job/cron_manager.rb
@@ -12,7 +12,7 @@ module GoodJob # :nodoc:
     #   @!scope class
     #   List of all instantiated CronManagers in the current process.
     #   @return [Array<GoodJob::CronManager>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # Task observer for cron task
     # @param time [Time]

--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -46,7 +46,7 @@ module GoodJob # :nodoc:
     #   @!scope class
     #   List of all instantiated Notifiers in the current process.
     #   @return [Array<GoodJob::Notifier>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # @!attribute [rw] connection
     #   @!scope class

--- a/lib/good_job/poller.rb
+++ b/lib/good_job/poller.rb
@@ -17,7 +17,7 @@ module GoodJob # :nodoc:
     #   @!scope class
     #   List of all instantiated Pollers in the current process.
     #   @return [Array<GoodJob::Poller>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # Creates GoodJob::Poller from a GoodJob::Configuration instance.
     # @param configuration [GoodJob::Configuration]

--- a/lib/good_job/scheduler.rb
+++ b/lib/good_job/scheduler.rb
@@ -33,7 +33,7 @@ module GoodJob # :nodoc:
     #   @!scope class
     #   List of all instantiated Schedulers in the current process.
     #   @return [Array<GoodJob::Scheduler>, nil]
-    cattr_reader :instances, default: [], instance_reader: false
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
 
     # Creates GoodJob::Scheduler(s) and Performers from a GoodJob::Configuration instance.
     # @param configuration [GoodJob::Configuration]


### PR DESCRIPTION
This is a noop for CRuby: https://github.com/ruby-concurrency/concurrent-ruby/blob/3bfe39e77958876403cefa3a2d89e86c7bdb5f9d/lib/concurrent-ruby/concurrent/array.rb#L23-L28