### PR TITLE
Wrap Notifier's `refresh_process` with Rails executor

### DIFF
--- a/lib/good_job/notifier/process_heartbeat.rb
+++ b/lib/good_job/notifier/process_heartbeat.rb
@@ -21,9 +21,11 @@ module GoodJob # :nodoc:
       end
 
       def refresh_process
-        GoodJob::Process.with_connection(connection) do
-          Process.logger.silence do
-            @process&.refresh_if_stale(cleanup: true)
+        Rails.application.executor.wrap do
+          GoodJob::Process.with_connection(connection) do
+            GoodJob::Process.logger.silence do
+              @process&.refresh_if_stale(cleanup: true)
+            end
           end
         end
       end


### PR DESCRIPTION
This was overlooked in #977.

Fixes #1006.