### PR TITLE
Move shared `BaseExecution` concerns into the base class.

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -5,6 +5,9 @@ module GoodJob
   # which both read out of the same table.
   class BaseExecution < BaseRecord
     include ErrorEvents
+    include Filterable
+    include Lockable
+    include Reportable
 
     self.table_name = 'good_jobs'
 

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -3,10 +3,6 @@
 module GoodJob
   # ActiveRecord model that represents an +ActiveJob+ job.
   class Execution < BaseExecution
-    include Lockable
-    include Filterable
-    include Reportable
-
     # Raised if something attempts to execute a previously completed Execution again.
     PreviouslyPerformedError = Class.new(StandardError)
 

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -7,10 +7,6 @@ module GoodJob
   # A single row from the +good_jobs+ table of executions is fetched to represent a Job.
   #
   class Job < BaseExecution
-    include Filterable
-    include Lockable
-    include Reportable
-
     # Raised when an inappropriate action is applied to a Job based on its state.
     ActionForStateMismatchError = Class.new(StandardError)
     # Raised when an action requires GoodJob to be the ActiveJob Queue Adapter but GoodJob is not.


### PR DESCRIPTION
Parent/base class for `Job and Execution` is `BaseExecution`, both of these child classes include same concerns: `Lockable, Filterable, Reportable`.

This commit moves inclusion of these concerns to the base class `BaseExecution`