### PR TITLE
Deprecate `GoodJob::Lockable` and rename to `GoodJob::AdvisoryLockable`

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -16,7 +16,7 @@ module GoodJob
   #     end
   #   end
   #
-  module Lockable
+  module AdvisoryLockable
     extend ActiveSupport::Concern
 
     # Indicates an advisory lock is already held on a record by another

--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -4,9 +4,9 @@ module GoodJob
   # ActiveRecord model to share behavior between {Job} and {Execution} models
   # which both read out of the same table.
   class BaseExecution < BaseRecord
+    include AdvisoryLockable
     include ErrorEvents
     include Filterable
-    include Lockable
     include Reportable
 
     self.table_name = 'good_jobs'

--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -2,7 +2,7 @@
 
 module GoodJob
   class BatchRecord < BaseRecord
-    include Lockable
+    include AdvisoryLockable
 
     self.table_name = 'good_job_batches'
 

--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -5,8 +5,8 @@ require 'socket'
 module GoodJob # :nodoc:
   # ActiveRecord model that represents an GoodJob process (either async or CLI).
   class Process < BaseRecord
+    include AdvisoryLockable
     include AssignableConnection
-    include Lockable
 
     # Interval until the process record being updated
     STALE_INTERVAL = 30.seconds

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -246,6 +246,9 @@ module GoodJob
     end
   end
 
+  include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+  deprecate_constant :Lockable, 'GoodJob::AdvisoryLockable', deprecator: deprecator
+
   # Whether all GoodJob migrations have been applied.
   # For use in tests/CI to validate GoodJob is up-to-date.
   # @return [Boolean]

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe GoodJob::Lockable do
+RSpec.describe GoodJob::AdvisoryLockable do
   let(:model_class) { GoodJob::Execution }
   let!(:execution) { model_class.create(active_job_id: SecureRandom.uuid, queue_name: "default") }
 
@@ -318,7 +318,7 @@ RSpec.describe GoodJob::Lockable do
 
     expect do
       Concurrent::Promises.future(execution, &:advisory_lock!).value!
-    end.to raise_error GoodJob::Lockable::RecordAlreadyAdvisoryLockedError
+    end.to raise_error GoodJob::AdvisoryLockable::RecordAlreadyAdvisoryLockedError
 
     execution.advisory_unlock
   end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe GoodJob::Job do
         job.with_advisory_lock do
           expect do
             Concurrent::Promises.future(job, &:retry_job).value!
-          end.to raise_error GoodJob::Lockable::RecordAlreadyAdvisoryLockedError
+          end.to raise_error GoodJob::AdvisoryLockable::RecordAlreadyAdvisoryLockedError
         end
       end
     end


### PR DESCRIPTION
I still plan to extract the Advisory Locking implementation to its own gem so it can be used on its own. Also being more specific on the naming to clear the way to introduce row/process-heartbeat locking (naming TB; its a couple of different strategies).