### PR TITLE
Notifier and CronManager share a 2-thread executor within the capsule

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,10 +956,9 @@ Keep in mind, queue operations and management is an advanced discipline. This st
 
 GoodJob job executor processes require the following database connections:
 
-- 1 connection for the job reader.
-- 1 connection per execution pool thread. E.g., `--queues=mice:2;elephants:1` is 3 threads. Pool size defaults to `--max-threads`.
-- 2 connections for the cron scheduler and executor, if cron is enabled.
-- 1 connection per subthread, if your application makes multithreaded database queries within a job.
+- 1 connection per execution pool thread. E.g., `--queues=mice:2;elephants:1` is 3 threads and thus 3 connections. Pool size defaults to `--max-threads`.
+- 2 additional connections that GoodJob uses for utility functionality (e.g. LISTEN/NOTIFY, cron, etc.)
+- 1 connection per subthread, if your application makes multithreaded database queries (e.g. `load_async`) within a job.
 
 The executor process will not crash if the connections pool is exhausted, instead it will report an exception (eg. `ActiveRecord::ConnectionTimeoutError`).
 

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -31,6 +31,7 @@ require "good_job/notifier"
 require "good_job/poller"
 require "good_job/probe_server"
 require "good_job/scheduler"
+require "good_job/shared_executor"
 
 # GoodJob is a multithreaded, Postgres-based, ActiveJob backend for Ruby on Rails.
 #

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -51,13 +51,10 @@ module GoodJob
     # @param warn [Boolean] whether to print a warning when over the limit
     # @return [Integer]
     def self.total_estimated_threads(warn: false)
-      configuration = new({})
-
-      cron_threads = configuration.enable_cron? ? 2 : 0
-      notifier_threads = 1
+      utility_threads = GoodJob::SharedExecutor::MAX_THREADS
       scheduler_threads = GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats[:max_threads] }
 
-      good_job_threads = cron_threads + notifier_threads + scheduler_threads
+      good_job_threads = utility_threads + scheduler_threads
       puma_threads = (Puma::Server.current&.max_threads if defined?(Puma::Server)) || 0
 
       total_threads = good_job_threads + puma_threads

--- a/lib/good_job/shared_executor.rb
+++ b/lib/good_job/shared_executor.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module GoodJob
+  class SharedExecutor
+    MAX_THREADS = 2
+
+    # @!attribute [r] instances
+    #   @!scope class
+    #   List of all instantiated SharedExecutor in the current process.
+    #   @return [Array<GoodJob::SharedExecutor>, nil]
+    cattr_reader :instances, default: Concurrent::Array.new, instance_reader: false
+
+    attr_reader :executor
+
+    def initialize
+      self.class.instances << self
+      create_executor
+    end
+
+    def running?
+      @executor&.running?
+    end
+
+    def shutdown?
+      if @executor
+        @executor.shutdown?
+      else
+        true
+      end
+    end
+
+    # Shut down the SharedExecutor.
+    # Use {#shutdown?} to determine whether threads have stopped.
+    # @param timeout [Numeric, nil] Seconds to wait for active threads.
+    #   * +nil+, the scheduler will trigger a shutdown but not wait for it to complete.
+    #   * +-1+, the scheduler will wait until the shutdown is complete.
+    #   * +0+, the scheduler will immediately shutdown and stop any threads.
+    #   * A positive number will wait that many seconds before stopping any remaining active threads.
+    # @return [void]
+    def shutdown(timeout: -1)
+      return if @executor.nil? || @executor.shutdown?
+
+      @executor.shutdown if @executor.running?
+
+      if @executor.shuttingdown? && timeout # rubocop:disable Style/GuardClause
+        executor_wait = timeout.negative? ? nil : timeout
+        @executor.kill unless @executor.wait_for_termination(executor_wait)
+      end
+    end
+
+    def restart(timeout: -1)
+      shutdown(timeout: timeout) if running?
+      create_executor
+    end
+
+    private
+
+    def create_executor
+      @executor = Concurrent::ThreadPoolExecutor.new(
+        min_threads: 0,
+        max_threads: MAX_THREADS,
+        auto_terminate: true,
+        idletime: 60,
+        max_queue: 0,
+        fallback_policy: :discard
+      )
+    end
+  end
+end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -13,6 +13,7 @@ module ::ErrorJob; end
 module ::ExpectedError; end
 module ::JOB_PERFORMED; end
 module ::JobError; end
+module ::LATCH; end
 module ::MemoryProfiler; end
 module ::PERFORMED; end
 module ::POLL_COUNT; end
@@ -27,7 +28,6 @@ module ::THREAD_JOBS; end
 module ::TestError; end
 module ::TestJob; end
 module ::TestJob::ExpectedError; end
-module GoodJob::DiscreteExecution::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_RETRIED; end
 module RSpec::Core::Example; end

--- a/spec/integration/capsule_spec.rb
+++ b/spec/integration/capsule_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Capsule' do
+  it 'hands off and executes in a different capsule as if it was a separate process' do
+    total_jobs = 250
+
+    stub_const "LATCH", Concurrent::CountDownLatch.new(total_jobs)
+    stub_const "TestJob", (Class.new(ActiveJob::Base) do
+      def perform
+        LATCH.count_down
+      end
+    end)
+
+    enqueue_capsule = GoodJob::Capsule.new(configuration: GoodJob::Configuration.new({}))
+    perform_capsule = GoodJob::Capsule.new(configuration: GoodJob::Configuration.new({ max_threads: 10 }))
+    perform_capsule.start
+
+    adapter = GoodJob::Adapter.new(execution_mode: :external, _capsule: enqueue_capsule)
+    TestJob.queue_adapter = adapter
+
+    total_jobs.times { TestJob.perform_later }
+
+    LATCH.wait(10)
+    wait_until { expect(GoodJob::Job.finished.count).to eq(total_jobs) }
+    expect(GoodJob::DiscreteExecution.count).to eq(total_jobs)
+
+    perform_capsule.shutdown
+  end
+end

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GoodJob::Configuration do
     end
 
     it 'counts up the total estimated threads' do
-      expect(described_class.total_estimated_threads).to eq 1
+      expect(described_class.total_estimated_threads).to eq 2
     end
 
     it 'outputs a warning message' do

--- a/spec/lib/good_job/shared_executor_spec.rb
+++ b/spec/lib/good_job/shared_executor_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoodJob::SharedExecutor do
+  let(:shared_executor) { described_class.new }
+
+  describe '#shutdown' do
+    it 'takes a timeout' do
+      shared_executor.shutdown(timeout: -1)
+      expect(shared_executor).to be_shutdown
+    end
+  end
+
+  describe '#restart' do
+    it 'shuts down and restarts' do
+      shared_executor.restart(timeout: -1)
+      expect(shared_executor).to be_running
+    end
+
+    it 'starts when shutdown' do
+      shared_executor.shutdown(timeout: -1)
+
+      expect do
+        shared_executor.restart
+      end.to change(shared_executor, :running?).from(false).to(true)
+    end
+  end
+end

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -24,12 +24,13 @@ RSpec.configure do |config|
     GoodJob.shutdown(timeout: -1)
 
     executables = [].concat(
+      GoodJob::Capsule.instances,
+      GoodJob::SharedExecutor.instances,
       GoodJob::CronManager.instances,
       GoodJob::Notifier.instances,
       GoodJob::Poller.instances,
       GoodJob::Scheduler.instances,
-      GoodJob::CronManager.instances,
-      GoodJob::Capsule.instances
+      GoodJob::CronManager.instances
     )
     GoodJob._shutdown_all(executables, timeout: -1)
 

--- a/spec/support/sleep_helper.rb
+++ b/spec/support/sleep_helper.rb
@@ -3,7 +3,7 @@
 module SleepHelper
   TooSlowError = Class.new(StandardError)
 
-  def wait_until(max: 5, increments_of: 0.1)
+  def wait_until(max: 5.seconds, increments_of: 0.1.seconds)
     start_time = Time.current
 
     loop do


### PR DESCRIPTION
This simplifies the number of additional database connections required per capsule to be 2:

- 1 for the LISTEN thread
- 1 for everything else GoodJob related (cron job enqueueing, and subsequently a heartbeat database query in #977)