### PR TITLE
Add database_connection_pool stats to `GoodJob::Process.current_state`

### DIFF
--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -63,7 +63,7 @@ module GoodJob # :nodoc:
         cron_enabled: GoodJob.configuration.enable_cron?,
         total_succeeded_executions_count: GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats.fetch(:succeeded_executions_count) },
         total_errored_executions_count: GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats.fetch(:errored_executions_count) },
-        connection_pool: {
+        database_connection_pool: {
           size: connection_pool.size,
           active: connection_pool.connections.count(&:in_use?),
         },

--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -63,6 +63,10 @@ module GoodJob # :nodoc:
         cron_enabled: GoodJob.configuration.enable_cron?,
         total_succeeded_executions_count: GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats.fetch(:succeeded_executions_count) },
         total_errored_executions_count: GoodJob::Scheduler.instances.sum { |scheduler| scheduler.stats.fetch(:errored_executions_count) },
+        connection_pool: {
+          size: connection_pool.size,
+          active: connection_pool.connections.count(&:in_use?),
+        },
       }
     end
 

--- a/spec/app/models/good_job/process_spec.rb
+++ b/spec/app/models/good_job/process_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe GoodJob::Process do
     end
   end
 
+  describe '.ns_current_state' do
+    it 'contains information about the process' do
+      expect(described_class.ns_current_state).to include(
+        database_connection_pool: include(
+          size: be_an(Integer),
+          active: be_an(Integer)
+        )
+      )
+    end
+  end
+
   describe '.register' do
     it 'registers the process' do
       process = nil


### PR DESCRIPTION
This commit adds snapshot of database connection pool to a `GoodJob::Process.current_state` method.

* `size` - Total capacity of connection pool
* `active` - Number of connections in the pool that are in_use/active


References #1014 