### PR TITLE
Fix Probe Server by retrying IO.select instead of returning early

### DIFF
--- a/lib/good_job/http_server.rb
+++ b/lib/good_job/http_server.rb
@@ -44,7 +44,7 @@ module GoodJob
       while @running.true?
         begin
           ready_sockets, = IO.select([@server], nil, nil, SOCKET_READ_TIMEOUT)
-          return unless ready_sockets
+          next unless ready_sockets
 
           client = @server.accept_nonblock(exception: false)
           request = client.gets

--- a/spec/lib/good_job/probe_server_spec.rb
+++ b/spec/lib/good_job/probe_server_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe GoodJob::ProbeServer do
         ip_addresses.each do |ip_address|
           response = Net::HTTP.get(ip_address, "/", port)
           expect(response).to eq("OK")
+
+          response = Net::HTTP.get(ip_address, "/status", port)
+          expect(response).to eq("OK")
+
+          response = Net::HTTP.get(ip_address, "/status/started", port)
+          expect(response).to eq("Not started")
+
+          response = Net::HTTP.get(ip_address, "/status/connected", port)
+          expect(response).to eq("Not connected")
         end
       end
     end


### PR DESCRIPTION
Fixes #1033