### PR TITLE
Fix NoMethodError: undefined method `silence' for nil:NilClass

### DIFF
--- a/app/models/good_job/base_record.rb
+++ b/app/models/good_job/base_record.rb
@@ -28,6 +28,18 @@ module GoodJob
       false
     end
 
+    # Runs the block with self.logger silenced.
+    # If self.logger is nil, simply runs the block.
+    def self.with_logger_silenced(&block)
+      # Assign to a local variable, just in case it's modified in another thread concurrently
+      logger = self.logger
+      if logger
+        logger.silence(&block)
+      else
+        block.call
+      end
+    end
+
     ActiveSupport.run_load_hooks(:good_job_base_record, self)
   end
 end

--- a/app/models/good_job/base_record.rb
+++ b/app/models/good_job/base_record.rb
@@ -36,7 +36,7 @@ module GoodJob
       if logger
         logger.silence(&block)
       else
-        block.call
+        yield
       end
     end
 

--- a/lib/good_job/notifier/process_heartbeat.rb
+++ b/lib/good_job/notifier/process_heartbeat.rb
@@ -23,7 +23,7 @@ module GoodJob # :nodoc:
       def refresh_process
         Rails.application.executor.wrap do
           GoodJob::Process.with_connection(connection) do
-            GoodJob::Process.logger.silence do
+            GoodJob::Process.with_logger_silenced do
               @process&.refresh_if_stale(cleanup: true)
             end
           end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -18,6 +18,7 @@ module ::MemoryProfiler; end
 module ::PERFORMED; end
 module ::POLL_COUNT; end
 module ::RECEIVED_MESSAGE; end
+module ::REFRESH_IF_STALE_CALLED; end
 module ::RESULTS; end
 module ::RUN_JOBS; end
 module ::RecursiveJob; end

--- a/spec/lib/good_job/notifier_spec.rb
+++ b/spec/lib/good_job/notifier_spec.rb
@@ -60,6 +60,36 @@ RSpec.describe GoodJob::Notifier do
       expect(RECEIVED_MESSAGE.false?).to be true
     end
 
+    shared_examples 'calls refresh_if_stale on every tick' do
+      specify do
+        stub_const 'REFRESH_IF_STALE_CALLED', Concurrent::AtomicFixnum.new(0)
+
+        allow_any_instance_of(GoodJob::Process).to receive(:refresh_if_stale) { REFRESH_IF_STALE_CALLED.increment }
+
+        recipient = proc { }
+        notifier = described_class.new(recipient, enable_listening: true)
+        sleep_until(max: 5) { notifier.listening? }
+        described_class.notify(true)
+        sleep_until(max: 5) { REFRESH_IF_STALE_CALLED.value > 0 }
+        notifier.shutdown
+
+        expect(REFRESH_IF_STALE_CALLED.value).to be > 0
+      end
+    end
+
+    it_behaves_like 'calls refresh_if_stale on every tick'
+
+    context 'with ActiveRecord::Base.logger equal to nil' do
+      around do |example|
+        logger = ActiveRecord::Base.logger
+        ActiveRecord::Base.logger = nil
+        example.run
+        ActiveRecord::Base.logger = logger
+      end
+
+      it_behaves_like 'calls refresh_if_stale on every tick'
+    end
+
     it 'raises exception to GoodJob.on_thread_error' do
       stub_const('ExpectedError', Class.new(StandardError))
       on_thread_error = instance_double(Proc, call: nil)

--- a/spec/lib/good_job/notifier_spec.rb
+++ b/spec/lib/good_job/notifier_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe GoodJob::Notifier do
 
         allow_any_instance_of(GoodJob::Process).to receive(:refresh_if_stale) { REFRESH_IF_STALE_CALLED.increment }
 
-        recipient = proc { }
+        recipient = proc {}
         notifier = described_class.new(recipient, enable_listening: true)
         sleep_until(max: 5) { notifier.listening? }
         described_class.notify(true)


### PR DESCRIPTION
Don't attempt to call `logger.silence` if ActiveRecord::Base.logger is
nil.

Fixes #1036.
