### PR TITLE
[Doc] for cron schedule add info about Dashboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ GoodJob's cron uses unique indexes to ensure that only a single job is enqueued 
 
 Cron-format is parsed by the [`fugit`](https://github.com/floraison/fugit) gem, which has support for seconds-level resolution (e.g. `* * * * * *`) and natural language parsing (e.g. `every second`).
 
+If you use the [Dashboard](#dashboard) the scheduled tasks can be viewed in the 'cron' menu. In this view you can also disable a task or run/enqueue a task immediately.
+
 ```ruby
 # config/environments/application.rb or a specific environment e.g. production.rb
 


### PR DESCRIPTION
Hi, 
Suggested minor update to the docs.

I noticed the Dashboard has a cron menu and that allows scheduled tasks to be called on demand or paused, which is fabulous! For testing I set myself a cron task to run every minute but I could have easily called it every time I was ready instead :-)
I didn't see this mentioned anywhere else in the read me... so this pull request suggest a one line addition in the cron section, linking back to the dashboard section for people skim reading.

PS Thanks for sharing your work on good_job!