### PR TITLE
New probe server fixes

### DIFF
--- a/lib/good_job/http_server.rb
+++ b/lib/good_job/http_server.rb
@@ -49,8 +49,10 @@ module GoodJob
           client = @server.accept_nonblock
           request = client.gets
 
-          status, headers, body = @app.call(parse_request(request))
-          respond(client, status, headers, body)
+          if request
+            status, headers, body = @app.call(parse_request(request))
+            respond(client, status, headers, body)
+          end
 
           client.close
         rescue IO::WaitReadable, Errno::EINTR

--- a/lib/good_job/http_server.rb
+++ b/lib/good_job/http_server.rb
@@ -46,7 +46,7 @@ module GoodJob
           ready_sockets, = IO.select([@server], nil, nil, SOCKET_READ_TIMEOUT)
           next unless ready_sockets
 
-          client = @server.accept_nonblock(exception: false)
+          client = @server.accept_nonblock
           request = client.gets
 
           status, headers, body = @app.call(parse_request(request))


### PR DESCRIPTION
A couple of suggested fixes for the new probe http server. Commits should be self-explanatory, still some more context below.

---

Passing `exceptions: false` no longer raises `IO::WaitReadable` leaving the server in an unknown state.

> By specifying a keyword argument exception to false, you can indicate that [accept_nonblock](https://ruby-doc.org/3.2.2/exts/socket/TCPServer.html#method-i-accept_nonblock) should not raise an IO::WaitReadable exception, but return the symbol :wait_readable instead.


---

An `IO.gets` returns either a string or a nil. A nil response from a socket was not handled, suggesting we just skip those.

---

Appreciate taking a look as we're affected by these issues.