### PR TITLE
`GoodJob.restart` should not start capsules (job execution) when in a webserver but not in async mode

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -151,6 +151,8 @@ module GoodJob
   # @param timeout [Numeric] Seconds to wait for active threads to finish.
   # @return [void]
   def self.restart(timeout: -1)
+    return if configuration.execution_mode != :async && configuration.in_webserver?
+
     _shutdown_all(Capsule.instances, :restart, timeout: timeout)
   end
 

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -185,7 +185,7 @@ module GoodJob
     # @return [Boolean]
     def execute_async?
       execution_mode == :async_all ||
-        (execution_mode.in?([:async, :async_server]) && in_server_process?)
+        (execution_mode.in?([:async, :async_server]) && GoodJob.configuration.in_webserver?)
     end
 
     # Whether in +:external+ execution mode.
@@ -193,7 +193,7 @@ module GoodJob
     def execute_externally?
       execution_mode.nil? ||
         execution_mode == :external ||
-        (execution_mode.in?([:async, :async_server]) && !in_server_process?)
+        (execution_mode.in?([:async, :async_server]) && !GoodJob.configuration.in_webserver?)
     end
 
     # Whether in +:inline+ execution mode.
@@ -218,21 +218,6 @@ module GoodJob
     end
 
     private
-
-    # Whether running in a web server process.
-    # @return [Boolean, nil]
-    def in_server_process?
-      return @_in_server_process if defined? @_in_server_process
-
-      @_in_server_process = Rails.const_defined?(:Server) || begin
-        self_caller = caller
-
-        self_caller.grep(%r{config.ru}).any? || # EXAMPLE: config.ru:3:in `block in <main>' OR config.ru:3:in `new_from_string'
-          self_caller.grep(%r{puma/request}).any? || # EXAMPLE: puma-5.6.4/lib/puma/request.rb:76:in `handle_request'
-          self_caller.grep(%{/rack/handler/}).any? || # EXAMPLE: iodine-0.7.44/lib/rack/handler/iodine.rb:13:in `start'
-          (Concurrent.on_jruby? && self_caller.grep(%r{jruby/rack/rails_booter}).any?) # EXAMPLE: uri:classloader:/jruby/rack/rails_booter.rb:83:in `load_environment'
-      end
-    end
 
     def send_notify?(active_job)
       return false unless GoodJob.configuration.enable_listen_notify

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -79,6 +79,8 @@ module GoodJob
     def initialize(options, env: ENV)
       @options = options
       @env = env
+
+      @_in_webserver = nil
     end
 
     def validate!
@@ -173,7 +175,7 @@ module GoodJob
 
     # The number of seconds to wait for jobs to finish when shutting down
     # before stopping the thread. +-1+ is forever.
-    # @return [Numeric]
+    # @return [Float]
     def shutdown_timeout
       (
         options[:shutdown_timeout] ||
@@ -245,7 +247,7 @@ module GoodJob
 
     # Number of jobs a {Scheduler} will execute before automatically cleaning up preserved jobs.
     # Positive values will clean up after that many jobs have run, false or 0 will disable, and -1 will clean up after every job.
-    # @return [Integer, nil]
+    # @return [Integer, Boolean, nil]
     def cleanup_interval_jobs
       if rails_config.key?(:cleanup_interval_jobs)
         value = rails_config[:cleanup_interval_jobs]
@@ -347,6 +349,20 @@ module GoodJob
 
     def dashboard_default_locale
       rails_config[:dashboard_default_locale] || DEFAULT_DASHBOARD_DEFAULT_LOCALE
+    end
+
+    # Whether running in a web server process.
+    # @return [Boolean, nil]
+    def in_webserver?
+      return @_in_webserver unless @_in_webserver.nil?
+
+      @_in_webserver = Rails.const_defined?(:Server) || begin
+        self_caller = caller
+        self_caller.grep(%r{config.ru}).any? || # EXAMPLE: config.ru:3:in `block in <main>' OR config.ru:3:in `new_from_string'
+          self_caller.grep(%r{puma/request}).any? || # EXAMPLE: puma-5.6.4/lib/puma/request.rb:76:in `handle_request'
+          self_caller.grep(%{/rack/handler/}).any? || # EXAMPLE: iodine-0.7.44/lib/rack/handler/iodine.rb:13:in `start'
+          (Concurrent.on_jruby? && self_caller.grep(%r{jruby/rack/rails_booter}).any?) # EXAMPLE: uri:classloader:/jruby/rack/rails_booter.rb:83:in `load_environment'
+      end || false
     end
 
     private

--- a/spec/lib/active_job/queue_adapters/good_job_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/good_job_adapter_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 describe ActiveJob::QueueAdapters::GoodJobAdapter do
+  before do
+    GoodJob.configuration.instance_variable_set(:@_in_webserver, nil)
+  end
+
   it 'inherits from GoodJob::Adapter' do
     expect(described_class).to be < GoodJob::Adapter
   end

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe GoodJob::Adapter do
   let(:active_job) { instance_double(ActiveJob::Base) }
   let(:good_job) { instance_double(GoodJob::Execution, queue_name: 'default', scheduled_at: nil) }
 
+  before do
+    GoodJob.configuration.instance_variable_set(:@_in_webserver, nil)
+  end
+
   describe '#initialize' do
     it 'uses the global configuration value' do
       allow(GoodJob.configuration).to receive(:execution_mode).and_return(:external)

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -36,6 +36,18 @@ describe GoodJob do
       GoodJob::Capsule.new(configuration: configuration)
       expect { described_class.restart }.to change(described_class, :shutdown?).from(true).to(false)
     end
+
+    context 'when in webserver but not in async mode' do
+      before do
+        allow(described_class.configuration).to receive(:execution_mode).and_return(:external)
+        allow(described_class.configuration).to receive(:in_webserver?).and_return(true)
+      end
+
+      it 'does not start capsules' do
+        GoodJob::Capsule.new(configuration: configuration)
+        expect { described_class.restart }.not_to change(described_class, :shutdown?).from(true)
+      end
+    end
   end
 
   describe '.cleanup_preserved_jobs' do

--- a/spec/support/reset_good_job.rb
+++ b/spec/support/reset_good_job.rb
@@ -72,6 +72,8 @@ RSpec.configure do |config|
     end
 
     expect(PgLock.current_database.advisory_lock.others.count).to eq(0), "Existing others advisory locks AFTER test run"
+
+    GoodJob.configuration.instance_variable_set(:@_in_webserver, nil)
   end
 end
 

--- a/spec/test_app/config/environments/production.rb
+++ b/spec/test_app/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = ActiveModel::Type::Boolean.new.cast(ENV["FORCE_SSL"])
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Fixes #1054 

This isn't my favorite, but the docs have been telling people forever to use this pattern and there isn't a simple way to fix #1054 while also not requiring everyone to change their configuration.

```ruby
# config/puma.rg
before_fork do
  GoodJob.shutdown
end

on_worker_boot do
  GoodJob.restart
end
```

If this causes problems, I imagine that I'll add something like `restart!` that will ignore the new check (or introduce a simpler "start", or ensure that "restart" doesn't actually _start_ the capsule if it hadn't previously been running but rather just return it to the same state). But I am not aware of anyone manually creating capsules, so it's likely not used. 