### PR TITLE
Respect the configured execution mode, even within the CLI

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -89,21 +89,24 @@ module GoodJob
     # for more details on possible values.
     # @return [Symbol]
     def execution_mode
-      mode = if GoodJob::CLI.within_exe?
-               :external
-             else
-               options[:execution_mode] ||
-                 rails_config[:execution_mode] ||
-                 env['GOOD_JOB_EXECUTION_MODE']
-             end
+      mode = options[:execution_mode] ||
+             rails_config[:execution_mode] ||
+             env['GOOD_JOB_EXECUTION_MODE']
+      mode = mode.to_sym if mode
 
       if mode
-        mode.to_sym
+        if GoodJob::CLI.within_exe? && [:async, :async_server].include?(mode)
+          :external
+        else
+          mode
+        end
+      elsif GoodJob::CLI.within_exe?
+        :external
       elsif Rails.env.development?
         :async
       elsif Rails.env.test?
         :inline
-      else
+      else # rubocop:disable Lint/DuplicateBranch
         :external
       end
     end


### PR DESCRIPTION
Closes #1052.

"Execution Mode" is a bit overly broad because it defines both what the Adapter should do with the job after it is enqueued, as well as what background work should be activated (e.g. cron, job scheduler, etc.)

In this case, I think it makes sense that when executing jobs within the CLI that setting execution mode _should_ still configure what the Active Job Adapter does with jobs that enqueued during the performance of other jobs. In this case:

- `:external` jobs are enqueued and executed anywhere
- `:inline` jobs are enqueued and executed inline
- `:async_all` jobs are enqueued and are attempted to be executed _within_ the same process, and if that's not possible, then treated like `:external` jobs
- I didn't change the meaning of `:async` which is intended to only configure behavior on webservers. If a CLI is configured in `:async` mode, the execution mode treated as `:external`