### PR TITLE
Add JRuby 9.4 to testing matrix; nerf ActiveJob::TestQueueAdapter overrides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", 3.1, 3.2, jruby-9.3]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2, jruby-9.3, jruby-9.4]
         pg: [15]
         include:
           - ruby: 3.2
@@ -87,13 +87,13 @@ jobs:
             pg: 13
           - ruby: 3.2
             pg: 14
-          - ruby: jruby-9.3
+          - ruby: jruby-9.4
             pg: 11
-          - ruby: jruby-9.3
+          - ruby: jruby-9.4
             pg: 12
-          - ruby: jruby-9.3
+          - ruby: jruby-9.4
             pg: 13
-          - ruby: jruby-9.3
+          - ruby: jruby-9.4
             pg: 14
     env:
       PGHOST: localhost

--- a/Appraisals
+++ b/Appraisals
@@ -26,16 +26,18 @@ if ruby_27_or_higher && !ruby_31_or_higher && !jruby
   end
 end
 
-if ruby_31_or_higher && !jruby
+if ruby_31_or_higher
   appraise "rails-7.0-ruby-3.1" do
     gem "capybara", "~> 3.36" # For Ruby 3.1 support https://github.com/teamcapybara/capybara/pull/2468
     gem "rails", "~> 7.0.1" # Ruby 3.1 requires Rails 7.0.1+
     gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
   end
 
-  appraise "rails-head" do
-    gem "capybara", "~> 3.36"
-    gem "rails", github: "rails/rails", branch: "main"
-    gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
+  unless jruby
+    appraise "rails-head" do
+      gem "capybara", "~> 3.36"
+      gem "rails", github: "rails/rails", branch: "main"
+      gem "selenium-webdriver", "~> 4.0" # https://github.com/rails/rails/pull/43498
+    end
   end
 end

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,17 +3,28 @@
 source "https://rubygems.org"
 
 gem "activerecord-jdbcpostgresql-adapter", platforms: [:jruby]
-gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/appraisal.git"
+gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.git"
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rack", "~> 2.0"
+gem "rack", "~> 2.2"
 gem "rails", "~> 6.0.0"
 gem "traces", "~> 0.9.1"
 
 platforms :ruby do
-  gem "activerecord-explain-analyze"
+  gem "activerecord-explain-analyze", require: false
+  gem "dotenv"
+  gem "foreman"
+  gem "gem-release"
+  gem "github_changelog_generator", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
   gem "pry-byebug"
+  gem "rack-mini-profiler"
+  gem "rbtrace"
+  gem "stackprof"
+  gem "tapioca", require: false, group: :development
 
   group :lint do
     gem "easy_translate"
@@ -24,6 +35,9 @@ platforms :ruby do
     gem "rubocop-performance"
     gem "rubocop-rails"
     gem "rubocop-rspec"
+    gem "sorbet"
+    gem "sorbet-runtime"
+    gem "spoom", require: false
   end
 end
 

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,17 +3,28 @@
 source "https://rubygems.org"
 
 gem "activerecord-jdbcpostgresql-adapter", platforms: [:jruby]
-gem "appraisal", branch: "fix-bundle-env", git: "https://github.com/bensheldon/appraisal.git"
+gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.git"
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rack", "~> 2.0"
+gem "rack", "~> 2.2"
 gem "rails", "~> 6.1.0"
 gem "traces", "~> 0.9.1"
 
 platforms :ruby do
-  gem "activerecord-explain-analyze"
+  gem "activerecord-explain-analyze", require: false
+  gem "dotenv"
+  gem "foreman"
+  gem "gem-release"
+  gem "github_changelog_generator", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
   gem "pry-byebug"
+  gem "rack-mini-profiler"
+  gem "rbtrace"
+  gem "stackprof"
+  gem "tapioca", require: false, group: :development
 
   group :lint do
     gem "easy_translate"
@@ -24,6 +35,9 @@ platforms :ruby do
     gem "rubocop-performance"
     gem "rubocop-rails"
     gem "rubocop-rspec"
+    gem "sorbet"
+    gem "sorbet-runtime"
+    gem "spoom", require: false
   end
 end
 

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -7,19 +7,24 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rack", "~> 2.0"
+gem "rack", "~> 2.2"
 gem "rails", "~> 7.0.0"
 gem "selenium-webdriver", "~> 4.0"
 
 platforms :ruby do
   gem "activerecord-explain-analyze", require: false
+  gem "dotenv"
+  gem "foreman"
+  gem "gem-release"
+  gem "github_changelog_generator", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
   gem "pry-byebug"
   gem "rack-mini-profiler"
   gem "rbtrace"
   gem "stackprof"
-  gem "net-imap", require: false
-  gem "net-pop", require: false
-  gem "net-smtp", require: false
+  gem "tapioca", require: false, group: :development
 
   group :lint do
     gem "easy_translate"
@@ -30,6 +35,9 @@ platforms :ruby do
     gem "rubocop-performance"
     gem "rubocop-rails"
     gem "rubocop-rspec"
+    gem "sorbet"
+    gem "sorbet-runtime"
+    gem "spoom", require: false
   end
 end
 

--- a/gemfiles/rails_7.0_ruby_3.1.gemfile
+++ b/gemfiles/rails_7.0_ruby_3.1.gemfile
@@ -7,20 +7,25 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rack", "~> 2.0"
+gem "rack", "~> 2.2"
 gem "rails", "~> 7.0.1"
 gem "capybara", "~> 3.36"
 gem "selenium-webdriver", "~> 4.0"
 
 platforms :ruby do
   gem "activerecord-explain-analyze", require: false
+  gem "dotenv"
+  gem "foreman"
+  gem "gem-release"
+  gem "github_changelog_generator", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
   gem "pry-byebug"
   gem "rack-mini-profiler"
   gem "rbtrace"
   gem "stackprof"
-  gem "net-imap", require: false
-  gem "net-pop", require: false
-  gem "net-smtp", require: false
+  gem "tapioca", require: false, group: :development
 
   group :lint do
     gem "easy_translate"
@@ -31,6 +36,9 @@ platforms :ruby do
     gem "rubocop-performance"
     gem "rubocop-rails"
     gem "rubocop-rspec"
+    gem "sorbet"
+    gem "sorbet-runtime"
+    gem "spoom", require: false
   end
 end
 

--- a/gemfiles/rails_head.gemfile
+++ b/gemfiles/rails_head.gemfile
@@ -7,20 +7,25 @@ gem "appraisal", branch: "main", git: "https://github.com/thoughtbot/appraisal.g
 gem "matrix"
 gem "nokogiri"
 gem "pg", platforms: [:mri, :mingw, :x64_mingw]
-gem "rack", "~> 2.0"
+gem "rack", "~> 2.2"
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
 gem "capybara", "~> 3.36"
 gem "selenium-webdriver", "~> 4.0"
 
 platforms :ruby do
   gem "activerecord-explain-analyze", require: false
+  gem "dotenv"
+  gem "foreman"
+  gem "gem-release"
+  gem "github_changelog_generator", require: false
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
   gem "pry-byebug"
   gem "rack-mini-profiler"
   gem "rbtrace"
   gem "stackprof"
-  gem "net-imap", require: false
-  gem "net-pop", require: false
-  gem "net-smtp", require: false
+  gem "tapioca", require: false, group: :development
 
   group :lint do
     gem "easy_translate"
@@ -31,6 +36,9 @@ platforms :ruby do
     gem "rubocop-performance"
     gem "rubocop-rails"
     gem "rubocop-rspec"
+    gem "sorbet"
+    gem "sorbet-runtime"
+    gem "spoom", require: false
   end
 end
 


### PR DESCRIPTION
I am experiencing problems with JRuby 9.4.3.0 and the usage of `prepend` and calling `descendants` (which is called by `ActiveJob::TestHelper`, with exceptions that look like: https://github.com/jruby/jruby/issues/6896

It is a little strange though because it could be a combination of `stub_constant` and doing weird things with ActiveSupport::Concern like:

https://github.com/bensheldon/good_job/blob/d1cde1767435aca3f7245c132aae9c886a81f20d/lib/good_job/active_job_extensions/concurrency.rb#L23-L24

Unfortunately, I wasn't able to isolate it down, but my working theory is that something like this _should_ be problematic (though maybe it is specifically `stub_const`):

```ruby
require 'bundler/inline'
gemfile do
  gem 'activesupport'
end

require 'active_support/concern'
require 'active_support/descendants_tracker'
module Paws
  extend ::ActiveSupport::Concern

  module Prepends
    def paws
      puts 'PAWS'
    end
  end

  included do
    prepend Prepends
  end
end

class Animal
  extend ActiveSupport::DescendantsTracker
end

class Dog < Animal
  include Paws
end

puts Dog.new.paws
puts Animal.descendants
puts ObjectSpace.each_object(Module).each(&:singleton_class)
```