### PR TITLE
Allow Probe Server's `/connect` to handle a certain number of reconnects before statusing

### DIFF
--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -24,6 +24,9 @@ module GoodJob # :nodoc:
     WAIT_INTERVAL = 1
     # Seconds to wait if database cannot be connected to
     RECONNECT_INTERVAL = 5
+    # Number of consecutive connection errors before reporting an error
+    CONNECTION_ERRORS_REPORTING_THRESHOLD = 6
+
     # Connection errors that will wait {RECONNECT_INTERVAL} before reconnecting
     CONNECTION_ERRORS = %w[
       ActiveRecord::ConnectionNotEstablished
@@ -31,7 +34,6 @@ module GoodJob # :nodoc:
       PG::UnableToSend
       PG::Error
     ].freeze
-    CONNECTION_ERRORS_REPORTING_THRESHOLD = 3
 
     # @!attribute [r] instances
     #   @!scope class
@@ -69,8 +71,8 @@ module GoodJob # :nodoc:
       @mutex = Mutex.new
       @shutdown_event = Concurrent::Event.new.tap(&:set)
       @running = Concurrent::AtomicBoolean.new(false)
-      @connected = Concurrent::AtomicBoolean.new(false)
-      @listening = Concurrent::AtomicBoolean.new(false)
+      @connected = Concurrent::Event.new
+      @listening = Concurrent::Event.new
       @connection_errors_count = Concurrent::AtomicFixnum.new(0)
       @connection_errors_reported = Concurrent::AtomicBoolean.new(false)
       @enable_listening = enable_listening
@@ -85,15 +87,25 @@ module GoodJob # :nodoc:
     end
 
     # Tests whether the notifier is active and has acquired a dedicated database connection.
+    # @param timeout [Numeric, nil] Seconds to wait for condition to be true, -1 is forever
     # @return [true, false, nil]
-    def connected?
-      @connected.true?
+    def connected?(timeout: nil)
+      if timeout.nil?
+        @connected.set?
+      else
+        @connected.wait(timeout == -1 ? nil : timeout)
+      end
     end
 
     # Tests whether the notifier is listening for new messages.
+    # @param timeout [Numeric, nil] Seconds to wait for condition to be true, -1 is forever
     # @return [true, false, nil]
-    def listening?
-      @listening.true?
+    def listening?(timeout: nil)
+      if timeout.nil?
+        @listening.set?
+      else
+        @listening.wait(timeout == -1 ? nil : timeout)
+      end
     end
 
     def shutdown?
@@ -114,11 +126,12 @@ module GoodJob # :nodoc:
 
         if @executor.shutdown? || @task&.complete?
           # clean up in the even the executor is killed
-          @connected.make_false
-          @listening.make_false
+          @connected.reset
+          @listening.reset
           @shutdown_event.set
         else
           @shutdown_event.wait(timeout == -1 ? nil : timeout) unless timeout.nil?
+          @connected.reset if @shutdown_event.set?
         end
         @shutdown_event.set?
       end
@@ -152,6 +165,7 @@ module GoodJob # :nodoc:
         if connection_error
           @connection_errors_count.increment
           if @connection_errors_reported.false? && @connection_errors_count.value >= CONNECTION_ERRORS_REPORTING_THRESHOLD
+            @connected.reset
             GoodJob._on_thread_error(thread_error)
             @connection_errors_reported.make_true
           end
@@ -180,15 +194,17 @@ module GoodJob # :nodoc:
     end
 
     def create_listen_task(delay: 0)
-      @task = Concurrent::ScheduledTask.new(delay, args: [@recipients, @running, @executor, @enable_listening, @listening], executor: @executor) do |thr_recipients, thr_running, thr_executor, thr_enable_listening, thr_listening|
+      @task = Concurrent::ScheduledTask.new(delay, args: [@recipients, @running, @executor, @enable_listening, @connected, @listening], executor: @executor) do |thr_recipients, thr_running, thr_executor, thr_enable_listening, thr_connected, thr_listening|
         with_connection do
+          thr_connected.set
+
           begin
             Rails.application.executor.wrap do
               run_callbacks :listen do
                 if thr_enable_listening
                   ActiveSupport::Notifications.instrument("notifier_listen.good_job") do
                     connection.execute("LISTEN #{CHANNEL}")
-                    thr_listening.make_true
+                    thr_listening.set
                   end
                 end
               end
@@ -216,7 +232,7 @@ module GoodJob # :nodoc:
             run_callbacks :unlisten do
               if thr_enable_listening
                 ActiveSupport::Notifications.instrument("notifier_unlisten.good_job") do
-                  thr_listening.make_false
+                  thr_listening.reset
                   connection.execute("UNLISTEN *")
                 end
               end
@@ -237,11 +253,9 @@ module GoodJob # :nodoc:
         end
       end
       connection.execute("SET application_name = #{connection.quote(self.class.name)}")
-      @connected.make_true
 
       yield
     ensure
-      @connected.make_false
       connection&.disconnect!
       self.connection = nil
     end

--- a/lib/good_job/probe_server.rb
+++ b/lib/good_job/probe_server.rb
@@ -37,7 +37,7 @@ module GoodJob
         started ? [200, {}, ["Started"]] : [503, {}, ["Not started"]]
       when '/status/connected'
         connected = GoodJob::Scheduler.instances.any? && GoodJob::Scheduler.instances.all?(&:running?) &&
-                    GoodJob::Notifier.instances.any? && GoodJob::Notifier.instances.all?(&:listening?)
+                    GoodJob::Notifier.instances.any? && GoodJob::Notifier.instances.all?(&:connected?)
         connected ? [200, {}, ["Connected"]] : [503, {}, ["Not connected"]]
       else
         [404, {}, ["Not found"]]

--- a/spec/lib/good_job/probe_server_spec.rb
+++ b/spec/lib/good_job/probe_server_spec.rb
@@ -82,12 +82,25 @@ RSpec.describe GoodJob::ProbeServer do
         end
       end
 
-      context 'when there are running schedulers and listening notifiers' do
+      context 'when there are running schedulers but disconnected notifiers' do
         it 'returns 200' do
           scheduler = instance_double(GoodJob::Scheduler, running?: true, shutdown: true, shutdown?: true)
           GoodJob::Scheduler.instances << scheduler
 
-          notifier = instance_double(GoodJob::Notifier, listening?: true, shutdown: true, shutdown?: true)
+          notifier = instance_double(GoodJob::Notifier, connected?: false, shutdown: true, shutdown?: true)
+          GoodJob::Notifier.instances << notifier
+
+          response = probe_server.call(env)
+          expect(response[0]).to eq(503)
+        end
+      end
+
+      context 'when there are running schedulers and connected notifiers' do
+        it 'returns 200' do
+          scheduler = instance_double(GoodJob::Scheduler, running?: true, shutdown: true, shutdown?: true)
+          GoodJob::Scheduler.instances << scheduler
+
+          notifier = instance_double(GoodJob::Notifier, connected?: true, shutdown: true, shutdown?: true)
           GoodJob::Notifier.instances << notifier
 
           response = probe_server.call(env)


### PR DESCRIPTION
Fixes #1068.

Once GoodJob has successfully connected, Probe Server's `/connected` endpoint will continue returning 200-success if the database connection is lost and reconnections are attempted. This is now aligned with the existing thread-error reporting behavior:
 https://github.com/bensheldon/good_job/blob/3c45787add63c72f6c365275f518121664faa126/lib/good_job/notifier.rb#L152-L160

I also increased the number of reconnect attempts, so it will now be 6 attempts, once every 5 seconds = 30 seconds of reconnecting before the `Notifier#connected?` will become false and the Probe Server will start returning a 503 and the `GoodJob.on_thread_error` callback will be triggered.

Also some slight refactoring so that the utility methods `listen?` and `wait?` are now condition variables and have a timeout.