### PR TITLE
Fix HttpServer to handle Errno::EPIPE

### DIFF
--- a/lib/good_job/http_server.rb
+++ b/lib/good_job/http_server.rb
@@ -55,7 +55,7 @@ module GoodJob
           end
 
           client.close
-        rescue IO::WaitReadable, Errno::EINTR
+        rescue IO::WaitReadable, Errno::EINTR, Errno::EPIPE
           retry
         end
       end


### PR DESCRIPTION
When client disconnects unexpectedly, TCPSocket#write raises the unhandled `Errno::EPIPE` error and HttpServer shuts down.