### PR TITLE
Correct `discrete_execution#status` method

### DIFF
--- a/app/models/good_job/discrete_execution.rb
+++ b/app/models/good_job/discrete_execution.rb
@@ -40,10 +40,10 @@ module GoodJob # :nodoc:
 
     def status
       if finished_at.present?
-        if error.present?
-          :retried
-        elsif error.present? && job.finished_at.present?
+        if error.present? && job.finished_at.present?
           :discarded
+        elsif error.present?
+          :retried
         else
           :succeeded
         end


### PR DESCRIPTION
The order of the conditions in this `discrete_execution#status` method was previously incorrect, which meant it was not possible for the `:discarded` status to ever be returned

If `error.present?` then the status should either be `:retried` or `:discarded`, depending on whether the parent job has a `finished_at` timestamp. However, the more specific check of `error.present? && job.finished_at.present?` was left in the `elsif` branch. That meant the value of `:retried` was always returned whenever the more generic `if error.present?` condition returned true (without ever checking the value of `job.finished_at`)