### PR TITLE
Address rails 7.1 deprecation when using `ActiveJobExtensions::Concurrency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ GoodJob.on_thread_error = -> (exception) { Rails.error.report(exception) }
 
 By default, GoodJob relies on ActiveJob's retry functionality.
 
-ActiveJob can be configured to retry an infinite number of times, with an exponential backoff. Using ActiveJob's `retry_on` prevents exceptions from reaching GoodJob:
+ActiveJob can be configured to retry an infinite number of times, with a polynomial backoff. Using ActiveJob's `retry_on` prevents exceptions from reaching GoodJob:
 
 ```ruby
 class ApplicationJob < ActiveJob::Base

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -36,10 +36,16 @@ module GoodJob
           end
         end
 
+        wait_key = if ActiveJob.gem_version >= Gem::Version.new("7.1.0")
+                     :polynomially_longer
+                   else
+                     :exponentially_longer
+                   end
+
         retry_on(
           GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
           attempts: Float::INFINITY,
-          wait: :exponentially_longer
+          wait: wait_key
         )
 
         before_perform do |job|


### PR DESCRIPTION
Closes #1096, it's a simple fix so why not do it myself.

There are still a few references to exponentially_longer in the readme but it didn't seem wise to change those while it's not actually usable. I did change one instance in the readme where it explains what it does, since it's not actually exponetially longer but if you think that's just going to cause confusion I'll just drop that.