### PR TITLE
Remove `pg_advisory_unlock_all()` after job is run; only verify blank `finished_at` (and not lock presence) before performing job

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -256,12 +256,13 @@ module GoodJob
     def self.perform_with_advisory_lock(parsed_queues: nil, queue_select_limit: nil)
       execution = nil
       result = nil
-      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(unlock_session: true, select_limit: queue_select_limit) do |executions|
+      unfinished.dequeueing_ordered(parsed_queues).only_scheduled.limit(1).with_advisory_lock(select_limit: queue_select_limit) do |executions|
         execution = executions.first
         break if execution.blank?
 
         unless execution.executable?
           result = ExecutionResult.new(value: nil, unexecutable: true)
+          execution = nil
           break
         end
 
@@ -491,7 +492,9 @@ module GoodJob
     # Tests whether this job is safe to be executed by this thread.
     # @return [Boolean]
     def executable?
-      self.class.unscoped.unfinished.owns_advisory_locked.exists?(id: id)
+      reload.finished_at.blank?
+    rescue ActiveRecord::RecordNotFound
+      false
     end
 
     def make_discrete

--- a/spec/app/models/good_job/execution_spec.rb
+++ b/spec/app/models/good_job/execution_spec.rb
@@ -196,13 +196,12 @@ RSpec.describe GoodJob::Execution do
       let!(:queue_one_job) { described_class.create!(job_params.merge(queue_name: "one", created_at: 1.minute.ago, priority: 1)) }
 
       it "orders by queue order" do
-        2.times do
-          described_class.perform_with_advisory_lock(parsed_queues: parsed_queues)
+        described_class.perform_with_advisory_lock(parsed_queues: parsed_queues) do |execution|
+          expect(execution).to eq queue_one_job
         end
-        expect(described_class.order(finished_at: :asc).to_a).to eq([
-                                                                      queue_one_job,
-                                                                      queue_two_job,
-                                                                    ])
+        described_class.perform_with_advisory_lock(parsed_queues: parsed_queues) do |execution|
+          expect(execution).to eq queue_two_job
+        end
       end
     end
   end

--- a/spec/test_app/config/database.yml
+++ b/spec/test_app/config/database.yml
@@ -20,7 +20,7 @@ default: &default
   host: localhost
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 10 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 20 } %>
 
 development:
   <<: *default


### PR DESCRIPTION
The background of this change arises from trying to overcome the performance limitations of the lock verification as described in #896. 

Before this change, the sequence when dequeuing a job to perform:
1. Do the advisory lock query, and return the record
2. Verify that the record is advisory locked _and_ `finished_at` is not set
3. Execute the job if the previous condition is ok
4. Blanket unlock all adisory unlocks held by the session

After this change:
1. Do the advisory lock query, and return the record
2. Verify that the record's `finished_at` is not set
3. Execute the job if the previous condition is ok
4. Unlock the specific record that was advisory locked in the first step


## Background / Analysis

Most briefly, GoodJob's advisory locking strategy went through a lot of churn in mid-2021.

Using `pg_advisory_unlock_all`, instead of unlocking the specifically returned record, was introduced in #285 to address unexpectedly advisory locked records caused by "an indeterminate reason" (😞). In the fullness of time, I'm fairly certain that it was caused by a `FOR UPDATE SKIP LOCKED` that was introduced in #273 (mistakenly? that PR says it was extracted to #274, and it wasn't), and the `SKIP LOCKED` was removed in #288. 

For the record, the problem wasn't inherently the `FOR UPDATE SKIP LOCKED` but the placement of it in the query. It was placed in the same subselect as the advisory-lock function, implying that sometimes the advisory-lock function would lock a record that would be then be skip-locked from the results _but still remain advisory locked_: https://github.com/bensheldon/good_job/pull/285#issuecomment-1764812449

Or, the issue could be that at the time I was using a [`Rails.application.executor.wrap`](https://github.com/bensheldon/good_job/blob/78737f26274e9f8bc8e0f63550433f1fc6f35a05/lib/good_job/scheduler.rb#L195) instead of a `Rails.application.reloader.wrap` which was also identified in #389 as as source of `WARNING:  you don't own a lock of type ExclusiveLock` errors. (a little more convo in #99 too, which is when the `executor.wrap` was last reviewed)

Or both!


