### PR TITLE
Wrap Adapter enqueue methods and Batch callbacks with Rails Reloader; verify in tests that no Advisory locks remain at database connection check-in 

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -237,7 +237,7 @@ module GoodJob
   def self.perform_inline(queue_string = "*")
     job_performer = JobPerformer.new(queue_string)
     loop do
-      result = job_performer.next
+      result = Rails.application.reloader.wrap { job_performer.next }
       break unless result
       raise result.unhandled_error if result.unhandled_error
     end

--- a/spec/app/models/good_job/execution_spec.rb
+++ b/spec/app/models/good_job/execution_spec.rb
@@ -3,6 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe GoodJob::Execution do
+  around do |example|
+    Rails.application.executor.wrap { example.run }
+  end
+
   before do
     allow(described_class).to receive(:discrete_support?).and_return(false)
 

--- a/spec/integration/complex_jobs_spec.rb
+++ b/spec/integration/complex_jobs_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Complex Jobs' do
   let(:inline_adapter) { GoodJob::Adapter.new(execution_mode: :inline) }
-  let(:async_adapter) { GoodJob::Adapter.new(execution_mode: :async) }
+  let(:async_adapter) { GoodJob::Adapter.new(execution_mode: :async_all) }
 
   before do
     GoodJob.capsule.restart

--- a/spec/lib/good_job/active_job_extensions/batches_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/batches_spec.rb
@@ -19,9 +19,11 @@ RSpec.describe GoodJob::ActiveJobExtensions::Batches do
 
   describe 'batch accessors' do
     it 'access batch' do
-      batch = GoodJob::Batch.enqueue(some_property: "Apple") do
-        TestJob.perform_later
-        TestJob.perform_later
+      batch = Rails.application.executor.wrap do
+        GoodJob::Batch.enqueue(some_property: "Apple") do
+          TestJob.perform_later
+          TestJob.perform_later
+        end
       end
 
       expect(batch).to be_a GoodJob::Batch

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -55,8 +55,10 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       it "is inclusive of both performing and enqueued jobs" do
         expect(TestJob.perform_later(name: "Alice")).to be_present
 
-        GoodJob::Execution.all.with_advisory_lock do
-          expect(TestJob.perform_later(name: "Alice")).to be false
+        Rails.application.executor.wrap do
+          GoodJob::Execution.all.with_advisory_lock do
+            expect(TestJob.perform_later(name: "Alice")).to be false
+          end
         end
       end
     end
@@ -96,9 +98,11 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(TestJob.perform_later(name: "Alice")).to be_present
 
         # Lock one of the jobs
-        GoodJob::Execution.first.with_advisory_lock do
-          # Third usage does enqueue
-          expect(TestJob.perform_later(name: "Alice")).to be_present
+        Rails.application.executor.wrap do
+          GoodJob::Execution.first.with_advisory_lock do
+            # Third usage does enqueue
+            expect(TestJob.perform_later(name: "Alice")).to be_present
+          end
         end
       end
     end

--- a/spec/requests/good_job/jobs_controller_spec.rb
+++ b/spec/requests/good_job/jobs_controller_spec.rb
@@ -6,7 +6,7 @@ describe GoodJob::JobsController do
   around do |example|
     orig_value = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = false
-    example.call
+    example.run
     ActionController::Base.allow_forgery_protection = orig_value
   end
 

--- a/spec/support/postgres_notices.rb
+++ b/spec/support/postgres_notices.rb
@@ -15,6 +15,15 @@ ActiveSupport.on_load :active_record do
       POSTGRES_NOTICES << result.error_message
     end
   }
+
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback :checkin, :before, lambda { |conn|
+    warning = PgLock.debug_own_locks(conn)
+    next if warning.blank?
+
+    $stdout.puts warning
+    Rails.logger.warn(warning)
+    POSTGRES_NOTICES << warning
+  }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Follow-up to #1121, #1122 and improved verification of #1113.

## Notes about Rails Executors/Reloaders

These are the general details: https://guides.rubyonrails.org/threading_and_code_execution.html

- Active Job perform is automatically wrapped with a Rails Reloader: https://github.com/rails/rails/blob/5534a2286b17e361ebfdca078e411578ed493e83/activejob/lib/active_job/railtie.rb#L63-L71
- GoodJob takes an Advisory Lock _before_ any individual Active Job job is performed, therefore GoodJob needs to wrap its calls with an Executor or Reloader.
- Nested Executors/Reloaders are fine, because the interior nested executor/reloader will be a noop.
- When the outermost/true Executor/Reloader is done, it will check-in the current database connections.
- If a Reloader is wrapped with an Executor (e.g. `Rails.application.executor.wrap { Rails.application.reloader.wrap { do_stuff } }`), if code reload is triggered between the Executor and the Reloader block, the Reloader seems like it checks in the current database connections.
- Rails Minitest now does seem to wrap all tests with an Executor: https://github.com/rails/rails/pull/43550
- RSpec Rails (which GoodJob uses) does not wrap with an Rails Executor: https://github.com/rspec/rspec-rails/issues/2644#issuecomment-1769412773
- I believe that some of GoodJob's flaky test behavior is a result of connections with Advisory Locks being checked-in to the connection pool when Executor/Reloader boundaries are crossed.

## Benefits / Risks

- In a regular application---controller actions, jobs---I would expect these additional reloaders to be noops, because controller actions and jobs are already wrapped with executors/reloaders.
- In tests, this might make tests slightly more reliable, if people are experiencing the same flakes that I am in GoodJob's test suite.
- Introducing Reloaders/Executors does add additional potential for deadlocks, but given above, I largely expect them to be noops, or running inline in tests.