### PR TITLE
Use a constant to represent `None` for default/blank memoizable values

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -42,6 +42,10 @@ require "good_job/systemd_service"
 module GoodJob
   include GoodJob::Dependencies
 
+  # Default, null, blank value placeholder.
+  NONE = Module.new.freeze
+
+  # Default logger for GoodJob; overridden by Rails.logger in Railtie.
   DEFAULT_LOGGER = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new($stdout))
 
   # @!attribute [rw] active_record_parent_class

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -168,13 +168,13 @@ module GoodJob
     end
 
     # Shut down the thread pool executors.
-    # @param timeout [nil, Numeric, Symbol] Seconds to wait for active threads.
+    # @param timeout [nil, Numeric, NONE] Seconds to wait for active threads.
     #   * +nil+ trigger a shutdown but not wait for it to complete.
     #   * +-1+ wait until the shutdown is complete.
     #   * +0+ immediately shutdown and stop any threads.
     #   * A positive number will wait that many seconds before stopping any remaining active threads.
     # @return [void]
-    def shutdown(timeout: :default)
+    def shutdown(timeout: NONE)
       @capsule&.shutdown(timeout: timeout)
       @_async_started = false
     end

--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -44,23 +44,23 @@ module GoodJob
     end
 
     # Shut down the thread pool executors.
-    # @param timeout [nil, Numeric, Symbol] Seconds to wait for active threads.
+    # @param timeout [nil, Numeric, NONE] Seconds to wait for active threads.
     #   * +-1+ will wait for all active threads to complete.
     #   * +0+ will interrupt active threads.
     #   * +N+ will wait at most N seconds and then interrupt active threads.
     #   * +nil+ will trigger a shutdown but not wait for it to complete.
     # @return [void]
-    def shutdown(timeout: :default)
-      timeout = @configuration.shutdown_timeout if timeout == :default
+    def shutdown(timeout: NONE)
+      timeout = @configuration.shutdown_timeout if timeout == NONE
       GoodJob._shutdown_all([@shared_executor, @notifier, @poller, @scheduler, @cron_manager].compact, timeout: timeout)
       @startable = false
       @running = false
     end
 
     # Shutdown and then start the capsule again.
-    # @param timeout [Numeric, Symbol] Seconds to wait for active threads.
+    # @param timeout [Numeric, NONE] Seconds to wait for active threads.
     # @return [void]
-    def restart(timeout: :default)
+    def restart(timeout: NONE)
       raise ArgumentError, "Capsule#restart cannot be called with a timeout of nil" if timeout.nil?
 
       shutdown(timeout: timeout)


### PR DESCRIPTION
Inspired by conversation about Object Shapes: https://ruby.social/@byroot/111194504155750732

...with reference to this PR: https://github.com/sporkmonger/addressable/pull/509