### PR TITLE
In test, shutdown schedulers/capsules before doing assertions because of race conditions; store CI logs for Dev Env tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,21 @@ jobs:
         run: bin/rails db:test:prepare
       - name: bin/rspec
         run: bin/rspec --require ./spec/support/pre_documentation_formatter.rb --format PreDocumentationFormatter
+      # Archive
+      - name: Archive system spec screenshots
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: screenshots
+          path: |
+            spec/test_app/tmp/screenshots
+            spec/test_app/tmp/capybara
+      - name: Archive Rails logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: rails_logs
+          path: spec/test_app/log
 
   test:
     name: Test

--- a/spec/integration/capsule_spec.rb
+++ b/spec/integration/capsule_spec.rb
@@ -24,8 +24,9 @@ RSpec.describe 'Capsule' do
 
     LATCH.wait(10)
     wait_until { expect(GoodJob::Job.finished.count).to eq(total_jobs) }
-    expect(GoodJob::DiscreteExecution.count).to eq(total_jobs)
-
     perform_capsule.shutdown
+    enqueue_capsule.shutdown
+
+    expect(GoodJob::DiscreteExecution.count).to eq(total_jobs)
   end
 end

--- a/spec/integration/complex_jobs_spec.rb
+++ b/spec/integration/complex_jobs_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Complex Jobs' do
-  let(:inline_adapter) { GoodJob::Adapter.new(execution_mode: :inline) }
-  let(:async_adapter) { GoodJob::Adapter.new(execution_mode: :async_all) }
+  let(:capsule) { GoodJob::Capsule.new }
+  let(:inline_adapter) { GoodJob::Adapter.new(execution_mode: :inline, _capsule: capsule) }
+  let(:async_adapter) { GoodJob::Adapter.new(execution_mode: :async_all, _capsule: capsule) }
 
   before do
-    GoodJob.capsule.restart
     allow(GoodJob.on_thread_error).to receive(:call).and_call_original
+  end
+
+  after do
+    capsule.shutdown
   end
 
   describe 'Job without error handler / unhandled' do
@@ -28,6 +32,8 @@ RSpec.describe 'Complex Jobs' do
       TestJob.perform_later
 
       wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+      capsule.shutdown
+
       good_job = GoodJob::Job.last
       expect(good_job).to have_attributes(
         executions_count: 1,
@@ -64,6 +70,8 @@ RSpec.describe 'Complex Jobs' do
       TestJob.perform_later
 
       wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+      capsule.shutdown
+
       good_job = GoodJob::Job.last
       expect(good_job).to have_attributes(
         executions_count: 1,
@@ -94,6 +102,8 @@ RSpec.describe 'Complex Jobs' do
       TestJob.perform_later
 
       wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+      capsule.shutdown
+
       good_job = GoodJob::Job.last
       expect(good_job).to have_attributes(
         executions_count: 1,
@@ -124,6 +134,8 @@ RSpec.describe 'Complex Jobs' do
       TestJob.perform_later
 
       wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+      capsule.shutdown
+
       good_job = GoodJob::Job.last
       expect(good_job).to have_attributes(
         executions_count: 2,
@@ -151,6 +163,8 @@ RSpec.describe 'Complex Jobs' do
       TestJob.perform_later
 
       wait_until { expect(GoodJob::Job.last.finished_at).to be_present }
+      capsule.shutdown
+
       good_job = GoodJob::Job.last
       expect(good_job).to have_attributes(
         executions_count: 2,


### PR DESCRIPTION
Noticed the problem in this build: https://github.com/bensheldon/good_job/actions/runs/6700028231/job/18205234300