### PR TITLE
Clarify on concurrency uniqueness constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ class MyJob < ApplicationJob
     # Can be String or Lambda/Proc that is invoked in the context of the job.
     # Note: Arguments passed to #perform_later can be accessed through ActiveJob's `arguments` method
     # which is an array containing positional arguments and, optionally, a kwarg hash.
-    key: -> { "Unique-#{arguments.first}-#{arguments.last[:version]}" } #  MyJob.perform_later("Alice", version: 'v2') => "Unique-Alice-v2"
+    key: -> { "MyJob-#{arguments.first}-#{arguments.last[:version]}" } #  MyJob.perform_later("Alice", version: 'v2') => "MyJob-Alice-v2"
   )
 
   def perform(first_name)
@@ -483,7 +483,7 @@ When testing, the resulting concurrency key value can be inspected:
 
 ```ruby
 job = MyJob.perform_later("Alice")
-job.good_job_concurrency_key #=> "Unique-Alice"
+job.good_job_concurrency_key #=> "MyJob-Alice"
 ```
 
 #### How concurrency controls work


### PR DESCRIPTION
See https://github.com/bensheldon/good_job/discussions/1142

TDLR concurrency keys are globally_ unique (like the readme says, duh). Basically all my concurrency keys just used the model ID and I was under the impression that that is enough. A different job which happens to take in a different model class with the same id will be discarded.

I think the point would have been hammered home for me if the readme example used the job class name as part of the key.

---

Somewhat related, sidekiq-unique-jobs automatically appends the job class and queue name to the key. It's what I mainly used so I just assumed it works the same here. [README](https://github.com/mhenrixon/sidekiq-unique-jobs?tab=readme-ov-file#introduction)

> This gem adds unique constraints to sidekiq jobs. The uniqueness is achieved by creating a set of keys in redis based off of queue, class, args (in the sidekiq job hash).

If you want to have a truly unique key you must explicitly mark them as such via the `unique_across_queues` and `unique_across_workers` keyword options.

It's similar for the native sidekiq enterprise functionality, though I can't actually test this myself for obvious reasons. [Wiki](https://github.com/sidekiq/sidekiq/wiki/Ent-Unique-Jobs)

> Jobs are considered unique based on (class, args, queue), meaning a job with the same args can be pushed to different queues.

When overwriting the default args you must take care of using the necessary values like class yourself if needed, it's not opt-out like for sidekiq-unique-jobs.