### PR TITLE
Bug: Polling only activates single thread, should eagerly create additional threads when jobs exist

### DIFF
--- a/lib/good_job/capsule.rb
+++ b/lib/good_job/capsule.rb
@@ -33,8 +33,8 @@ module GoodJob
         @notifier = GoodJob::Notifier.new(enable_listening: @configuration.enable_listen_notify, executor: @shared_executor.executor)
         @poller = GoodJob::Poller.new(poll_interval: @configuration.poll_interval)
         @multi_scheduler = GoodJob::MultiScheduler.from_configuration(@configuration, warm_cache_on_initialize: true)
-        @notifier.recipients << [@multi_scheduler, :create_thread]
-        @poller.recipients << [@multi_scheduler, :create_thread]
+        @notifier.recipients.push([@multi_scheduler, :create_thread])
+        @poller.recipients.push(-> { @multi_scheduler.create_thread({ fanout: true }) })
 
         @cron_manager = GoodJob::CronManager.new(@configuration.cron_entries, start_on_initialize: true, executor: @shared_executor.executor) if @configuration.enable_cron?
 

--- a/lib/good_job/job_performer.rb
+++ b/lib/good_job/job_performer.rb
@@ -26,6 +26,7 @@ module GoodJob
     end
 
     # Perform the next eligible job
+    # @yield [Execution] Yields the execution, if one is dequeued
     # @return [Object, nil] Returns job result or +nil+ if no job was found
     def next
       active_job_id = nil
@@ -36,6 +37,7 @@ module GoodJob
           active_job_id = execution.active_job_id
           performing_active_job_ids << active_job_id
           @metrics.touch_execution_at
+          yield(execution) if block_given?
         else
           @metrics.increment_empty_executions
         end

--- a/lib/good_job/multi_scheduler.rb
+++ b/lib/good_job/multi_scheduler.rb
@@ -66,7 +66,7 @@ module GoodJob
     def create_thread(state = nil)
       results = []
 
-      if state
+      if state && !state[:fanout]
         schedulers.any? do |scheduler|
           scheduler.create_thread(state).tap { |result| results << result }
         end

--- a/spec/lib/good_job/capsule_spec.rb
+++ b/spec/lib/good_job/capsule_spec.rb
@@ -66,7 +66,7 @@ describe GoodJob::Capsule do
     it 'passes the job state to the scheduler' do
       scheduler = instance_double(GoodJob::Scheduler, create_thread: nil, shutdown?: true, shutdown: nil)
       allow(GoodJob::Scheduler).to receive(:new).and_return(scheduler)
-      job_state = "STATE"
+      job_state = { animal: "cat" }
 
       capsule = described_class.new
       capsule.start


### PR DESCRIPTION
I think this is a bug. When only using polling (e.g. #810's `config.good_job.enable_listen_notify = false`), only a single thread is ever active. This is because the Poller only ever activates a single thread, and then when a job is complete, it will only then activate the same thread _again_.

This PR changes that behavior: now, when the poller triggers a Scheduler to activate a thread to query for a job, _and a job is found_, a 2nd thread will be activated before performing the first job. If there are significant jobs, this should fan out until all available threads are used.

I am classifying this as a bug, though it only affects performance/throughput. It's possible that this may cause your GoodJob processes to use more resources _if you are relying on polling alone_.

fyi, @mitchellhenke 