### PR TITLE
Explicitly require `active_job/arguments` in `GoodJob::BatchRecord`

### DIFF
--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_job/arguments'
+
 module GoodJob
   class BatchRecord < BaseRecord
     include AdvisoryLockable


### PR DESCRIPTION
resolve #1149 
