### PR TITLE
Skip `RecordAlreadyAdvisoryLockedError` during mass-update action

### DIFF
--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -44,7 +44,7 @@ module GoodJob
         end
 
         job
-      rescue GoodJob::Job::ActionForStateMismatchError
+      rescue GoodJob::Job::ActionForStateMismatchError, GoodJob::AdvisoryLockable::RecordAlreadyAdvisoryLockedError
         nil
       end.compact
 


### PR DESCRIPTION
When running mass update discard, there can be a condition where the good_job tries to destroy a record that is locked. I have added a rescue for this error condition, so good_job skips the discard on this job but doesn't raise an error.