### PR TITLE
Add correct paths to $LOAD_PATH

### DIFF
--- a/demo/config/boot.rb
+++ b/demo/config/boot.rb
@@ -1,5 +1,5 @@
 # Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __dir__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)


### PR DESCRIPTION
The `bin/setup` script was failing due to being unable to find the required files in `demo/config/application.rb`. It looks like the directory references were nested one level to deep in the `boot.rb` file. This PR changes the references to refer back to the project home directory.