### PR TITLE
[minor] Use symbol form of index name

### DIFF
--- a/demo/db/migrate/20200224015928_create_good_jobs.rb
+++ b/demo/db/migrate/20200224015928_create_good_jobs.rb
@@ -15,7 +15,7 @@ class CreateGoodJobs < ActiveRecord::Migration[5.2]
       t.timestamps
     end
 
-    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: "index_good_jobs_on_scheduled_at"
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
     add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
   end
 end

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -70,7 +70,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.index :key, unique: true
     end
 
-    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: "index_good_jobs_on_scheduled_at"
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
     add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
     add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished

--- a/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
@@ -28,7 +28,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.jsonb :state
     end
 
-    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: "index_good_jobs_on_scheduled_at"
+    add_index :good_jobs, :scheduled_at, where: "(finished_at IS NULL)", name: :index_good_jobs_on_scheduled_at
     add_index :good_jobs, [:queue_name, :scheduled_at], where: "(finished_at IS NULL)", name: :index_good_jobs_on_queue_name_and_scheduled_at
     add_index :good_jobs, [:active_job_id, :created_at], name: :index_good_jobs_on_active_job_id_and_created_at
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished


### PR DESCRIPTION
All the other indexes that use an explicit (non-generated) name use symbols, except this one. This is for consistency. I've tested that a version of this gem that includes this change, generates the Good Jobs migration, and that the migration applies as expected.

```sql
-- From generated migration file,
--with this change included (using "path" bundler option in Gemfile)
\di index_good_jobs_on_scheduled_at*
                            List of relations
  Schema   |              Name               | Type  | Owner |   Table
-----------+---------------------------------+-------+-------+-----------
 rideshare | index_good_jobs_on_scheduled_at | index | owner | good_jobs
```