### PR TITLE
Fix no method error in systemd service

### DIFF
--- a/lib/good_job/systemd_service.rb
+++ b/lib/good_job/systemd_service.rb
@@ -11,10 +11,10 @@ module GoodJob # :nodoc:
   #
   class SystemdService
     def self.task_observer(_time, _output, thread_error) # :nodoc:
-      return if thread_error.is_a? Concurrent::CancelledOperationError
+      return if thread_error.is_a?(Concurrent::CancelledOperationError) || thread_error.blank?
 
       ActiveSupport::Notifications.instrument("systemd_watchdog_error.good_job", { error: thread_error })
-      GoodJob._on_thread_error(thread_error) if thread_error
+      GoodJob._on_thread_error(thread_error)
     end
 
     # Indicates whether the service is actively notifying systemd's watchdog.

--- a/lib/good_job/systemd_service.rb
+++ b/lib/good_job/systemd_service.rb
@@ -11,7 +11,7 @@ module GoodJob # :nodoc:
   #
   class SystemdService
     def self.task_observer(_time, _output, thread_error) # :nodoc:
-      return if thread_error.is_a?(Concurrent::CancelledOperationError) || thread_error.blank?
+      return if !thread_error || thread_error.is_a?(Concurrent::CancelledOperationError)
 
       ActiveSupport::Notifications.instrument("systemd_watchdog_error.good_job", { error: thread_error })
       GoodJob._on_thread_error(thread_error)


### PR DESCRIPTION
Related to https://github.com/bensheldon/good_job/issues/1172

While I was dealing with deploying `good_job` to production using `systemd`, I encountered an error in the logs. Overall it's just a missed return check in the `systemd_service`. 