### PR TITLE
Fix latest migration not affecting `GoodJob.migrated?`

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -49,6 +49,13 @@ module GoodJob
         migration_pending_warning!
         false
       end
+
+      def cron_indices_migrated?
+        return true if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_cron_key_and_created_at_cond)
+
+        migration_pending_warning!
+        false
+      end
     end
 
     # The ActiveJob job class, as a string

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -272,7 +272,7 @@ module GoodJob
   def self.migrated?
     # Always update with the most recent migration check
     GoodJob::Execution.reset_column_information
-    GoodJob::Execution.error_event_migrated?
+    GoodJob::Execution.cron_indices_migrated?
   end
 
   ActiveSupport.run_load_hooks(:good_job, self)

--- a/spec/generators/good_job/update_generator_spec.rb
+++ b/spec/generators/good_job/update_generator_spec.rb
@@ -24,10 +24,10 @@ describe GoodJob::UpdateGenerator, :skip_if_java, type: :generator do
         run_in_example_app 'rails db:migrate'
       end
 
-      # Check that `GoodJob.pending_migrations?` is updated
+      # Check that `GoodJob.migrated?` is updated
       expect(GoodJob.migrated?).to be true
       quiet do
-        run_in_example_app 'rails db:rollback STEP=2'
+        run_in_example_app 'rails db:rollback'
         expect(GoodJob.migrated?).to be false
         run_in_example_app 'rails db:migrate'
       end


### PR DESCRIPTION
The latest migration was added but the test was sidestepped by just rolling back the latest 2 migrations.

This allows you to be notified in tests/CI about this latest migration.