### PR TITLE
Remove redundant `good_jobs.active_job_id` index

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -70,6 +70,13 @@ module GoodJob
         migration_pending_warning!
         false
       end
+
+      def active_job_id_index_removal_migrated?
+        return true unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+
+        migration_pending_warning!
+        false
+      end
     end
 
     # The ActiveJob job class, as a string

--- a/demo/db/migrate/20230131214927_create_good_job_batches.rb
+++ b/demo/db/migrate/20230131214927_create_good_job_batches.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class CreateGoodJobBatches < ActiveRecord::Migration[6.1]
+
+class CreateGoodJobBatches < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|
       dir.up do

--- a/demo/db/migrate/20230412144442_create_good_job_executions.rb
+++ b/demo/db/migrate/20230412144442_create_good_job_executions.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class CreateGoodJobExecutions < ActiveRecord::Migration[7.0]
+
+class CreateGoodJobExecutions < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|
       dir.up do

--- a/demo/db/migrate/20230703035750_create_good_jobs_error_event.rb
+++ b/demo/db/migrate/20230703035750_create_good_jobs_error_event.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.0]
+
+class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|
       dir.up do
@@ -9,7 +10,7 @@ class CreateGoodJobsErrorEvent < ActiveRecord::Migration[7.0]
       end
     end
 
-    add_column :good_jobs, :error_event, :smallint
-    add_column :good_job_executions, :error_event, :smallint
+    add_column :good_jobs, :error_event, :integer, limit: 2
+    add_column :good_job_executions, :error_event, :integer, limit: 2
   end
 end

--- a/demo/db/migrate/20231216183915_create_good_job_labels_index.rb
+++ b/demo/db/migrate/20231216183915_create_good_job_labels_index.rb
@@ -7,8 +7,8 @@ class CreateGoodJobLabelsIndex < ActiveRecord::Migration[7.1]
     reversible do |dir|
       dir.up do
         unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_labels)
-          add_index :good_jobs, :labels, where: "(labels IS NOT NULL)",
-            using: :gin, name: :index_good_jobs_on_labels, algorithm: :concurrently
+          add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)",
+            name: :index_good_jobs_on_labels, algorithm: :concurrently
         end
       end
 

--- a/demo/db/migrate/20231218003738_remove_good_job_active_id_index.rb
+++ b/demo/db/migrate/20231218003738_remove_good_job_active_id_index.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_16_183915) do
+ActiveRecord::Schema.define(version: 2023_12_18_003738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -81,7 +81,6 @@ ActiveRecord::Schema.define(version: 2023_12_16_183915) do
     t.integer "error_event", limit: 2
     t.text "labels", array: true
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
-    t.index ["active_job_id"], name: "index_good_jobs_on_active_job_id"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
     t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -77,7 +77,6 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
     add_index :good_jobs, [:cron_key, :created_at], where: "(cron_key IS NOT NULL)", name: :index_good_jobs_on_cron_key_and_created_at_cond
     add_index :good_jobs, [:cron_key, :cron_at], where: "(cron_key IS NOT NULL)", unique: true, name: :index_good_jobs_on_cron_key_and_cron_at_cond
-    add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
     add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
       where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished

--- a/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
@@ -34,7 +34,6 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
     add_index :good_jobs, [:cron_key, :created_at], name: :index_good_jobs_on_cron_key_and_created_at
     add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
-    add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/01_create_good_jobs.rb.erb
@@ -34,6 +34,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :concurrency_key, where: "(finished_at IS NULL)", name: :index_good_jobs_on_concurrency_key_when_unfinished
     add_index :good_jobs, [:cron_key, :created_at], name: :index_good_jobs_on_cron_key_and_created_at
     add_index :good_jobs, [:cron_key, :cron_at], name: :index_good_jobs_on_cron_key_and_cron_at, unique: true
+    add_index :good_jobs, [:active_job_id], name: :index_good_jobs_on_active_job_id
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/10_remove_good_job_active_id_index.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/10_remove_good_job_active_id_index.rb.erb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RemoveGoodJobActiveIdIndex < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        if connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          remove_index :good_jobs, name: :index_good_jobs_on_active_job_id
+        end
+      end
+
+      dir.down do
+        unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+          add_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id
+        end
+      end
+    end
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -273,7 +273,7 @@ module GoodJob
   def self.migrated?
     # Always update with the most recent migration check
     GoodJob::Execution.reset_column_information
-    GoodJob::Execution.labels_indices_migrated?
+    GoodJob::Execution.active_job_id_index_removal_migrated?
   end
 
   ActiveSupport.run_load_hooks(:good_job, self)


### PR DESCRIPTION
Try running active_record_doctor on a project with GoodJob migrations:

```sh
bundle exec rake active_record_doctor
```

You'll see this output:

remove the index index_good_jobs_on_active_job_id from the table good_jobs - queries should be able to use the following index instead: index_good_jobs_on_active_job_id_and_created_at

This change removes the single column index on 'active_job_id'

A query that used that index before could instead use the existing multicolumn index on
['active_job_id', 'created_at'], where ‘active_job_id’ is also the “leading” column.

The single column index is not a unique index that enforces a unique constraint.

So the single column appears redundant given the multicolumn index with the same leading column, which means it could be removed.