### PR TITLE
Fix new migrations to work with `strong_migrations`

### DIFF
--- a/lib/generators/good_job/templates/update/migrations/02_create_good_job_settings.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/02_create_good_job_settings.rb.erb
@@ -2,19 +2,15 @@
 
 class CreateGoodJobSettings < ActiveRecord::Migration<%= migration_version %>
   def change
-    reversible do |dir|
-      dir.up do
-        # Ensure this incremental update migration is idempotent
-        # with monolithic install migration.
-        return if connection.table_exists?(:good_job_settings)
+    # Ensure this incremental update migration is idempotent
+    # with monolithic install migration.
+    unless connection.table_exists?(:good_job_settings)
+      create_table :good_job_settings, id: :uuid do |t|
+        t.timestamps
+        t.text :key
+        t.jsonb :value
+        t.index :key, unique: true
       end
-    end
-
-    create_table :good_job_settings, id: :uuid do |t|
-      t.timestamps
-      t.text :key
-      t.jsonb :value
-      t.index :key, unique: true
     end
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/04_create_good_job_batches.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/04_create_good_job_batches.rb.erb
@@ -2,34 +2,29 @@
 
 class CreateGoodJobBatches < ActiveRecord::Migration<%= migration_version %>
   def change
-    reversible do |dir|
-      dir.up do
-        # Ensure this incremental update migration is idempotent
-        # with monolithic install migration.
-        return if connection.table_exists?(:good_job_batches)
+    # Ensure this incremental update migration is idempotent
+    # with monolithic install migration.
+    unless connection.table_exists?(:good_job_batches)
+      create_table :good_job_batches, id: :uuid do |t|
+        t.timestamps
+        t.text :description
+        t.jsonb :serialized_properties
+        t.text :on_finish
+        t.text :on_success
+        t.text :on_discard
+        t.text :callback_queue_name
+        t.integer :callback_priority
+        t.datetime :enqueued_at
+        t.datetime :discarded_at
+        t.datetime :finished_at
       end
-    end
 
-    create_table :good_job_batches, id: :uuid do |t|
-      t.timestamps
-      t.text :description
-      t.jsonb :serialized_properties
-      t.text :on_finish
-      t.text :on_success
-      t.text :on_discard
-      t.text :callback_queue_name
-      t.integer :callback_priority
-      t.datetime :enqueued_at
-      t.datetime :discarded_at
-      t.datetime :finished_at
-    end
+      # good_jobs table changes
+      add_column :good_jobs, :batch_id, :uuid
+      add_column :good_jobs, :batch_callback_id, :uuid
 
-    change_table :good_jobs do |t|
-      t.uuid :batch_id
-      t.uuid :batch_callback_id
-
-      t.index :batch_id, where: "batch_id IS NOT NULL"
-      t.index :batch_callback_id, where: "batch_callback_id IS NOT NULL"
+      add_index :good_jobs, :batch_id, where: "batch_id IS NOT NULL"
+      add_index :good_jobs, :batch_callback_id, where: "batch_callback_id IS NOT NULL"
     end
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/05_create_good_job_executions.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/05_create_good_job_executions.rb.erb
@@ -10,24 +10,25 @@ class CreateGoodJobExecutions < ActiveRecord::Migration<%= migration_version %>
       end
     end
 
-    create_table :good_job_executions, id: :uuid do |t|
-      t.timestamps
+    unless connection.table_exists?(:good_job_executions)
+      create_table :good_job_executions, id: :uuid do |t|
+        t.timestamps
 
-      t.uuid :active_job_id, null: false
-      t.text :job_class
-      t.text :queue_name
-      t.jsonb :serialized_params
-      t.datetime :scheduled_at
-      t.datetime :finished_at
-      t.text :error
+        t.uuid :active_job_id, null: false
+        t.text :job_class
+        t.text :queue_name
+        t.jsonb :serialized_params
+        t.datetime :scheduled_at
+        t.datetime :finished_at
+        t.text :error
 
-      t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
-    end
+        t.index [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
+      end
 
-    change_table :good_jobs do |t|
-      t.boolean :is_discrete
-      t.integer :executions_count
-      t.text :job_class
+      # good_jobs table changes
+      add_column :good_jobs, :is_discrete,      :boolean
+      add_column :good_jobs, :executions_count, :integer
+      add_column :good_jobs, :job_class,        :text
     end
   end
 end


### PR DESCRIPTION
I needed to fix new migrations in order for `strong_migrations` to let them pass.

Don't think there was anything wrong with the original approach, I think it is more issue on the `strong_migrations` side, but still there is no reason users should do this manually.