### PR TITLE
Add extension partials to good_job/jobs#show view

### DIFF
--- a/app/views/good_job/jobs/_custom_execution_details.html.erb
+++ b/app/views/good_job/jobs/_custom_execution_details.html.erb
@@ -1,0 +1,7 @@
+<%#
+This partial is intentionally blank, and rendered above the collapsible JSON representation of each execution
+on the jobs#show view.
+
+You can override this partial by creating app/views/good_job/jobs/_custom_execution_details.html.erb in your own app. See README for an example.
+%>
+

--- a/app/views/good_job/jobs/_custom_job_details.html.erb
+++ b/app/views/good_job/jobs/_custom_job_details.html.erb
@@ -1,0 +1,5 @@
+<%#
+This partial is intentionally blank, and rendered above the arguments list on the jobs#show view.
+
+You can override this partial by creating app/views/good_job/jobs/_custom_job_details.html.erb in your own app. See README for an example.
+%>

--- a/app/views/good_job/jobs/_executions.erb
+++ b/app/views/good_job/jobs/_executions.erb
@@ -40,6 +40,7 @@
           </div>
         <% end %>
       <% end %>
+      <%= render 'custom_execution_details', execution: execution, job: @job %>
       <%= tag.div id: dom_id(execution, "params"), class: "list-group-item collapse small bg-dark text-light" do %>
         <%= tag.pre JSON.pretty_generate(execution.display_serialized_params) %>
       <% end %>

--- a/app/views/good_job/jobs/show.html.erb
+++ b/app/views/good_job/jobs/show.html.erb
@@ -67,6 +67,8 @@
   </div>
 </div>
 
+<%= render 'custom_job_details', job: @job %>
+
 <div class="my-4">
   <h5>
     <%= t "good_job.models.job.arguments" %>


### PR DESCRIPTION
This is a minimal implementation of the idea from #1197.

I've opted not to address the issues of exposing internal classes in this first pass, but rather just document the potential for unstable APIs. I'm open to ideas, but my opinion at the moment is that this strikes the right balance between complexity/maintenance burden for GoodJob maintainers and users.
