### PR TITLE
Fix: Interacting with input field should pause the live poll

### DIFF
--- a/app/frontend/good_job/modules/live_poll.js
+++ b/app/frontend/good_job/modules/live_poll.js
@@ -3,6 +3,23 @@ import renderCharts from "charts";
 
 const MINIMUM_POLL_INTERVAL = 1;
 const STORAGE_KEY = "live_poll";
+const input_box = document.getElementById('query');
+
+input_box.addEventListener('keyup', () => {
+  closePolling(input_box.value);
+})
+
+function closePolling(value) {
+  const checkbox = document.querySelector('input[name="live_poll"]');
+  const livePollInstance = new LivePoll();
+
+  checkbox.checked = false;
+  if(value > 0){
+    livePollInstance.togglePolling();
+  }else{
+    this.togglePolling()
+  }
+}
 
 function getStorage(key) {
   const value = localStorage.getItem('good_job-' + key);

--- a/app/frontend/good_job/modules/live_poll.js
+++ b/app/frontend/good_job/modules/live_poll.js
@@ -3,23 +3,6 @@ import renderCharts from "charts";
 
 const MINIMUM_POLL_INTERVAL = 1;
 const STORAGE_KEY = "live_poll";
-const input_box = document.getElementById('query');
-
-input_box.addEventListener('keyup', () => {
-  closePolling(input_box.value);
-})
-
-function closePolling(value) {
-  const checkbox = document.querySelector('input[name="live_poll"]');
-  const livePollInstance = new LivePoll();
-
-  checkbox.checked = false;
-  if(value > 0){
-    livePollInstance.togglePolling();
-  }else{
-    this.togglePolling()
-  }
-}
 
 function getStorage(key) {
   const value = localStorage.getItem('good_job-' + key);

--- a/app/views/good_job/shared/_filter.erb
+++ b/app/views/good_job/shared/_filter.erb
@@ -1,4 +1,4 @@
-<div data-live-poll-region id="filter" class="">
+<div id="filter">
   <div class="">
     <div class="border-bottom mb-3">
       <h2 class="pt-3 pb-2"><%= title %></h2>
@@ -47,7 +47,7 @@
       </div>
     <% end %>
 
-    <ul class="nav nav-tabs my-3">
+    <ul data-live-poll-region="filter-tabs" class="nav nav-tabs my-3">
       <li class="nav-item">
         <%= link_to t(".all"), filter.to_params(state: nil), class: "nav-link #{"active" unless params[:state].present?}" %>
       </li>


### PR DESCRIPTION
The pr adresses #585. This enhancement addresses the frustration users may experience when live polling disrupts their workflow on the dashboard. The update introduces a seamless solution by programmatically toggling off live polling when users makes the use of the search bar.

-  Key Features:
1. Search Bar Interaction: Live polling is now dynamically disabled when users initiate a search. Once the search request is complete, live polling resumes, ensuring a smooth and uninterrupted user experience. 