### PR TITLE
Discard job with nonexistent job class

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -92,7 +92,7 @@ module GoodJob
     # Build an ActiveJob instance and deserialize the arguments, using `#active_job_data`.
     #
     # @param ignore_deserialization_errors [Boolean]
-    #   Whether to ignore ActiveJob::DeserializationError when deserializing the arguments.
+    #   Whether to ignore ActiveJob::DeserializationError and NameError when deserializing the arguments.
     #   This is most useful if you aren't planning to use the arguments directly.
     def active_job(ignore_deserialization_errors: false)
       ActiveJob::Base.deserialize(active_job_data).tap do |aj|

--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -97,9 +97,9 @@ module GoodJob
     def active_job(ignore_deserialization_errors: false)
       ActiveJob::Base.deserialize(active_job_data).tap do |aj|
         aj.send(:deserialize_arguments_if_needed)
-      rescue ActiveJob::DeserializationError
-        raise unless ignore_deserialization_errors
       end
+    rescue ActiveJob::DeserializationError, NameError
+      raise unless ignore_deserialization_errors
     end
 
     private

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe GoodJob::Job do
 
     context 'when job class does not exist' do
       before do
-        job.update!(serialized_params: { 'job_class' => 'NonExistentJob' })
+        job.update!(serialized_params: { 'job_class' => 'NonexistentJob' })
       end
 
       it 'ignores the error and discards the job' do

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -324,6 +324,18 @@ RSpec.describe GoodJob::Job do
         end.to change { job.reload.status }.from(:scheduled).to(:discarded)
       end
     end
+
+    context 'when job class does not exist' do
+      before do
+        job.update!(serialized_params: { 'job_class' => 'NonExistentJob' })
+      end
+
+      it 'ignores the error and discards the job' do
+        expect do
+          job.discard_job("Discarded in test")
+        end.to change { job.reload.status }.from(:scheduled).to(:discarded)
+      end
+    end
   end
 
   describe '#force_discard_job' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("spec/fixtures")
+  config.fixture_paths = [Rails.root.join("spec/fixtures")]
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_paths = [Rails.root.join("spec/fixtures")]
+  config.fixture_path = Rails.root.join("spec/fixtures")
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
Currently, a NameError is raised when a job with a nonexistent job class is discarded. Job classes may be deleted after the job is scheduled and currently, it's impossible to discard these scheduled jobs from the dashboard.