### PR TITLE
Add an index to better support `smaller_number_is_higher_priority`

### DIFF
--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -77,6 +77,13 @@ module GoodJob
         migration_pending_warning!
         false
       end
+
+      def candidate_lookup_index_migrated?
+        return true if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+
+        migration_pending_warning!
+        false
+      end
     end
 
     # The ActiveJob job class, as a string

--- a/demo/db/migrate/20240114223450_create_index_good_job_jobs_for_candidate_lookup.rb
+++ b/demo/db/migrate/20240114223450_create_index_good_job_jobs_for_candidate_lookup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_18_003738) do
+ActiveRecord::Schema.define(version: 2024_01_14_221613) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2023_12_18_003738) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
+    t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -80,6 +80,8 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at
     add_index :good_jobs, [:priority, :created_at], order: { priority: "DESC NULLS LAST", created_at: :asc },
       where: "finished_at IS NULL", name: :index_good_jobs_jobs_on_priority_created_at_when_unfinished
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup
     add_index :good_jobs, [:batch_id], where: "batch_id IS NOT NULL"
     add_index :good_jobs, [:batch_callback_id], where: "batch_callback_id IS NOT NULL"
     add_index :good_jobs, :labels, using: :gin, where: "(labels IS NOT NULL)", name: :index_good_jobs_on_labels

--- a/lib/generators/good_job/templates/update/migrations/11_create_index_good_job_jobs_for_candidate_lookup.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/11_create_index_good_job_jobs_for_candidate_lookup.rb.erb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateIndexGoodJobJobsForCandidateLookup < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, :index_good_job_jobs_for_candidate_lookup)
+      end
+    end
+
+    add_index :good_jobs, [:priority, :created_at], order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL", name: :index_good_job_jobs_for_candidate_lookup,
+      algorithm: :concurrently
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -273,7 +273,7 @@ module GoodJob
   def self.migrated?
     # Always update with the most recent migration check
     GoodJob::Execution.reset_column_information
-    GoodJob::Execution.active_job_id_index_removal_migrated?
+    GoodJob::Execution.candidate_lookup_index_migrated?
   end
 
   ActiveSupport.run_load_hooks(:good_job, self)


### PR DESCRIPTION
The preexisting index (introduced in #726) gave a direct answer to the materialized subquery used to find candidate jobs, subject to the ordering rules that were in place at that time.  In #883, `GoodJob` deprecated that ordering in favour of a lower-is-more-important scheme, aligning with Active Job, but the index was not updated at that time.

I observed a substantial improvement in job throughput on applying an equivalent index, in the context of a jobs table with some 10M+ completed jobs. This catches the index change mentioned in #1005.

<summary>
Plan changes for the subquery (admittedly, not the most recent GoodJob version) before and after applying:
<details>
Before:

<pre>
Limit  (cost=14528.90..14529.15 rows=100 width=44) (actual time=517.784..517.794 rows=70 loops=1)
  ->  Sort  (cost=14528.90..14532.43 rows=1415 width=44) (actual time=517.783..517.787 rows=70 loops=1)
        Sort Key: priority, created_at
        Sort Method: quicksort  Memory: 30kB
        ->  Bitmap Heap Scan on good_jobs  (cost=8951.83..14474.81 rows=1415 width=44) (actual time=111.465..517.719 rows=70 loops=1)
              Recheck Cond: (finished_at IS NULL)
              Rows Removed by Index Recheck: 1168042
              Filter: ((scheduled_at <= '2024-01-12 02:51:38.927646'::timestamp without time zone) OR (scheduled_at IS NULL))
              Rows Removed by Filter: 847
              Heap Blocks: exact=557 lossy=99411
              ->  Bitmap Index Scan on index_good_jobs_on_concurrency_key_when_unfinished  (cost=0.00..8951.48 rows=1415 width=0) (actual time=56.387..56.388 rows=552240 loops=1)
Planning Time: 1.276 ms
Execution Time: 518.545 ms
</pre>

After (a different index name):
<pre>
Limit  (cost=5.90..5.91 rows=1 width=44) (actual time=0.022..0.023 rows=0 loops=1)
  ->  Sort  (cost=5.90..5.91 rows=1 width=44) (actual time=0.021..0.022 rows=0 loops=1)
        Sort Key: priority, created_at
        Sort Method: quicksort  Memory: 25kB
        ->  Index Scan using index_good_jobs_jobs_on_priority_created_at_when_unfinished on good_jobs  (cost=0.12..5.89 rows=1 width=44) (actual time=0.004..0.004 rows=0 loops=1)
              Filter: ((scheduled_at <= '2024-01-12 02:51:38.927646'::timestamp without time zone) OR (scheduled_at IS NULL))
Planning Time: 0.668 ms
Execution Time: 0.041 ms
</pre>
</details>
</summary>
