### PR TITLE
Add job-iteration integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gemspec
 
 gem 'activerecord-jdbcpostgresql-adapter', platforms: [:jruby]
 gem 'appraisal'
+gem 'job-iteration'
 gem 'matrix'
 gem 'nokogiri'
 gem 'pg', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,8 @@ GEM
       reline (>= 0.3.8)
     jar-dependencies (0.4.1)
     jdbc-postgres (42.6.0)
+    job-iteration (1.4.1)
+      activejob (>= 5.2)
     json (2.6.3)
     json (2.6.3-java)
     kramdown (2.4.0)
@@ -514,6 +516,7 @@ DEPENDENCIES
   github_changelog_generator
   good_job!
   i18n-tasks
+  job-iteration
   kramdown
   kramdown-parser-gfm
   matrix

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -38,6 +38,8 @@ require "good_job/scheduler"
 require "good_job/shared_executor"
 require "good_job/systemd_service"
 
+require "job_iteration/integrations/good_job"
+
 # GoodJob is a multithreaded, Postgres-based, ActiveJob backend for Ruby on Rails.
 #
 # +GoodJob+ is the top-level namespace and exposes configuration attributes.

--- a/lib/job_iteration/integrations/good_job.rb
+++ b/lib/job_iteration/integrations/good_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+begin
+  require "job-iteration"
+
+  module JobIteration
+    module Integrations
+      module GoodJob
+        class << self
+          def call
+            ::GoodJob.shutdown?
+          end
+        end
+      end
+    end
+  end
+
+  JobIteration.interruption_adapter = JobIteration::Integrations::GoodJob
+rescue LoadError
+  # job-iteration is not present
+end

--- a/spec/lib/job_iteration/integrations/good_job_spec.rb
+++ b/spec/lib/job_iteration/integrations/good_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe JobIteration::Integrations::GoodJob do
+  it 'sets up the interruption adapter' do
+    expect(JobIteration.interruption_adapter).to eq(described_class)
+  end
+
+  describe '.call' do
+    context 'when GoodJob is shutting down' do
+      before { allow(GoodJob).to receive(:shutdown?).and_return(true) }
+
+      it 'returns true' do
+        expect(described_class.call).to be(true)
+      end
+    end
+
+    context 'when GoodJob is not shutting down' do
+      before { allow(GoodJob).to receive(:shutdown?).and_return(false) }
+
+      it 'returns false' do
+        expect(described_class.call).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an integration for the [job-iteration](https://github.com/Shopify/job-iteration) gem.

job-iteration needs to know when the job worker is shutting down so that it can complete the current iteration and gracefully shut down. The gem ships with integrations for [Sidekiq](https://github.com/thatch-health/job-iteration/blob/main/lib/job-iteration/integrations/sidekiq.rb) and [Resque](https://github.com/thatch-health/job-iteration/blob/main/lib/job-iteration/integrations/resque.rb).

My first approach was to add an integration for GoodJob to the job-iteration gem. However that proved difficult because job-iteration's test harness uses a MySQL database, so I would have to either switch everything to Postgres or set up a multiple databases. Both of these sounded more complex than necessary, so I thought I'd add the integration to GoodJob instead.

I'm opening this PR as a draft to get some early feedback:
1. Would you be okay with adding this integration to GoodJob's codebase in the first place? It would add some maintenance burden, but the integration is trivial enough that I don't expect it to be much of an issue.
2. The implementation in this PR probably needs a bit more work. My understanding is that `GoodJob.shutdown?` will only return `true` _after_ GoodJob is fully shut down (i.e. when all threads have shut down). If so, that's probably too late for job-iteration's purposes. The interruption adapters for Sidekiq and Resque return `true` as soon as a shutdown is requested. AFAICT, there is no such hook in GoodJob at the moment. Can you confirm this is the case? If so, I'll update the PR accordingly.
 