### PR TITLE
Use Rails executor instead of reloader when wrapping inline execution

### DIFF
--- a/app/models/good_job/batch.rb
+++ b/app/models/good_job/batch.rb
@@ -101,7 +101,7 @@ module GoodJob
 
       active_jobs = add(active_jobs, &block)
 
-      Rails.application.reloader.wrap do
+      Rails.application.executor.wrap do
         record.with_advisory_lock(function: "pg_advisory_lock") do
           record.update!(enqueued_at: Time.current)
 

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -247,7 +247,7 @@ module GoodJob
     loop do
       break if limit && iteration >= limit
 
-      result = Rails.application.reloader.wrap { job_performer.next }
+      result = Rails.application.executor.wrap { job_performer.next }
       break unless result
       raise result.unhandled_error if result.unhandled_error
 

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -49,7 +49,7 @@ module GoodJob
       active_jobs = Array(active_jobs)
       return 0 if active_jobs.empty?
 
-      Rails.application.reloader.wrap do
+      Rails.application.executor.wrap do
         current_time = Time.current
         executions = active_jobs.map do |active_job|
           GoodJob::Execution.build_for_enqueue(active_job).tap do |execution|
@@ -139,7 +139,7 @@ module GoodJob
       # job there to be enqueued using enqueue_all
       return if GoodJob::Bulk.capture(active_job, queue_adapter: self)
 
-      Rails.application.reloader.wrap do
+      Rails.application.executor.wrap do
         will_execute_inline = execute_inline? && (scheduled_at.nil? || scheduled_at <= Time.current)
         execution = GoodJob::Execution.enqueue(
           active_job,


### PR DESCRIPTION
Closes #1215 

This slightly adjust a change in #1124 to use a Rails executor instead of a Reloader.