### PR TITLE
Tweak docs for new concurrency default

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,12 @@ class MyJob < ApplicationJob
     # To disable concurrency control, for example in a subclass, set the
     # key explicitly to nil (e.g. `key: nil` or `key: -> { nil }`)
     #
-    # If you provide a custom concurrency key (for example, if one of your arguments
-    # is transient) make sure that it is sufficiently unique across jobs and queues
-    # by adding the job class or queue to the key yourself, if needed.
+    # If you provide a custom concurrency key (for example, if concurrency is supposed
+    # to be controlled by the first job argument) make sure that it is sufficiently unique across
+    # jobs and queues by adding the job class or queue to the key yourself, if needed.
+    #
+    # Note: When using a model instance as part of your custom concurrency key, make sure
+    # to explicitly use its `id` or `to_global_id` because otherwise it will not stringify as expected.
     #
     # Note: Arguments passed to #perform_later can be accessed through Active Job's `arguments` method
     # which is an array containing positional arguments and, optionally, a kwarg hash.


### PR DESCRIPTION
Followup to #1145. When I initially wrote this I expected all arguments to be part of the concurrency key by default. Now that that isn't the case anymore it doesn't really make sense to use transient arguments as an example since that is something the user has thought about already when setting a custom key.

I've instead chosen the (probably) common case of `def perform(my_model)` and added a note about what you need to do to make that work. model.to_s is something like `#<MyModel:0x00007f3f634a7320>` which won't work. On it's own this argument isn't allowed but when used in interpolation it will just be cast to a string so I added a note about that as well.