### PR TITLE
Fix batches so that retried-and-successful jobs leave the batch succeeded

### DIFF
--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -46,7 +46,7 @@ module GoodJob
     end
 
     def _continue_discard_or_finish(execution = nil, lock: true)
-      execution_discarded = execution && execution.error.present? && execution.retried_good_job_id.nil?
+      execution_discarded = execution && execution.error.present? && execution.finished_at && execution.retried_good_job_id.nil?
       take_advisory_lock(lock) do
         Batch.within_thread(batch_id: nil, batch_callback_id: id) do
           reload

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -28,6 +28,7 @@ module ::TestError; end
 module ::TestJob; end
 module ::WAIT_EVENT; end
 module ::TestJob::ExpectedError; end
+module ::TestJob::SuccessCallbackJob; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_RETRIED; end
 module Prism::AliasGlobalVariableNode::AliasGlobalVariableNode; end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
           )
           retry_on StandardError
 
-          def perform
+          def perform(*)
             raise "ERROR"
           end
         end)


### PR DESCRIPTION
Fixes #1239.

When #928 was implemented, I overlooked how reusing the execution/job record would interact with batches. This ensures that only when the job is _finished_ (not just retried once or more) will the batch's discard callback be evaluated.