### PR TITLE
Clean up icon helpers for less noisy view rendering

### DIFF
--- a/app/helpers/good_job/application_helper.rb
+++ b/app/helpers/good_job/application_helper.rb
@@ -2,6 +2,11 @@
 
 module GoodJob
   module ApplicationHelper
+    # Explicit helper inclusion because ApplicationController inherits from the host app.
+    #
+    # We can't rely on +config.action_controller.include_all_helpers = true+ in the host app.
+    include IconsHelper
+
     def format_duration(sec)
       return unless sec
 
@@ -22,42 +27,6 @@ module GoodJob
       options = options.reverse_merge({ scope: "good_job.datetime.distance_in_words" })
       text = t("good_job.helpers.relative_time.#{timestamp.future? ? 'future' : 'past'}", time: time_ago_in_words(timestamp, **options))
       tag.time(text, datetime: timestamp, title: timestamp)
-    end
-
-    STATUS_ICONS = {
-      discarded: "exclamation",
-      succeeded: "check",
-      queued: "dash_circle",
-      retried: "arrow_clockwise",
-      running: "play",
-      scheduled: "clock",
-    }.freeze
-
-    STATUS_COLOR = {
-      discarded: "danger",
-      succeeded: "success",
-      queued: "secondary",
-      retried: "warning",
-      running: "primary",
-      scheduled: "secondary",
-    }.freeze
-
-    def status_badge(status)
-      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: 'good_job.status', count: 1),
-                  class: "badge rounded-pill bg-#{STATUS_COLOR.fetch(status)} d-inline-flex gap-2 ps-1 pe-3 align-items-center"
-    end
-
-    def status_icon(status, **options)
-      options[:class] ||= "text-#{STATUS_COLOR.fetch(status)}"
-      icon = render_icon STATUS_ICONS.fetch(status)
-      content_tag :span, icon, **options
-    end
-
-    def render_icon(name, **options)
-      # workaround to render svg icons without all of the log messages
-      partial = lookup_context.find_template("good_job/shared/icons/#{name}", [], true)
-      options[:class] = Array(options[:class]).join(" ")
-      partial.render(self, { class: options[:class] })
     end
 
     def translate_hash(key, **options)

--- a/app/helpers/good_job/icons_helper.rb
+++ b/app/helpers/good_job/icons_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module GoodJob
+  module IconsHelper
+    STATUS_ICONS = {
+      discarded: "exclamation",
+      succeeded: "check",
+      queued: "dash_circle",
+      retried: "arrow_clockwise",
+      running: "play",
+      scheduled: "clock",
+    }.freeze
+
+    STATUS_COLOR = {
+      discarded: "danger",
+      succeeded: "success",
+      queued: "secondary",
+      retried: "warning",
+      running: "primary",
+      scheduled: "secondary",
+    }.freeze
+
+    def status_badge(status)
+      content_tag :span, status_icon(status, class: "text-white") + t(status, scope: 'good_job.status', count: 1),
+                  class: "badge rounded-pill bg-#{STATUS_COLOR.fetch(status)} d-inline-flex gap-2 ps-1 pe-3 align-items-center"
+    end
+
+    def status_icon(status, **options)
+      options[:class] ||= "text-#{STATUS_COLOR.fetch(status)}"
+      icon = render_icon STATUS_ICONS.fetch(status)
+      content_tag :span, icon, **options
+    end
+
+    def render_icon(name, **options)
+      # workaround to render svg icons without all of the log messages
+      partial = lookup_context.find_template("good_job/shared/icons/#{name}", [], true)
+      options[:class] = Array(options[:class]).join(" ")
+      partial.render(self, { class: options[:class] })
+    end
+  end
+end

--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -52,27 +52,27 @@
 
                 <div class="dropdown float-end">
                   <button class="d-flex align-items-center btn btn-sm" type="button" id="<%= dom_id(job, :actions) %>" data-bs-toggle="dropdown" aria-expanded="false">
-                    <%= render "good_job/shared/icons/dots" %>
+                    <%= render_icon :dots %>
                     <span class="visually-hidden"><%=t ".actions.title" %></span>
                   </button>
                   <ul class="dropdown-menu shadow" aria-labelledby="<%= dom_id(job, :actions) %>">
                     <li>
                       <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
                       <%= link_to reschedule_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job_reschedulable}", title: t(".actions.reschedule"), data: { confirm: t(".actions.confirm_reschedule"), disable: true } do %>
-                        <%= render "good_job/shared/icons/skip_forward" %>
+                        <%= render_icon "skip_forward" %>
                         <%=t "good_job.actions.reschedule" %>
                       <% end %>
                     </li>
                     <li>
                       <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
                       <%= link_to discard_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job_discardable}", title: t(".actions.discard"), data: { confirm: t(".actions.confirm_discard"), disable: true } do %>
-                        <%= render "good_job/shared/icons/stop" %>
+                        <%= render_icon "stop" %>
                         <%=t "good_job.actions.discard" %>
                       <% end %>
                     </li>
                     <li>
                       <%= link_to retry_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job.status == :discarded}", title: t(".actions.retry"), data: { confirm: t(".actions.confirm_retry"), disable: true } do %>
-                        <%= render "good_job/shared/icons/arrow_clockwise" %>
+                        <%= render_icon "arrow_clockwise" %>
                         <%=t "good_job.actions.retry" %>
                       <% end %>
                     </li>

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -109,34 +109,34 @@
 
                 <div class="dropdown float-end">
                   <button class="d-flex align-items-center btn btn-sm" type="button" id="<%= dom_id(job, :actions) %>" data-bs-toggle="dropdown" aria-expanded="false">
-                    <%= render "good_job/shared/icons/dots" %>
+                    <%= render_icon "dots" %>
                     <span class="visually-hidden"><%=t ".actions.title" %></span>
                   </button>
                   <ul class="dropdown-menu shadow" aria-labelledby="<%= dom_id(job, :actions) %>">
                     <li>
                       <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
                       <%= link_to reschedule_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job_reschedulable}", title: t("good_job.jobs.actions.reschedule"), data: { confirm: t("good_job.jobs.actions.confirm_reschedule"), disable: true } do %>
-                        <%= render "good_job/shared/icons/skip_forward" %>
+                        <%= render_icon "skip_forward" %>
                         <%=t "good_job.actions.reschedule" %>
                       <% end %>
                     </li>
                     <li>
                       <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
                       <%= link_to discard_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job_discardable}", title: t("good_job.jobs.actions.discard"), data: { confirm: t("good_job.jobs.actions.confirm_discard"), disable: true } do %>
-                        <%= render "good_job/shared/icons/stop" %>
+                        <%= render_icon "stop" %>
                         <%=t "good_job.actions.discard" %>
                       <% end %>
                     </li>
                     <li>
                       <% job_force_discardable = job.status.in? [:running] %>
                       <%= link_to force_discard_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job_force_discardable}", title: t("good_job.jobs.actions.force_discard"), data: { confirm: t("good_job.jobs.actions.confirm_force_discard"), disable: true } do %>
-                        <%= render "good_job/shared/icons/eject" %>
+                        <%= render_icon "eject" %>
                         <%=t "good_job.actions.force_discard" %>
                       <% end %>
                     </li>
                     <li>
                       <%= link_to retry_job_path(job.id), method: :put, class: "dropdown-item #{'disabled' unless job.status == :discarded}", title: t("good_job.jobs.actions.retry"), data: { confirm: t("good_job.jobs.actions.confirm_retry"), disable: true } do %>
-                        <%= render "good_job/shared/icons/arrow_clockwise" %>
+                        <%= render_icon "arrow_clockwise" %>
                         <%=t "good_job.actions.retry" %>
                       <% end %>
                     </li>

--- a/app/views/good_job/shared/_alert.erb
+++ b/app/views/good_job/shared/_alert.erb
@@ -2,7 +2,7 @@
   <% if notice %>
     <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-body d-flex align-items-center gap-2">
-        <%= render "good_job/shared/icons/check", class: "flex-shrink-0 text-success" %>
+        <%= render_icon "check", class: "flex-shrink-0 text-success" %>
         <div class="flex-fill"><%= notice %></div>
         <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
       </div>
@@ -11,7 +11,7 @@
   <% if alert %>
     <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-body d-flex align-items-center gap-2">
-        <%= render "good_job/shared/icons/exclamation", class: "flex-shrink-0 text-danger" %>
+        <%= render_icon "exclamation", class: "flex-shrink-0 text-danger" %>
         <div class="flex-fill"><%= alert %></div>
         <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
       </div>

--- a/app/views/good_job/shared/icons/_check.html.erb
+++ b/app/views/good_job/shared/icons/_check.html.erb
@@ -1,5 +1,5 @@
 <!-- https://icons.getbootstrap.com/icons/check-circle/ -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-circle <%= local_assigns[:class] %>" viewBox="0 0 16 16">
   <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
   <path d="M10.97 4.97a.235.235 0 0 0-.02.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z" />
 </svg>

--- a/app/views/good_job/shared/icons/_exclamation.html.erb
+++ b/app/views/good_job/shared/icons/_exclamation.html.erb
@@ -1,5 +1,5 @@
 <!-- https://icons.getbootstrap.com/icons/exclamation-circle/ -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-circle" viewBox="0 0 16 16">
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-exclamation-circle <%= local_assigns[:class] %>" viewBox="0 0 16 16">
   <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
   <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z" />
 </svg>


### PR DESCRIPTION
I haven't been consistent in using the `render_icon` helper.