### PR TITLE
[Docs] Bulk.enqueue takes an array of jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ end
 active_jobs.all?(&:provider_job_id)
 
 # Bulk enqueue Active Job instances directly without using `.perform_later`:
-GoodJob::Bulk.enqueue(MyJob.new, AnotherJob.new)
+GoodJob::Bulk.enqueue([MyJob.new, AnotherJob.new])
 ```
 
 ### Batches


### PR DESCRIPTION
This is a simple change to fix the `Bulk.enqueue` interface in the docs

Handing in jobs as arguments, as specified in the README, results in an argument error: `ArgumentError: wrong number of arguments (given 2, expected 0..1)`