### PR TITLE
Ignore job deserialization errors when mass-retrying through the dashboard

### DIFF
--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -44,10 +44,13 @@ module GoodJob
         end
 
         job
-      rescue GoodJob::Job::ActionForStateMismatchError, GoodJob::AdvisoryLockable::RecordAlreadyAdvisoryLockedError
+      rescue GoodJob::Job::ActiveJobDeserializationError,
+             GoodJob::Job::ActionForStateMismatchError,
+             GoodJob::AdvisoryLockable::RecordAlreadyAdvisoryLockedError
         nil
       end.compact
 
+      # TODO: Put these messages through I18n
       notice = if processed_jobs.any?
                  "Successfully #{ACTIONS[mass_action]} #{processed_jobs.count} #{'job'.pluralize(processed_jobs.count)}"
                else
@@ -94,11 +97,14 @@ module GoodJob
     private
 
     def redirect_on_error(exception)
+      # TODO: Put these messages through I18n
       alert = case exception
               when GoodJob::Job::AdapterNotGoodJobError
                 "Active Job Queue Adapter must be GoodJob."
               when GoodJob::Job::ActionForStateMismatchError
                 "Job is not in an appropriate state for this action."
+              when GoodJob::Job::ActiveJobDeserializationError
+                "Active Job data could not be deserialized."
               else
                 exception.to_s
               end

--- a/app/models/good_job/base_execution.rb
+++ b/app/models/good_job/base_execution.rb
@@ -104,8 +104,10 @@ module GoodJob
     def active_job(ignore_deserialization_errors: false)
       ActiveJob::Base.deserialize(active_job_data).tap do |aj|
         aj.send(:deserialize_arguments_if_needed)
+      rescue ActiveJob::DeserializationError
+        raise unless ignore_deserialization_errors
       end
-    rescue ActiveJob::DeserializationError, NameError
+    rescue NameError
       raise unless ignore_deserialization_errors
     end
 

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -34,6 +34,7 @@ module ::TestJob::Error; end
 module ::TestJob::ExpectedError; end
 module ::TestJob::RunError; end
 module ::TestJob::SuccessCallbackJob; end
+module GoodJob::Job::DeserializationError; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_RETRIED; end
 module Prism::AliasGlobalVariableNode::AliasGlobalVariableNode; end

--- a/spec/requests/good_job/jobs_controller_spec.rb
+++ b/spec/requests/good_job/jobs_controller_spec.rb
@@ -110,6 +110,21 @@ describe GoodJob::JobsController do
         job.reload
         expect(job.discrete_executions.count).to eq 2
       end
+
+      context 'when Job is not deserializable' do
+        before do
+          job.update(serialized_params: { "job_class" => "NonExistentJob" })
+        end
+
+        it 'ignores the job' do
+          put good_job.mass_update_jobs_path, params: {
+            mass_action: 'retry',
+            job_ids: [job.id],
+          }
+          expect(response).to have_http_status(:found)
+          expect(flash[:notice]).to eq("No jobs were retried")
+        end
+      end
     end
 
     describe 'mass_action=destroy' do


### PR DESCRIPTION
Fixes #1263 