### PR TITLE
Fix for Rails head: Don't try to override connection on connection checkin in tests

### DIFF
--- a/spec/support/postgres_notices.rb
+++ b/spec/support/postgres_notices.rb
@@ -17,9 +17,10 @@ ActiveSupport.on_load :active_record do
   }
 
   ActiveRecord::ConnectionAdapters::AbstractAdapter.set_callback :checkin, :before, lambda { |conn|
-    warning = PgLock.debug_own_locks(conn)
-    next if warning.blank?
+    count = PgLock.count_locks_for(conn)
+    next if count.zero?
 
+    warning = "Connection returned to pool with #{count} advisory locks"
     $stdout.puts warning
     Rails.logger.warn(warning)
     POSTGRES_NOTICES << warning


### PR DESCRIPTION
Fixes breakage with how GoodJob's tests assert that a connection, on check-in back to the connection pool, do not hold any advisory locks. Breakage caused by stuff moving around in Active Record: https://github.com/rails/rails/pull/51230

Similar to #1259.