### PR TITLE
Ensure job execution Advisory Lock query uses bind parameters

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -94,7 +94,7 @@ module GoodJob
     # @!method only_scheduled
     # @!scope class
     # @return [ActiveRecord::Relation]
-    scope :only_scheduled, -> { where(arel_table['scheduled_at'].lteq(Time.current)).or(where(scheduled_at: nil)) }
+    scope :only_scheduled, -> { where(arel_table['scheduled_at'].lteq(Arel::Nodes::BindParam.new(ActiveModel::Attribute.with_cast_value("scheduled_at", Time.current, ActiveModel::Type::DateTime.new)))).or(where(scheduled_at: nil)) }
 
     # Order executions by priority (highest priority first).
     # @!method priority_ordered

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe GoodJob::AdvisoryLockable do
       end
     end
 
+    it 'generates bind parameters instead of serialized values' do
+      messages = []
+      allow(model_class.logger).to receive(:debug) do |message|
+        messages << message
+      end
+      model_class.where(priority: 99).order(priority: :desc).advisory_lock.to_a
+      expect(messages.first).to match(/WHERE "good_jobs"."priority" = (\$1|\?)/)
+    end
+
     describe 'lockable column do' do
       it 'default column generates appropriate SQL' do
         allow(model_class).to receive(:advisory_lockable_column).and_return(:id)


### PR DESCRIPTION
- Do not call `to_sql` when generating materialized CTE; use Arel UnaryOperation instead
- Use a `Arel::Nodes::BindParam` instead of a Time value directly