### PR TITLE
fix(ui-dropdown): use dropdown-end on locales dropdown

### DIFF
--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -38,3 +38,7 @@
 .btn-outline-secondary {
   border-color: #ced4da; /* $gray-400 */
 }
+
+.min-w-auto {
+  min-width: auto;
+}

--- a/app/views/good_job/shared/_navbar.erb
+++ b/app/views/good_job/shared/_navbar.erb
@@ -73,7 +73,7 @@
             <%= I18n.locale %>
           </a>
 
-          <ul class="dropdown-menu" aria-labelledby="localeOptions">
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeOptions">
             <% possible_locales = I18n.available_locales %>
             <% possible_locales.reject { |locale| locale == I18n.locale }.each do |locale| %>
               <li><%= link_to locale, url_for(locale: locale), class: "dropdown-item" %></li>

--- a/app/views/good_job/shared/_navbar.erb
+++ b/app/views/good_job/shared/_navbar.erb
@@ -73,7 +73,7 @@
             <%= I18n.locale %>
           </a>
 
-          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeOptions">
+          <ul class="dropdown-menu min-w-auto" aria-labelledby="localeOptions">
             <% possible_locales = I18n.available_locales %>
             <% possible_locales.reject { |locale| locale == I18n.locale }.each do |locale| %>
               <li><%= link_to locale, url_for(locale: locale), class: "dropdown-item" %></li>


### PR DESCRIPTION
**Description:**

Add class `dropdown-menu-end` to fix overflow on header locales dropdown open state

**Before:**

![image](https://github.com/bensheldon/good_job/assets/53980548/d4dffed4-4a9a-4a62-aa20-86a3af9de57a)


**After:**

![image](https://github.com/bensheldon/good_job/assets/53980548/8e4137b7-9859-4689-9fa8-c5bc4e7f30ec)


**Other options:**

- Set min width to auto based on child element, it would look like this:

![image](https://github.com/bensheldon/good_job/assets/53980548/82c42f6c-db0f-4ba2-9b3f-8f0a3089f102)

