### PR TITLE
Invoke inline Bootstrap Color Mode javascript above CSS link tag to better avoid flash of un-themed content

### DIFF
--- a/app/views/layouts/good_job/application.html.erb
+++ b/app/views/layouts/good_job/application.html.erb
@@ -6,6 +6,20 @@
     <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+
+    <%# Bootstrap Color Modes
+      "It is suggested to include the JavaScript at the top of your page
+      to reduce potential screen flickering during reloading of your site."
+      https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript
+    %>
+    <%= tag.script "", nonce: content_security_policy_nonce do %>
+      let theme = localStorage.getItem('good_job-theme');
+      if (!["light", "dark"].includes(theme)) {
+        theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+      }
+      document.documentElement.setAttribute('data-bs-theme', theme);
+    <% end %>
+
     <%# Do not use asset tag helpers to avoid paths being overriden by config.asset_host %>
     <%= tag.link rel: "stylesheet", href: frontend_static_path(:bootstrap, format: :css, v: GoodJob::VERSION, locale: nil), nonce: content_security_policy_nonce %>
     <%= tag.link rel: "stylesheet", href: frontend_static_path(:style, format: :css, v: GoodJob::VERSION, locale: nil), nonce: content_security_policy_nonce %>
@@ -16,14 +30,6 @@
     <% importmaps = GoodJob::FrontendsController.js_modules.keys.index_with { |module_name| frontend_module_path(module_name, format: :js, locale: nil, v: GoodJob::VERSION) } %>
     <%= tag.script({ imports: importmaps }.to_json.html_safe, type: "importmap", nonce: content_security_policy_nonce) %>
     <%= tag.script "", type: "module", nonce: content_security_policy_nonce do %> import "application"; <% end %>
-    <%= tag.script "", nonce: content_security_policy_nonce do %>
-      // Ensure theme is updated before dom loads to avoid flash of style
-      let theme = localStorage.getItem('good_job-theme');
-      if (!["light", "dark"].includes(theme)) {
-      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-      }
-      document.documentElement.setAttribute('data-bs-theme', theme);
-    <% end %>
   </head>
   <body>
     <div class="d-flex flex-column min-vh-100">


### PR DESCRIPTION
Fixes #1224

Big thank you to @carlosmintfan for pointing out the change.