### PR TITLE
Use scope-resolutioned constants in Notifier loop

### DIFF
--- a/lib/good_job/notifier.rb
+++ b/lib/good_job/notifier.rb
@@ -50,7 +50,7 @@ module GoodJob # :nodoc:
     # Send a message via Postgres NOTIFY
     # @param message [#to_json]
     def self.notify(message)
-      connection = Execution.connection
+      connection = ::GoodJob::Execution.connection
       connection.exec_query <<~SQL.squish
         NOTIFY #{CHANNEL}, #{connection.quote(message.to_json)}
       SQL
@@ -248,8 +248,8 @@ module GoodJob # :nodoc:
 
     def with_connection
       Rails.application.executor.wrap do
-        self.connection = Execution.connection_pool.checkout.tap do |conn|
-          Execution.connection_pool.remove(conn)
+        self.connection = ::GoodJob::Execution.connection_pool.checkout.tap do |conn|
+          ::GoodJob::Execution.connection_pool.remove(conn)
         end
       end
       connection.execute("SET application_name = #{connection.quote(self.class.name)}")


### PR DESCRIPTION
Received a bug report with `NameError: uninitialized constant GoodJob::Notifier::Execution` at `good_job (3.26.2) lib/good_job/notifier.rb in block in with_connection at line 251`.

I'm not sure why the constant wouldn't be lookup-able, but this seems like a small fix that might provide more info should it reoccur.