### PR TITLE
Revert "Start async adapters `after_initialize` instead of once Active Job and Active Record are loaded and Rails initialized?"

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -25,6 +25,7 @@ require_relative "good_job/configuration"
 require_relative "good_job/cron_manager"
 require_relative "good_job/current_thread"
 require_relative "good_job/daemon"
+require_relative "good_job/dependencies"
 require_relative "good_job/job_performer"
 require_relative "good_job/job_performer/metrics"
 require_relative "good_job/log_subscriber"
@@ -45,6 +46,7 @@ require_relative "good_job/thread_status"
 #
 # +GoodJob+ is the top-level namespace and exposes configuration attributes.
 module GoodJob
+  include GoodJob::Dependencies
   include GoodJob::ThreadStatus
 
   # Default, null, blank value placeholder.
@@ -111,11 +113,6 @@ module GoodJob
   #   Global/default execution capsule for GoodJob.
   #   @return [GoodJob::Capsule, nil]
   mattr_accessor :capsule, default: GoodJob::Capsule.new(configuration: configuration)
-
-  mattr_accessor :_async_ready, default: false
-  def self._async_ready?
-    _async_ready
-  end
 
   # Called with exception when a GoodJob thread raises an exception
   # @param exception [Exception] Exception that was raised

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -30,7 +30,7 @@ module GoodJob
       GoodJob::Configuration.validate_execution_mode(@_execution_mode_override) if @_execution_mode_override
       @capsule = _capsule
 
-      start_async if GoodJob._async_ready?
+      start_async if GoodJob.async_ready?
       self.class.instances << self
     end
 

--- a/lib/good_job/dependencies.rb
+++ b/lib/good_job/dependencies.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module GoodJob # :nodoc:
+  # Extends GoodJob module to track Rails boot dependencies.
+  module Dependencies
+    extend ActiveSupport::Concern
+
+    included do
+      mattr_accessor :_framework_ready, default: false
+    end
+
+    class_methods do
+      # Whether Rails framework has sufficiently initialized to enable Async execution.
+      def async_ready?
+        Rails.application.initialized? || _framework_ready
+      end
+
+      def _start_async_adapters
+        return unless async_ready?
+
+        ActiveJob::Base.queue_adapter # Ensure Active Job is initialized
+        GoodJob::Adapter.instances
+                        .select(&:execute_async?)
+                        .reject(&:async_started?)
+                        .each(&:start_async)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reverts bensheldon/good_job#1297

This seems related to #1302, #1297. I'm going to pull this for now because it seems more disruptive than the previous status quo.