### PR TITLE
Implement enqueue_after_transaction_commit?

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -25,7 +25,7 @@ module GoodJob
     #   -+test+: +:inline+
     #  - +production+ and all other environments: +:external+
     #
-    def initialize(execution_mode: nil, _capsule: GoodJob.capsule, enqueue_after_transaction_commit: true) # rubocop:disable Lint/UnderscorePrefixedVariableName
+    def initialize(execution_mode: nil, _capsule: GoodJob.capsule, enqueue_after_transaction_commit: false) # rubocop:disable Lint/UnderscorePrefixedVariableName
       @_execution_mode_override = execution_mode
       @enqueue_after_transaction_commit = enqueue_after_transaction_commit
       GoodJob::Configuration.validate_execution_mode(@_execution_mode_override) if @_execution_mode_override

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -25,9 +25,8 @@ module GoodJob
     #   -+test+: +:inline+
     #  - +production+ and all other environments: +:external+
     #
-    def initialize(execution_mode: nil, _capsule: GoodJob.capsule, enqueue_after_transaction_commit: false) # rubocop:disable Lint/UnderscorePrefixedVariableName
+    def initialize(execution_mode: nil, _capsule: GoodJob.capsule) # rubocop:disable Lint/UnderscorePrefixedVariableName
       @_execution_mode_override = execution_mode
-      @enqueue_after_transaction_commit = enqueue_after_transaction_commit
       GoodJob::Configuration.validate_execution_mode(@_execution_mode_override) if @_execution_mode_override
       @capsule = _capsule
 
@@ -46,7 +45,7 @@ module GoodJob
     # Defines if enqueueing this job from inside an Active Record transaction
     # automatically defers the enqueue to after the transaction commit.
     def enqueue_after_transaction_commit?
-      @enqueue_after_transaction_commit
+      GoodJob.configuration.enqueue_after_transaction_commit
     end
 
     # Enqueues multiple ActiveJob instances at once

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -25,8 +25,9 @@ module GoodJob
     #   -+test+: +:inline+
     #  - +production+ and all other environments: +:external+
     #
-    def initialize(execution_mode: nil, _capsule: GoodJob.capsule) # rubocop:disable Lint/UnderscorePrefixedVariableName
+    def initialize(execution_mode: nil, _capsule: GoodJob.capsule, enqueue_after_transaction_commit: true) # rubocop:disable Lint/UnderscorePrefixedVariableName
       @_execution_mode_override = execution_mode
+      @enqueue_after_transaction_commit = enqueue_after_transaction_commit
       GoodJob::Configuration.validate_execution_mode(@_execution_mode_override) if @_execution_mode_override
       @capsule = _capsule
 
@@ -40,6 +41,12 @@ module GoodJob
     # @return [GoodJob::Execution]
     def enqueue(active_job)
       enqueue_at(active_job, nil)
+    end
+
+    # Defines if enqueueing this job from inside an Active Record transaction
+    # automatically defers the enqueue to after the transaction commit.
+    def enqueue_after_transaction_commit?
+      @enqueue_after_transaction_commit
     end
 
     # Enqueues multiple ActiveJob instances at once

--- a/lib/good_job/bulk.rb
+++ b/lib/good_job/bulk.rb
@@ -14,7 +14,7 @@ module GoodJob
 
     # Capture jobs to a buffer. Pass either a block, or specific Active Jobs to be buffered.
     # @param active_jobs [Array<ActiveJob::Base>] Active Jobs to be buffered.
-    # @param queue_adapter Override the jobs implict queue adapter with an explicit one.
+    # @param queue_adapter Override the jobs implicit queue adapter with an explicit one.
     # @return [nil, Array<ActiveJob::Base>] The ActiveJob instances that have been buffered; nil if no active buffer
     def self.capture(active_jobs = nil, queue_adapter: nil, &block)
       raise(ArgumentError, "Use either the block form or the argument form, not both") if block && active_jobs

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -33,6 +33,8 @@ module GoodJob
     DEFAULT_DASHBOARD_DEFAULT_LOCALE = :en
     # Default Dashboard Live Poll button enabled
     DEFAULT_DASHBOARD_LIVE_POLL_ENABLED = true
+    # Default enqueue_after_transaction_commit
+    DEFAULT_ENQUEUE_AFTER_TRANSACTION_COMMIT = false
 
     def self.validate_execution_mode(execution_mode)
       raise ArgumentError, "GoodJob execution mode must be one of #{EXECUTION_MODES.join(', ')}. It was '#{execution_mode}' which is not valid." unless execution_mode.in?(EXECUTION_MODES)
@@ -387,6 +389,14 @@ module GoodJob
       return rails_config[:dashboard_live_poll_enabled] unless rails_config[:dashboard_live_poll_enabled].nil?
 
       DEFAULT_DASHBOARD_LIVE_POLL_ENABLED
+    end
+
+    # Whether the Adapter should have Active Job enqueue jobs after the transaction has committed.
+    # @return [Boolean]
+    def enqueue_after_transaction_commit
+      return options[:enqueue_after_transaction_commit] unless options[:enqueue_after_transaction_commit].nil?
+
+      DEFAULT_ENQUEUE_AFTER_TRANSACTION_COMMIT
     end
 
     # Whether running in a web server process.

--- a/spec/lib/good_job/bulk_spec.rb
+++ b/spec/lib/good_job/bulk_spec.rb
@@ -96,7 +96,8 @@ describe GoodJob::Bulk do
     end
 
     it 'can handle non-GoodJob jobs that are directly inserted into the buffer' do
-      adapter = instance_double(ActiveJob::QueueAdapters::InlineAdapter, enqueue: nil, enqueue_at: nil)
+      optional_adapter_kwargs = ActiveJob::QueueAdapters::InlineAdapter.method_defined?(:enqueue_after_transaction_commit?) ? { enqueue_after_transaction_commit?: false } : {}
+      adapter = instance_double(ActiveJob::QueueAdapters::InlineAdapter, enqueue: nil, enqueue_at: nil, **optional_adapter_kwargs)
       TestJob.queue_adapter = adapter
 
       described_class.enqueue(TestJob.new)


### PR DESCRIPTION
Closes #1310

It defines whether the job should be enqueued implicitly after committing an ActiveRecord transaction. More details [here](https://github.com/rails/rails/commit/a134d9166e4d34ab0d97fb82f3e4f0092b3b98ee)