### PR TITLE
add missing dropdown-item class

### DIFF
--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -25,7 +25,7 @@
             </button>
             <ul class="dropdown-menu" aria-labelledby="destroy-dropdown-toggle">
               <li>
-                <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn', title: t(".actions.destroy_all"), data: { confirm: t(".actions.confirm_destroy_all"), disable: true } do %>
+                <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn dropdown-item', title: t(".actions.destroy_all"), data: { confirm: t(".actions.confirm_destroy_all"), disable: true } do %>
                   <span class="me-1"><%= render_icon "trash" %></span> <%=t "good_job.actions.destroy" %>
                 <% end %>
               </li>


### PR DESCRIPTION
hi! I've been using good_job a lot lately and noticed that when I wanted to mass destroy some jobs the destroy dropdown button didn't have the right style. So here's a small PR to fix that!

Thanks :) 

before:
![image](https://github.com/bensheldon/good_job/assets/321978/54d23bb0-95d4-4be9-8a11-e13f3c0357e4)

after:
![image](https://github.com/bensheldon/good_job/assets/321978/bffbae1d-0d9a-46c4-9782-04791974b464)
