### PR TITLE
Store and optionally display the full execution backtrace

### DIFF
--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -42,3 +42,7 @@
 .min-w-auto {
   min-width: auto;
 }
+
+.w-fit-content {
+  width: fit-content
+}

--- a/app/models/good_job/discrete_execution.rb
+++ b/app/models/good_job/discrete_execution.rb
@@ -65,5 +65,9 @@ module GoodJob # :nodoc:
                                 _good_job_execution: attributes.except('serialized_params'),
                               })
     end
+
+    def filtered_error_backtrace
+      Rails.backtrace_cleaner.clean(error_backtrace || [])
+    end
   end
 end

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -362,10 +362,6 @@ module GoodJob
       [error.class.to_s, ERROR_MESSAGE_SEPARATOR, error.message].join
     end
 
-    def self.format_backtrace(backtrace)
-      Rails.backtrace_cleaner.clean(backtrace || [])
-    end
-
     # Execute the ActiveJob job this {Execution} represents.
     # @return [ExecutionResult]
     #   An array of the return value of the job's +#perform+ method and the
@@ -465,10 +461,7 @@ module GoodJob
           if discrete_execution
             discrete_execution.error = error_string
             discrete_execution.error_event = result.error_event
-            if discrete_execution.class.backtrace_migrated?
-              error_backtrace = self.class.format_backtrace(job_error.backtrace)
-              discrete_execution.error_backtrace = error_backtrace
-            end
+            discrete_execution.error_backtrace = job_error.backtrace if discrete_execution.class.backtrace_migrated?
           end
         else
           job_attributes[:error] = nil

--- a/app/views/good_job/jobs/_executions.erb
+++ b/app/views/good_job/jobs/_executions.erb
@@ -39,9 +39,30 @@
             <code class="text-wrap text-break m-0 text-secondary-emphasis"><%= execution.error %></code>
           </div>
           <% if GoodJob::DiscreteExecution.backtrace_migrated? && execution.error_backtrace&.any? %>
-            <div class="small">
-              <code class="text-wrap text-break m-0 text-secondary-emphasis"><%= execution.error_backtrace[0] %></code>
-            </div>
+            <%= tag.ul class: "nav nav-tabs small w-fit-content", id: dom_id(execution, :tab), role:"tablist" do %>
+              <li class="nav-item" role="presentation">
+                <%= tag.button t(".application_trace"), class: "nav-link active p-1", id: dom_id(execution, :application), data: { bs_toggle: "tab", bs_target: dom_id(execution, :"#application_pane") }, type: "button", role: "tab", aria: { controls: dom_id(execution, :application_pane), selected: true  }  %>
+              </li>
+              <li class="nav-item" role="presentation">
+                <%= tag.button t(".full_trace"), class: "nav-link p-1", id: dom_id(execution, :full), data: { bs_toggle: "tab", bs_target: dom_id(execution, :"#full_pane") }, type: "button", role: "tab", aria: { controls: dom_id(execution, :full_pane), selected: false } %>
+              </li>
+            <% end %>
+            <%= tag.div class: "tab-content", id: "#{dom_id(execution, :tab)}Content" do %>
+              <%= tag.div class: "tab-pane fade show active", id: dom_id(execution, :application_pane), role: "tabpane", aria: { labelledby: dom_id(execution, :application) }, tabindex: 0 do %>
+                <div class="small">
+                  <code class="text-wrap text-break m-0 text-secondary-emphasis">
+                    <%= safe_join(execution.filtered_error_backtrace, tag.br) %>
+                  </code>
+                </div>
+              <% end %>
+              <%= tag.div class: "tab-pane fade", id: dom_id(execution, :full_pane), role: "tabpane", aria: { labelledby: dom_id(execution, :full) }, tabindex: 0 do %>
+                <div class="small">
+                  <code class="text-wrap text-break m-0 text-secondary-emphasis">
+                    <%= safe_join(execution.error_backtrace, tag.br) %>
+                  </code>
+                </div>
+              <% end %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -124,6 +124,8 @@ de:
       discard:
         notice: Auftrag wurde verworfen
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: in der Warteschlange
         runtime: Laufzeit
         title: Hinrichtungen

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,8 @@ en:
       discard:
         notice: Job has been discarded
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: in queue
         runtime: runtime
         title: Executions

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -124,6 +124,8 @@ es:
       discard:
         notice: La tarea ha sido descartada
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: en cola
         runtime: en ejecución
         title: Ejecuciones

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -124,6 +124,8 @@ fr:
       discard:
         notice: Le job a été mis au rebut
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: Dans la file d'attente
         runtime: Durée
         title: Exécutions

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -124,6 +124,8 @@ it:
       discard:
         notice: Il job è stato scartato
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: in coda
         runtime: tempo di esecuzione
         title: Esecuzioni

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -124,6 +124,8 @@ ja:
       discard:
         notice: ジョブが破棄されました
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: 待機中
         runtime: 実行時間
         title: 実行

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -124,6 +124,8 @@ ko:
       discard:
         notice: 작업이 폐기되었습니다.
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: 대기 중
         runtime: 실행 시간
         title: 실행

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -33,7 +33,7 @@ nl:
         no_batches_found: Geen batches gevonden.
     cron_entries:
       actions:
-        confirm_disable: Weet u zeker dat u deze cron-vermelding wilt uitschakelen?
+        confirm_disable: Weet u zekerf dat u deze cron-vermelding wilt uitschakelen?
         confirm_enable: Weet u zeker dat u deze cron-invoer wilt inschakelen?
         confirm_enqueue: Weet u zeker dat u deze cron-vermelding in de wachtrij wilt plaatsen?
         disable: Schakel cron-invoer uit
@@ -124,6 +124,8 @@ nl:
       discard:
         notice: Job is weggegooid
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: in de wachtrij
         runtime: looptijd
         title: Executies

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -124,6 +124,8 @@ pt-BR:
       discard:
         notice: A tarefa foi descartada.
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: na fila
         runtime: tempo de execução
         title: Execuções

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -148,6 +148,8 @@ ru:
       discard:
         notice: Задание было отменено
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: в очереди
         runtime: время выполнения
         title: Выполнение заданий

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -124,6 +124,8 @@ tr:
       discard:
         notice: İş İptal Edildi
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: sırada
         runtime: çalışma süresi
         title: İşlemler

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -148,6 +148,8 @@ uk:
       discard:
         notice: Завдання було відхилено
       executions:
+        application_trace: Application Trace
+        full_trace: Full Trace
         in_queue: у черзі
         runtime: час виконання
         title: Виконання

--- a/spec/app/jobs/example_job_spec.rb
+++ b/spec/app/jobs/example_job_spec.rb
@@ -59,8 +59,10 @@ describe ExampleJob do
 
         good_job = GoodJob::Job.find_by(active_job_id: active_job.job_id)
         expect(good_job.discrete_executions.count).to eq 3
-        expect(good_job.discrete_executions.last.error).to be_present
-        expect(good_job.discrete_executions.last.error_backtrace).to eq(["app/jobs/example_job.rb:41:in `perform'"])
+        discrete_execution = good_job.discrete_executions.last
+        expect(discrete_execution.error).to be_present
+        expect(discrete_execution.error_backtrace.count).to be > 100
+        expect(discrete_execution.filtered_error_backtrace).to eq(["app/jobs/example_job.rb:41:in `perform'"])
       end
     end
 


### PR DESCRIPTION
See https://github.com/bensheldon/good_job/pull/1325#issuecomment-2066050703. This stores the full backtrace and later displays a filtered one by default. The user can optionally switch to a tab for viewing the complete backtrace.

![grafik](https://github.com/bensheldon/good_job/assets/14981592/617e42ae-b6c4-464d-9dd5-94eebfff70a9)
