### PR TITLE
Ensure job context does not leak into extensions when`perform_now` is called within another job

### DIFF
--- a/lib/good_job/active_job_extensions/batches.rb
+++ b/lib/good_job/active_job_extensions/batches.rb
@@ -6,7 +6,7 @@ module GoodJob
       extend ActiveSupport::Concern
 
       def batch
-        @_batch ||= CurrentThread.execution&.batch&.to_batch
+        @_batch ||= CurrentThread.execution&.batch&.to_batch if CurrentThread.execution.present? && CurrentThread.execution.active_job_id == job_id
       end
       alias batch? batch
     end

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -75,7 +75,7 @@ module GoodJob
           key = job.good_job_concurrency_key
           next if key.blank?
 
-          if CurrentThread.execution.blank?
+          if CurrentThread.execution.blank? || CurrentThread.execution.active_job_id != job_id
             logger.debug("Ignoring concurrency limits because the job is executed with `perform_now`.")
             next
           end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -34,6 +34,7 @@ module ::TestJob::Error; end
 module ::TestJob::ExpectedError; end
 module ::TestJob::RunError; end
 module ::TestJob::SuccessCallbackJob; end
+module ::WrapperJob; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_RETRIED; end
 module Rails::Server; end

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         TestJob.perform_now(name: "Alice")
         expect(JOB_PERFORMED).to be_true
       end
+
+      it 'is ignored when the job is executed inside another job' do
+        stub_const("WrapperJob", Class.new(ApplicationJob) do
+          def perform
+            TestJob.perform_now(name: "Alice")
+          end
+        end)
+
+        WrapperJob.perform_later
+        GoodJob.perform_inline
+        expect(JOB_PERFORMED).to be_true
+      end
     end
 
     describe '#enqueue_throttle' do


### PR DESCRIPTION
- Fixes #1335 for Concurrency
- Also fixes `batch`