### PR TITLE
Don't abort CI jobs when a single one fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.6, 2.7, "3.0", 3.1, 3.2, 3.3, jruby-9.3, jruby-9.4]
         pg: [15]


### PR DESCRIPTION
Some tests appear flaky (at least on CI, or just for JRuby): https://github.com/bensheldon/good_job/actions/runs/8892740760/job/24417466385?pr=1345

This prevents all jobs from aborting when that happens and gives a better idea for the scope of failures.