### PR TITLE
Strip more whitespace when parsing queues string

### DIFF
--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -40,7 +40,7 @@ module GoodJob
     #   GoodJob::Execution.queue_parser('-queue1,queue2')
     #   => { exclude: [ 'queue1', 'queue2' ] }
     def self.queue_parser(string)
-      string = string.presence || '*'
+      string = string.strip.presence || '*'
 
       case string.first
       when '-'

--- a/lib/good_job/multi_scheduler.rb
+++ b/lib/good_job/multi_scheduler.rb
@@ -8,8 +8,8 @@ module GoodJob
     # @param warm_cache_on_initialize [Boolean]
     # @return [GoodJob::MultiScheduler]
     def self.from_configuration(configuration, warm_cache_on_initialize: false)
-      schedulers = configuration.queue_string.split(';').map do |queue_string_and_max_threads|
-        queue_string, max_threads = queue_string_and_max_threads.split(':')
+      schedulers = configuration.queue_string.split(';').map(&:strip).map do |queue_string_and_max_threads|
+        queue_string, max_threads = queue_string_and_max_threads.split(':').map { |str| str.strip.presence }
         max_threads = (max_threads || configuration.max_threads).to_i
 
         job_performer = GoodJob::JobPerformer.new(queue_string)

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe 'Server modes', :skip_if_java do
     it 'successfully runs in the server' do
       env = {
         "RAILS_ENV" => "production",
+        "SECRET_KEY_BASE" => "iaminallyoursecretkeybase",
         "GOOD_JOB_EXECUTION_MODE" => "async",
         "GOOD_JOB_ENABLE_CRON" => "true",
       }
@@ -54,6 +55,7 @@ RSpec.describe 'Server modes', :skip_if_java do
     it 'does not start GoodJob when running other commands' do
       env = {
         "RAILS_ENV" => "production",
+        "SECRET_KEY_BASE" => "iaminallyoursecretkeybase",
         "GOOD_JOB_EXECUTION_MODE" => "async",
       }
       ShellOut.command('bundle exec rails db:version', env: env) do |shell|

--- a/spec/lib/good_job/multi_scheduler_spec.rb
+++ b/spec/lib/good_job/multi_scheduler_spec.rb
@@ -26,6 +26,25 @@ RSpec.describe GoodJob::MultiScheduler do
           max_threads: 4
         )
       end
+
+      it "can handle spaces in the configuration" do
+        configuration = GoodJob::Configuration.new({ queues: ' +  mice , ferrets: 2 ; elephant : 4 ; ' })
+        multi_scheduler = described_class.from_configuration(configuration)
+
+        rodents_scheduler, elephants_scheduler = multi_scheduler.schedulers
+
+        expect(rodents_scheduler.stats).to include(
+          queues: '+  mice , ferrets',
+          max_threads: 2
+        )
+        expect(rodents_scheduler.send(:performer).send(:parsed_queues)).to eq({ include: %w[mice ferrets], ordered_queues: true })
+
+        expect(elephants_scheduler.stats).to include(
+          queues: 'elephant',
+          max_threads: 4
+        )
+        expect(elephants_scheduler.send(:performer).send(:parsed_queues)).to eq({ include: ["elephant"] })
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #1351 

The alternative would be to gsub away all of the whitespace, but I don't like transforming input strings for display.