### PR TITLE
Fix AdvisoryLockable using wrong `advisory_lockable_column` attribute when aborting `create_with_advisory_lock`

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -133,7 +133,7 @@ module GoodJob
 
       after_create lambda {
         advisory_lock || begin
-          errors.add(self.class.advisory_lockable_column, "Failed to acquire advisory lock: #{lockable_key}")
+          errors.add(self.class._advisory_lockable_column, "Failed to acquire advisory lock: #{lockable_key}")
           raise ActiveRecord::RecordInvalid # do not reference the record because it can cause I18n missing translation error
         end
       }, if: :create_with_advisory_lock

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -387,6 +387,16 @@ RSpec.describe GoodJob::AdvisoryLockable do
 
       execution.advisory_unlock
     end
+
+    it 'aborts when the lock already exists' do
+      existing = model_class.create!(active_job_id: SecureRandom.uuid, create_with_advisory_lock: true)
+
+      expect do
+        rails_promise { model_class.create!(active_job_id: existing.active_job_id, create_with_advisory_lock: true) }.value!
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    ensure
+      existing.advisory_unlock
+    end
   end
 
   it 'is lockable' do


### PR DESCRIPTION
Fixes #1358 