### PR TITLE
Synchronize `CapsuleTracker#renew`

### DIFF
--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -101,7 +101,8 @@ module GoodJob # :nodoc:
 
     def refresh
       self.state = self.class.process_state
-      reload.update(state: state, updated_at: Time.current)
+      reload # verify the record still exists in the database
+      update(state: state, updated_at: Time.current)
     rescue ActiveRecord::RecordNotFound
       @new_record = true
       self.created_at = self.updated_at = nil

--- a/lib/good_job/capsule_tracker.rb
+++ b/lib/good_job/capsule_tracker.rb
@@ -143,8 +143,10 @@ module GoodJob # :nodoc:
     # @param silent [Boolean] Whether to silence logging.
     # @return [void]
     def renew(silent: false)
-      GoodJob::Process.with_logger_silenced(silent: silent) do
-        @record&.refresh_if_stale(cleanup: true)
+      synchronize do
+        GoodJob::Process.with_logger_silenced(silent: silent) do
+          @record&.refresh_if_stale(cleanup: true)
+        end
       end
     end
 

--- a/spec/lib/good_job/capsule_tracker_spec.rb
+++ b/spec/lib/good_job/capsule_tracker_spec.rb
@@ -149,7 +149,7 @@ describe GoodJob::CapsuleTracker do
   end
 
   describe '#process_id' do
-    it 'is a UUID' do
+    it 'is a UUID the process has been locked' do
       expect(tracker.process_id).to be_a_uuid
     end
   end


### PR DESCRIPTION
Connects to https://github.com/bensheldon/good_job/issues/1363

This is the one unsynchronized call that updates the Process record inside of the Capsule tracker. I suspect there is a weird concurrency thing going on in #1363 but I'm not entirely sure. This should be safe and the worst downside will be a little performance hit because of the lock.