### PR TITLE
Use newer syntax in documentation for `wait` config on `retry`

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ Active Job can be configured to retry an infinite number of times, with a polyno
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
-  retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
+  retry_on StandardError, wait: :polynomially_longer, attempts: Float::INFINITY
   # ...
 end
 ```
@@ -868,7 +868,7 @@ When using `retry_on` with an infinite number of retries, exceptions will never 
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
-  retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
+  retry_on StandardError, wait: :polynomially_longer, attempts: Float::INFINITY
 
   retry_on SpecialError, attempts: 5 do |_job, exception|
     Rails.error.report(exception)
@@ -894,7 +894,7 @@ You can use an initializer to configure `ActionMailer::MailDeliveryJob`, for exa
 
 ```ruby
 # config/initializers/good_job.rb
-ActionMailer::MailDeliveryJob.retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
+ActionMailer::MailDeliveryJob.retry_on StandardError, wait: :polynomially_longer, attempts: Float::INFINITY
 
 # With Sentry (or Bugsnag, Airbrake, Honeybadger, etc.)
 ActionMailer::MailDeliveryJob.around_perform do |_job, block|

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ Active Job can be configured to retry an infinite number of times, with a polyno
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
-  retry_on StandardError, wait: :exponentially_longer, attempts: Float::INFINITY
+  retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
   # ...
 end
 ```
@@ -868,7 +868,7 @@ When using `retry_on` with an infinite number of retries, exceptions will never 
 
 ```ruby
 class ApplicationJob < ActiveJob::Base
-  retry_on StandardError, wait: :exponentially_longer, attempts: Float::INFINITY
+  retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
 
   retry_on SpecialError, attempts: 5 do |_job, exception|
     Rails.error.report(exception)
@@ -894,7 +894,7 @@ You can use an initializer to configure `ActionMailer::MailDeliveryJob`, for exa
 
 ```ruby
 # config/initializers/good_job.rb
-ActionMailer::MailDeliveryJob.retry_on StandardError, wait: :exponentially_longer, attempts: Float::INFINITY
+ActionMailer::MailDeliveryJob.retry_on StandardError, wait: ::polynomially_longer, attempts: Float::INFINITY
 
 # With Sentry (or Bugsnag, Airbrake, Honeybadger, etc.)
 ActionMailer::MailDeliveryJob.around_perform do |_job, block|


### PR DESCRIPTION
good_job already handle both of course, but doc should provide code that do not produce deprecation warnings like:

```
W, [2024-06-20T23:10:09.948834 #81411]  WARN -- : DEPRECATION WARNING: `wait: :exponentially_longer` will actually wait polynomially longer and is therefore deprecated. Prefer `wait: :polynomially_longer` to avoid confusion and keep the same behavior. (called from <class:TaskWebhookJob> at /Users/benoit.tigeot/projects/tooling/k8s-tooling-gw/app/jobs/task_webhook_job.rb:3)
```

No problem if you think it's better to have doc that work on more version of Rails.