### PR TITLE
fix: require rack/handler for rack >= 3.1.x

### DIFF
--- a/bin/tapioca
+++ b/bin/tapioca
@@ -24,4 +24,5 @@ end
 require "rubygems"
 require "bundler/setup"
 
+ENV['BOOTSNAP_CACHE_DIR'] ||= File.expand_path("../demo/tmp/cache/bootsnap", __dir__)
 load Gem.bin_path("tapioca", "tapioca")

--- a/lib/good_job/probe_server/webrick_handler.rb
+++ b/lib/good_job/probe_server/webrick_handler.rb
@@ -12,12 +12,12 @@ module GoodJob
         # We should move to rackup in the long run.
         # See https://github.com/rack/rack/pull/1937.
         @handler = begin
-                     require 'rackup/handler'
-                     ::Rackup::Handler.get('webrick')
-                   rescue LoadError
-                     require "rack/handler"
-                     ::Rack::Handler.get('webrick')
-                   end
+          require 'rackup/handler'
+          ::Rackup::Handler.get('webrick')
+        rescue LoadError
+          require "rack/handler"
+          ::Rack::Handler.get('webrick')
+        end
       end
 
       def stop

--- a/lib/good_job/probe_server/webrick_handler.rb
+++ b/lib/good_job/probe_server/webrick_handler.rb
@@ -7,6 +7,11 @@ module GoodJob
         @app    = app
         @port   = options[:port]
         @logger = options[:logger]
+
+        # Workaround for rack >= 3.1.x as auto-loading of rack/handler was removed.
+        # We should move to rackup in the long run.
+        # See https://github.com/rack/rack/pull/1937.
+        require 'rack/handler'
         @handler = ::Rack::Handler.get('webrick')
       end
 

--- a/lib/good_job/probe_server/webrick_handler.rb
+++ b/lib/good_job/probe_server/webrick_handler.rb
@@ -11,8 +11,13 @@ module GoodJob
         # Workaround for rack >= 3.1.x as auto-loading of rack/handler was removed.
         # We should move to rackup in the long run.
         # See https://github.com/rack/rack/pull/1937.
-        require 'rack/handler'
-        @handler = ::Rack::Handler.get('webrick')
+        @handler = begin
+                     require 'rackup/handler'
+                     ::Rackup::Handler.get('webrick')
+                   rescue LoadError
+                     require "rack/handler"
+                     ::Rack::Handler.get('webrick')
+                   end
       end
 
       def stop

--- a/sorbet/rbi/shims/rackup.rbi
+++ b/sorbet/rbi/shims/rackup.rbi
@@ -1,0 +1,53 @@
+# Manually exported via Tapioca because rackup is not compatible with Rack 2.0
+# which is used for development, but Rackup is is necessary as a fallback for
+# Rack 3.0 compatibility. And Rackup 1.0 is bugged.
+#
+# https://github.com/rack/rackup/issues/13#issuecomment-2186788166
+
+module Rackup; end
+module Rackup::Handler
+  class << self
+    # source://rackup//lib/rackup/handler.rb#30
+    def [](name); end
+
+    # source://rackup//lib/rackup/handler.rb#84
+    def default; end
+
+    # source://rackup//lib/rackup/handler.rb#40
+    def get(name); end
+
+    # Select first available Rack handler given an `Array` of server names.
+    # Raises `LoadError` if no handler was found.
+    #
+    #   > pick ['puma', 'webrick']
+    #   => Rackup::Handler::WEBrick
+    #
+    # @raise [LoadError]
+    #
+    # source://rackup//lib/rackup/handler.rb#69
+    def pick(server_names); end
+
+    # Register a named handler class.
+    #
+    # source://rackup//lib/rackup/handler.rb#18
+    def register(name, klass); end
+
+    # Transforms server-name constants to their canonical form as filenames,
+    # then tries to require them but silences the LoadError if not found
+    #
+    # Naming convention:
+    #
+    #   Foo # => 'foo'
+    #   FooBar # => 'foo_bar.rb'
+    #   FooBAR # => 'foobar.rb'
+    #   FOObar # => 'foobar.rb'
+    #   FOOBAR # => 'foobar.rb'
+    #   FooBarBaz # => 'foo_bar_baz.rb'
+    #
+    # source://rackup//lib/rackup/handler.rb#106
+    def require_handler(prefix, const_name); end
+  end
+end
+
+# source://rackup//lib/rackup/version.rb#7
+Rackup::VERSION = T.let(T.unsafe(nil), String)


### PR DESCRIPTION
From rack >= 3.1.x, `Rack::Handler` is not auto-loaded anymore. Though we should migrate to `Rackup::Handler`, we can't in the short term. This is because of the support of rails <= 7.0 that doesn't depend on rackup.