### PR TITLE
Add missing newline after frozen string literal for migrations

### DIFF
--- a/demo/db/migrate/20240518175057_create_good_job_process_lock_ids.rb
+++ b/demo/db/migrate/20240518175057_create_good_job_process_lock_ids.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateGoodJobProcessLockIds < ActiveRecord::Migration[7.1]
   def change
     reversible do |dir|

--- a/demo/db/migrate/20240518175058_create_good_job_process_lock_indexes.rb
+++ b/demo/db/migrate/20240518175058_create_good_job_process_lock_indexes.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/lib/generators/good_job/templates/update/migrations/13_create_good_job_process_lock_ids.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/13_create_good_job_process_lock_ids.rb.erb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateGoodJobProcessLockIds < ActiveRecord::Migration<%= migration_version %>
   def change
     reversible do |dir|

--- a/lib/generators/good_job/templates/update/migrations/14_create_good_job_process_lock_indexes.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/14_create_good_job_process_lock_indexes.rb.erb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CreateGoodJobProcessLockIndexes < ActiveRecord::Migration<%= migration_version %>
   disable_ddl_transaction!
 


### PR DESCRIPTION
Very small nit. All the other current migrations follow the RuboCop rule. It's erb so RuboCop doesn't know about it.