### PR TITLE
Actually change `smaller_number_is_higher_priority` for v4

### DIFF
--- a/demo/config/initializers/good_job.rb
+++ b/demo/config/initializers/good_job.rb
@@ -1,7 +1,4 @@
 Rails.application.configure do
-  # TODO: Remove on GoodJob 4.0 release
-  config.good_job.smaller_number_is_higher_priority = true
-
   config.good_job.cron = {
     example: {
       cron: '*/5 * * * * *', # every 5 seconds

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -35,6 +35,8 @@ module GoodJob
     DEFAULT_DASHBOARD_LIVE_POLL_ENABLED = true
     # Default enqueue_after_transaction_commit
     DEFAULT_ENQUEUE_AFTER_TRANSACTION_COMMIT = false
+    # Default smaller_number_is_higher_priority
+    DEFAULT_SMALLER_NUMBER_IS_HIGHER_PRIORITY = true
 
     def self.validate_execution_mode(execution_mode)
       raise ArgumentError, "GoodJob execution mode must be one of #{EXECUTION_MODES.join(', ')}. It was '#{execution_mode}' which is not valid." unless execution_mode.in?(EXECUTION_MODES)
@@ -378,7 +380,9 @@ module GoodJob
     end
 
     def smaller_number_is_higher_priority
-      rails_config[:smaller_number_is_higher_priority]
+      return rails_config[:smaller_number_is_higher_priority] unless rails_config[:smaller_number_is_higher_priority].nil?
+
+      DEFAULT_SMALLER_NUMBER_IS_HIGHER_PRIORITY
     end
 
     def dashboard_default_locale

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -579,14 +579,14 @@ RSpec.describe GoodJob::Job do
         expect(described_class.priority_ordered.pluck(:priority)).to eq([-50, 50])
       end
 
-      it 'smaller_number_is_higher_priority=false orders with smaller priority being LOWER priority' do
+      it 'smaller_number_is_higher_priority=false orders with smaller number being LOWER priority' do
         allow(Rails.application.config).to receive(:good_job).and_return({ smaller_number_is_higher_priority: false })
         expect(described_class.priority_ordered.pluck(:priority)).to eq([50, -50])
       end
 
-      it 'smaller_number_is_higher_priority=false orders with lower priority being LOWER priority' do
+      it 'smaller_number_is_higher_priority=nil orders with smaller number being HIGHER priority' do
         allow(Rails.application.config).to receive(:good_job).and_return({})
-        expect(described_class.priority_ordered.pluck(:priority)).to eq([50, -50])
+        expect(described_class.priority_ordered.pluck(:priority)).to eq([-50, 50])
       end
     end
 


### PR DESCRIPTION
I removed this config value and noticed that it still falls back to the old behaviour.