### PR TITLE
Fix a rails 6.1 deprecation warning for the duration attribute

### DIFF
--- a/app/models/good_job/discrete_execution.rb
+++ b/app/models/good_job/discrete_execution.rb
@@ -14,6 +14,9 @@ module GoodJob # :nodoc:
 
     alias_attribute :performed_at, :created_at
 
+    # TODO: Remove when support for Rails 6.1 is dropped
+    attribute :duration, :interval
+
     def number
       serialized_params.fetch('executions', 0) + 1
     end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -972,7 +972,7 @@ RSpec.describe GoodJob::Job do
             created_at: within(0.001).of(good_job.performed_at),
             scheduled_at: within(0.001).of(good_job.created_at),
             finished_at: within(1.second).of(Time.current),
-            duration: be_present,
+            duration: be_a(ActiveSupport::Duration),
             error: nil,
             serialized_params: good_job.serialized_params
           )
@@ -1011,7 +1011,7 @@ RSpec.describe GoodJob::Job do
               created_at: within(1.second).of(Time.current),
               scheduled_at: within(1.second).of(Time.current),
               finished_at: within(1.second).of(Time.current),
-              duration: be_present
+              duration: be_a(ActiveSupport::Duration)
             )
           end
         end
@@ -1036,7 +1036,7 @@ RSpec.describe GoodJob::Job do
             expect(good_job.discrete_executions.first).to have_attributes(
               performed_at: within(1.second).of(Time.current),
               finished_at: within(1.second).of(Time.current),
-              duration: be_present
+              duration: be_a(ActiveSupport::Duration)
             )
           end
         end


### PR DESCRIPTION
This is only a thing on Rails 6.1, I noticed this in the CI output for the system tests. It doesn't seem to terribly matter right now if it is returned as a string or interval but I don't think this distinction was intended. 

```
DEPRECATION WARNING: The behavior of the `:interval` type will be changing in Rails 7.0
to return an `ActiveSupport::Duration` object. If you'd like to keep
the old behavior, you can add this line to GoodJob::Execution model:

  attribute :duration, :string

If you'd like the new behavior today, you can add this line:

  attribute :duration, :interval
 (called from block (3 levels) in perform at /home/runner/work/good_job/good_job/app/models/good_job/base_execution.rb:440)
```