### PR TITLE
Only set duration attribute to interval on Rails 6.1

### DIFF
--- a/app/models/good_job/discrete_execution.rb
+++ b/app/models/good_job/discrete_execution.rb
@@ -15,7 +15,7 @@ module GoodJob # :nodoc:
     alias_attribute :performed_at, :created_at
 
     # TODO: Remove when support for Rails 6.1 is dropped
-    attribute :duration, :interval
+    attribute :duration, :interval if ActiveJob.version.canonical_segments.take(2) == [6, 1]
 
     def number
       serialized_params.fetch('executions', 0) + 1


### PR DESCRIPTION
This causes `ActiveRecord::ConnectionNotEstablished` issues in 4.0.2 with Tapioca, this works around the problem by not setting it if not needed. I think it's a bug in Tapioca so I opened https://github.com/Shopify/tapioca/issues/1950 but figured this might be a useful workaround in the meantime.

This line was originally shipped in https://github.com/bensheldon/good_job/pull/1408, 4.0.1 does not causes issues for me.