### PR TITLE
v3.99: Have `GoodJob.v4_ready?` check all migrations, not just discrete jobs

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -272,7 +272,7 @@ module GoodJob
   # Tests whether GoodJob can be safely upgraded to v4
   # @return [Boolean]
   def self.v4_ready?
-    GoodJob::Job.discrete_support? && GoodJob::Job.where(finished_at: nil).where(is_discrete: [nil, false]).none?
+    GoodJob.migrated? && GoodJob::Job.discrete_support? && GoodJob::Job.where(finished_at: nil).where(is_discrete: [nil, false]).none?
   end
 
   # Deprecator for providing deprecation warnings.


### PR DESCRIPTION
Related to #1415. 

Examples this should help:

- #1404
- #1405
- #1413 