### PR TITLE
Use rails enum for `error_event` and `lock_type`

### DIFF
--- a/app/models/concerns/good_job/error_events.rb
+++ b/app/models/concerns/good_job/error_events.rb
@@ -5,41 +5,20 @@ module GoodJob
   module ErrorEvents
     extend ActiveSupport::Concern
 
-    ERROR_EVENTS = [
-      ERROR_EVENT_INTERRUPTED = 'interrupted',
-      ERROR_EVENT_UNHANDLED = 'unhandled',
-      ERROR_EVENT_HANDLED = 'handled',
-      ERROR_EVENT_RETRIED = 'retried',
-      ERROR_EVENT_RETRY_STOPPED = 'retry_stopped',
-      ERROR_EVENT_DISCARDED = 'discarded',
-    ].freeze
-
-    ERROR_EVENT_ENUMS = {
-      ERROR_EVENT_INTERRUPTED => 0,
-      ERROR_EVENT_UNHANDLED => 1,
-      ERROR_EVENT_HANDLED => 2,
-      ERROR_EVENT_RETRIED => 3,
-      ERROR_EVENT_RETRY_STOPPED => 4,
-      ERROR_EVENT_DISCARDED => 5,
-    }.freeze
-
-    # TODO: GoodJob v4 can make this an `enum` once migrations are guaranteed.
-    def error_event
-      return unless self.class.columns_hash['error_event']
-
-      enum = read_attribute(:error_event)
-      return unless enum
-
-      ERROR_EVENT_ENUMS.key(enum)
-    end
-
-    def error_event=(event)
-      return unless self.class.columns_hash['error_event']
-
-      enum = ERROR_EVENT_ENUMS[event]
-      raise(ArgumentError, "Invalid error_event: #{event}") if event && !enum
-
-      write_attribute(:error_event, enum)
+    included do
+      error_event_enum = {
+        interrupted: 0,
+        unhandled: 1,
+        handled: 2,
+        retried: 3,
+        retry_stopped: 4,
+        discarded: 5,
+      }
+      if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.a')
+        enum :error_event, error_event_enum, validate: { allow_nil: true }
+      else
+        enum error_event: error_event_enum
+      end
     end
   end
 end

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -146,7 +146,7 @@ module GoodJob
 
           self.class.transaction(joinable: false, requires_new: true) do
             new_active_job = active_job.retry_job(wait: 0, error: error)
-            self.error_event = ERROR_EVENT_RETRIED if error
+            self.error_event = :retried if error
             save!
           end
         end
@@ -212,7 +212,7 @@ module GoodJob
         update(
           finished_at: Time.current,
           error: self.class.format_error(job_error),
-          error_event: ERROR_EVENT_DISCARDED
+          error_event: :discarded
         )
       end
 

--- a/lib/good_job/capsule_tracker.rb
+++ b/lib/good_job/capsule_tracker.rb
@@ -84,7 +84,7 @@ module GoodJob # :nodoc:
             if !advisory_locked? || !advisory_locked_connection?
               @record.class.transaction do
                 @record.advisory_lock!
-                @record.update(lock_type: GoodJob::Process::LOCK_TYPE_ADVISORY)
+                @record.update(lock_type: :advisory)
               end
               @advisory_locked_connection = WeakRef.new(@record.class.connection)
             end

--- a/spec/app/models/concerns/good_job/filterable_spec.rb
+++ b/spec/app/models/concerns/good_job/filterable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GoodJob::Filterable do
       serialized_params: { example_key: 'example_value' },
       labels: %w[buffalo gopher],
       error: "ExampleJob::ExampleError: a message",
-      error_event: GoodJob::ErrorEvents::ERROR_EVENT_RETRIED
+      error_event: "retried"
     )
   end
 

--- a/spec/lib/good_job/active_job_extensions/interrupt_errors_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/interrupt_errors_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::InterruptErrors do
       expect { GoodJob.perform_inline }.to raise_error(GoodJob::InterruptError)
       expect(GoodJob::Job.last).to have_attributes(
         error: start_with('GoodJob::InterruptError: Interrupted after starting perform at'),
-        error_event: GoodJob::Job::ERROR_EVENT_INTERRUPTED
+        error_event: "interrupted"
       )
     end
 
@@ -44,7 +44,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::InterruptErrors do
           performed_at: be_blank,
           finished_at: be_blank,
           error: start_with('GoodJob::InterruptError: Interrupted after starting perform at'),
-          error_event: GoodJob::Job::ERROR_EVENT_RETRIED
+          error_event: "retried"
         )
 
         initial_discrete_execution = job.discrete_executions.first
@@ -53,7 +53,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::InterruptErrors do
           finished_at: be_present,
           duration: be_present,
           error: start_with('GoodJob::InterruptError: Interrupted after starting perform at'),
-          error_event: GoodJob::Job::ERROR_EVENT_INTERRUPTED
+          error_event: "interrupted"
         )
 
         retried_discrete_execution = job.discrete_executions.last
@@ -62,7 +62,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::InterruptErrors do
           finished_at: be_present,
           duration: be_present,
           error: start_with('GoodJob::InterruptError: Interrupted after starting perform at'),
-          error_event: GoodJob::Job::ERROR_EVENT_RETRIED
+          error_event: "retried"
         )
       end
     end


### PR DESCRIPTION
A bit more cleanup now that v4 is released.

Rails 7.2 will deprecate the legacy enum notation but the new one was only introduced in Rails 7.0 so a bit of version introspection is needed here.

I also had to notice that proper validations are only available in rails 7.1. I think that's fine, the test matrix will take care of this but its not as nice as I expected it would be.

There was a duplicate `table_name` in `process.rb`, I've removed that in the process of this.