### PR TITLE
Add keepalive SQL query to Notifier

### DIFF
--- a/spec/lib/good_job/notifier_spec.rb
+++ b/spec/lib/good_job/notifier_spec.rb
@@ -134,6 +134,20 @@ RSpec.describe GoodJob::Notifier do
 
       notifier.shutdown
     end
+
+    it 'executes a noop SQL query every 10 seconds to keep the connection alive' do
+      stub_const("GoodJob::Notifier::KEEPALIVE_INTERVAL", 0.1)
+      stub_const("GoodJob::Notifier::WAIT_INTERVAL", 0.1)
+
+      notifier = described_class.new(enable_listening: true)
+      original_keepalive = notifier.instance_variable_get(:@last_keepalive_time)
+
+      expect(notifier).to be_listening(timeout: 2)
+      sleep 0.2
+      expect(notifier.instance_variable_get(:@last_keepalive_time)).to be > original_keepalive
+
+      notifier.shutdown
+    end
   end
 
   describe '#shutdown' do


### PR DESCRIPTION
Related to #1417

Add a noop SQL query every 10 seconds to keep the connection alive. I expect that this could surface more database exceptions that are currently being ignored because the socket isn't actually being exercised solely by running `wait_for_notify`.

I'm not sure if it matters if this is being run _after_ `wait_for_notify` or if it should be before in the loop. Either way this loop should be fairly tight (once every second).