### PR TITLE
Fix nonexistant association error between DiscreteExecution and Execution

### DIFF
--- a/app/models/good_job/discrete_execution.rb
+++ b/app/models/good_job/discrete_execution.rb
@@ -7,7 +7,6 @@ module GoodJob # :nodoc:
     self.table_name = 'good_job_executions'
     self.implicit_order_column = 'created_at'
 
-    belongs_to :execution, class_name: 'GoodJob::Execution', foreign_key: 'active_job_id', primary_key: 'active_job_id', inverse_of: :discrete_executions, optional: true
     belongs_to :job, class_name: 'GoodJob::Job', foreign_key: 'active_job_id', primary_key: 'active_job_id', inverse_of: :discrete_executions, optional: true
 
     scope :finished, -> { where.not(finished_at: nil) }


### PR DESCRIPTION
Fixes #1424

Remove the `belongs_to :execution` association from the `DiscreteExecution` model to fix the inverse association error.