### PR TITLE
Refactor inline adapter to enable deferred execution after enqueue to allow batch-callbacks to use transaction-based advisory lock

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -367,7 +367,8 @@ module GoodJob
       begin
         yield
       ensure
-        advisory_unlock(key: key, function: self.class.advisory_unlockable_function(function))
+        unlock_function = self.class.advisory_unlockable_function(function)
+        advisory_unlock(key: key, function: unlock_function) if unlock_function
       end
     end
 

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -7,6 +7,7 @@ require_relative "good_job/version"
 require_relative "good_job/engine"
 
 require_relative "good_job/adapter"
+require_relative "good_job/adapter/inline_buffer"
 require_relative "active_job/queue_adapters/good_job_adapter"
 require_relative "good_job/active_job_extensions/batches"
 require_relative "good_job/active_job_extensions/concurrency"

--- a/lib/good_job/adapter/inline_buffer.rb
+++ b/lib/good_job/adapter/inline_buffer.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/module/attribute_accessors_per_thread'
+
+module GoodJob
+  class Adapter
+    # The InlineBuffer is integrated into the Adapter and captures jobs that have been enqueued inline.
+    # The purpose is allow job records to be persisted, in a locked state, while within a transaction,
+    # and then execute the jobs after the transaction has been committed to ensure that the jobs
+    # do not run within a transaction.
+    #
+    # @private This is intended for internal GoodJob usage only.
+    class InlineBuffer
+      # @!attribute [rw] current_buffer
+      #   @!scope class
+      #   Current buffer of jobs to be enqueued.
+      #   @return [GoodJob::Adapter::InlineBuffer, nil]
+      thread_mattr_accessor :current_buffer
+
+      # This block should be used to wrap the transaction that could enqueue jobs.
+      # @yield The block that may enqueue jobs.
+      # @return [Proc] A proc that will execute enqueued jobs after the transaction has been committed.
+      # @example Wrapping a transaction
+      #   buffer = GoodJob::Adapter::InlineBuffer.capture do
+      #     ActiveRecord::Base.transaction do
+      #       MyJob.perform_later
+      #     end
+      #   end
+      #   buffer.call
+      def self.capture
+        if current_buffer
+          yield
+          return proc {}
+        end
+
+        begin
+          self.current_buffer = new
+          yield
+          current_buffer.to_proc
+        ensure
+          self.current_buffer = nil
+        end
+      end
+
+      # Used within the adapter to wrap inline job execution
+      def self.perform_now_or_defer(&block)
+        if defer?
+          current_buffer.defer(block)
+        else
+          yield
+        end
+      end
+
+      def self.defer?
+        current_buffer.present?
+      end
+
+      def initialize
+        @callables = []
+      end
+
+      def defer(callable)
+        @callables << callable
+      end
+
+      def to_proc
+        proc do
+          @callables.map(&:call)
+        end
+      end
+    end
+  end
+end

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -33,6 +33,8 @@ module ::THREAD_HAS_RUN; end
 module ::THREAD_JOBS; end
 module ::TestError; end
 module ::TestJob; end
+module ::SuccessJob; end
+module ::ErrorJob; end
 module ::WAIT_EVENT; end
 module ::TestJob::Error; end
 module ::TestJob::ExpectedError; end

--- a/spec/lib/good_job/adapter/inline_buffer_spec.rb
+++ b/spec/lib/good_job/adapter/inline_buffer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GoodJob::Adapter::InlineBuffer do
+  before do
+    stub_const 'SuccessJob', (Class.new(ActiveJob::Base) do
+      def perform
+        true
+      end
+    end)
+    SuccessJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+
+    stub_const 'ErrorJob', (Class.new(ActiveJob::Base) do
+      def perform
+        raise 'Error'
+      end
+    end)
+    ErrorJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+  end
+
+  context "when using enqueue_all" do
+    it "defers enqueue_all" do
+      Rails.application.executor.wrap do
+        buffer = described_class.capture do
+          SuccessJob.queue_adapter.enqueue_all([SuccessJob.new, SuccessJob.new])
+          expect(GoodJob::Job.count).to eq 2
+          expect(GoodJob::Job.all).to all have_attributes(finished_at: nil)
+        end
+
+        buffer.call
+
+        expect(GoodJob::Job.all).to all have_attributes(finished_at: be_present)
+      end
+    end
+
+    it "defers enqueue_all with errors" do
+      Rails.application.executor.wrap do
+        buffer = described_class.capture do
+          ErrorJob.queue_adapter.enqueue_all([ErrorJob.new, SuccessJob.new])
+          expect(GoodJob::Job.count).to eq 2
+          expect(GoodJob::Job.all).to all have_attributes(finished_at: nil)
+        end
+
+        expect { buffer.call }.to raise_error(/Error/)
+        expect(GoodJob::Job.find_by(job_class: "ErrorJob")).to have_attributes(finished_at: be_present, error: be_present, error_event: 'unhandled')
+        expect(GoodJob::Job.find_by(job_class: "SuccessJob")).to have_attributes(finished_at: nil)
+      end
+    end
+  end
+
+  context "when using enqueue" do
+    it "defers inline enqueued jobs" do
+      Rails.application.executor.wrap do
+        buffer = described_class.capture do
+          SuccessJob.perform_later
+          expect(GoodJob::Job.count).to eq 1
+        end
+        buffer.call
+
+        expect(GoodJob::Job.count).to eq 1
+        expect(GoodJob::Job.first).to have_attributes(finished_at: be_present)
+      end
+    end
+
+    it "defers inline enqueued jobs with errors" do
+      Rails.application.executor.wrap do
+        buffer = described_class.capture do
+          ErrorJob.perform_later
+          expect(GoodJob::Job.count).to eq 1
+        end
+
+        expect { buffer.call }.to raise_error(/Error/)
+        expect(GoodJob::Job.first).to have_attributes(finished_at: be_present, error: be_present, error_event: 'unhandled')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm not quite sure whether the "juice is worth the squeeze" here, but it feels like the more correct thing to do.

Eventually, GoodJob will move to using a combination of row-level locking (to execute jobs) and transaction-level advisory locks (for control/synchronization). To use transaction-level advisory locks (instead of the current connection-based advisory locks), the locks have to be wrapped in a transaction. I would prefer jobs not execute within a transaction, but this presents a problem for Inline Execution mode in places where it's necessary to take a lock, and enqueue a job. Though this is (right now, maybe always) just a problem for the batch-callback job enqueueing. Which means, this is really a bunch of effort solely so that:

- Batch callbacks can be synchronized with a transaction-based advisory lock
- ...and when running in inline execution mode,
- ...the batch-callback job is not executed inline within a transaction.