### PR TITLE
Ensure remaining inline jobs are unlocked when one job raises in Adapter#enqueue_all

### DIFF
--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -92,6 +92,8 @@ module GoodJob
               inline_job = inline_jobs.shift
               perform_inline(inline_job, notify: false)
             end
+          ensure
+            inline_jobs.each(&:advisory_unlock)
           end
         end
 

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -38,6 +38,9 @@ module ::TestJob::Error; end
 module ::TestJob::ExpectedError; end
 module ::TestJob::RunError; end
 module ::TestJob::SuccessCallbackJob; end
+module ::SuccessJob; end
+module ::ErrorJob; end
+module ::ErrorJob::Error; end
 module ::TestRecord; end
 module ::WrapperJob; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -200,9 +200,9 @@ RSpec.describe GoodJob::Adapter do
     context 'when the adapter is inline' do
       let(:adapter) { described_class.new(execution_mode: :inline) }
 
-      it 'executes the jobs immediately' do
+      before do
         stub_const 'PERFORMED', []
-        stub_const 'TestJob', (Class.new(ActiveJob::Base) do
+        stub_const 'SuccessJob', (Class.new(ActiveJob::Base) do
           def perform
             raise "Not advisory locked" unless GoodJob::Job.find(provider_job_id).advisory_locked?
 
@@ -210,10 +210,42 @@ RSpec.describe GoodJob::Adapter do
           end
         end)
 
-        active_jobs = [TestJob.new, TestJob.new]
+        stub_const 'ErrorJob', (Class.new(ActiveJob::Base) do
+          def perform
+            raise "Not advisory locked" unless GoodJob::Job.find(provider_job_id).advisory_locked?
+
+            PERFORMED << Time.current
+            raise TestJob::Error, "Error"
+          end
+        end)
+        stub_const 'TestJob::Error', Class.new(StandardError)
+      end
+
+      it 'executes the jobs immediately' do
+        active_jobs = [SuccessJob.new, SuccessJob.new]
         result = adapter.enqueue_all(active_jobs)
         expect(result).to eq 2
         expect(PERFORMED.size).to eq 2
+      end
+
+      it 'raises an exception when the job errors' do
+        active_jobs = [ErrorJob.new, SuccessJob.new]
+        expect do
+          adapter.enqueue_all(active_jobs)
+        end.to raise_error(TestJob::Error)
+
+        expect(PERFORMED.size).to eq 1
+      end
+
+      it 'does not execute future scheduled jobs' do
+        allow(GoodJob::Notifier).to receive(:notify)
+        scheduled_at = 1.minute.from_now
+        future_job = SuccessJob.new.tap { |job| job.scheduled_at = scheduled_at }
+
+        adapter.enqueue_all([SuccessJob.new, future_job])
+        expect(PERFORMED.size).to eq 1
+        expect(GoodJob::Notifier).to have_received(:notify).once
+        expect(GoodJob::Notifier).to have_received(:notify).with(queue_name: 'default', count: 1, scheduled_at: scheduled_at)
       end
     end
   end


### PR DESCRIPTION
Bug introduced in #1426