### PR TITLE
All running jobs now have `performed_at` set so use that in status query; fix flaky test that took advisory lock in `before` block

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -57,9 +57,9 @@ module GoodJob
     # Execution errored, will run in the future
     scope :retried, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.gt(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).where(params_execution_count.gt(1)) }
     # Immediate/Scheduled time to run has passed, waiting for an available thread run
-    scope :queued, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
+    scope :queued, -> { where(performed_at: nil, finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
     # Advisory locked and executing
-    scope :running, -> { where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
+    scope :running, -> { where.not(performed_at: nil).where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
     # Finished executing (succeeded or discarded)
     scope :finished, -> { where.not(finished_at: nil) }
     # Completed executing successfully

--- a/spec/app/filters/good_job/jobs_filter_spec.rb
+++ b/spec/app/filters/good_job/jobs_filter_spec.rb
@@ -29,13 +29,9 @@ RSpec.describe GoodJob::JobsFilter do
     running_active_job = ExampleJob.perform_later('success')
     running_job = GoodJob::Job.find(running_active_job.provider_job_id)
     running_job.update!(
+      performed_at: 1.minute.ago,
       finished_at: nil
     )
-    running_job.advisory_lock
-  end
-
-  after do
-    GoodJob::Job.advisory_unlock_session
   end
 
   describe '#job_classes' do


### PR DESCRIPTION
Connects to #1440 