### PR TITLE
Redefine `Batch#finished_at` to mean all callback jobs have finished too; add `Batch#jobs_finished_at` to allow not deleting batches until all their callback jobs complete

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,5 @@
 --color
 --order random
 --require spec_helper
+--require ./spec/support/pre_documentation_formatter.rb \
+--format PreDocumentationFormatter

--- a/app/models/good_job/batch.rb
+++ b/app/models/good_job/batch.rb
@@ -26,10 +26,12 @@ module GoodJob
       :enqueued_at,
       :finished_at,
       :discarded_at,
+      :jobs_finished_at,
       :enqueued?,
       :finished?,
       :succeeded?,
       :discarded?,
+      :jobs_finished?,
       :description,
       :description=,
       :on_finish,
@@ -95,8 +97,12 @@ module GoodJob
         record.transaction do
           record.with_advisory_lock(function: "pg_advisory_xact_lock") do
             record.enqueued_at_will_change!
+            record.jobs_finished_at_will_change! if GoodJob::BatchRecord.jobs_finished_at_migrated?
             record.finished_at_will_change!
-            record.update!(enqueued_at: nil, finished_at: nil)
+
+            update_attributes = { discarded_at: nil, finished_at: nil }
+            update_attributes[:jobs_finished_at] = nil if GoodJob::BatchRecord.jobs_finished_at_migrated?
+            record.update!(**update_attributes)
           end
         end
       end
@@ -142,7 +148,9 @@ module GoodJob
         buffer = GoodJob::Adapter::InlineBuffer.capture do
           record.transaction do
             record.with_advisory_lock(function: "pg_advisory_xact_lock") do
-              record.update!(discarded_at: nil, finished_at: nil)
+              update_attributes = { discarded_at: nil, finished_at: nil }
+              update_attributes[:jobs_finished_at] = nil if GoodJob::BatchRecord.jobs_finished_at_migrated?
+              record.update!(update_attributes)
               record.jobs.discarded.each(&:retry_job)
               record._continue_discard_or_finish(lock: false)
             end

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -40,6 +40,7 @@ module GoodJob
     set_callback :perform_unlocked, :after, :continue_discard_or_finish_batch
 
     belongs_to :batch, class_name: 'GoodJob::BatchRecord', inverse_of: :jobs, optional: true
+    belongs_to :callback_batch, class_name: 'GoodJob::BatchRecord', foreign_key: :batch_callback_id, inverse_of: :callback_jobs, optional: true
     belongs_to :locked_by_process, class_name: "GoodJob::Process", foreign_key: :locked_by_id, inverse_of: :locked_jobs, optional: true
     has_many :executions, class_name: 'GoodJob::Execution', foreign_key: 'active_job_id', primary_key: "id", inverse_of: :job, dependent: :delete_all
 
@@ -743,6 +744,7 @@ module GoodJob
 
     def continue_discard_or_finish_batch
       batch._continue_discard_or_finish(self) if batch.present?
+      callback_batch._continue_discard_or_finish if callback_batch.present?
     end
 
     def active_job_data

--- a/demo/db/migrate/20240801143343_add_jobs_finished_at_to_good_job_batches.rb
+++ b/demo/db/migrate/20240801143343_add_jobs_finished_at_to_good_job_batches.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddJobsFinishedAtToGoodJobBatches < ActiveRecord::Migration[7.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_batches, :jobs_finished_at)
+      end
+    end
+
+    change_table :good_job_batches do |t|
+      t.datetime :jobs_finished_at
+    end
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_13_151310) do
+ActiveRecord::Schema.define(version: 2024_08_01_143343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2024_06_13_151310) do
     t.datetime "enqueued_at"
     t.datetime "discarded_at"
     t.datetime "finished_at"
+    t.datetime "jobs_finished_at"
   end
 
   create_table "good_job_executions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -46,6 +46,7 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       t.datetime :enqueued_at
       t.datetime :discarded_at
       t.datetime :finished_at
+      t.datetime :jobs_finished_at
     end
 
     create_table :good_job_executions, id: :uuid do |t|

--- a/lib/generators/good_job/templates/update/migrations/02_add_jobs_finished_at_to_good_job_batches.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/02_add_jobs_finished_at_to_good_job_batches.rb.erb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddJobsFinishedAtToGoodJobBatches < ActiveRecord::Migration<%= migration_version %>
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_batches, :jobs_finished_at)
+      end
+    end
+
+    change_table :good_job_batches do |t|
+      t.datetime :jobs_finished_at
+    end
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -171,10 +171,10 @@ module GoodJob
     _shutdown_all(Capsule.instances, :restart, timeout: timeout)
   end
 
-  # Sends +#shutdown+ or +#restart+ to executable objects ({GoodJob::Notifier}, {GoodJob::Poller}, {GoodJob::Scheduler}, {GoodJob::MultiScheduler}, {GoodJob::CronManager})
+  # Sends +#shutdown+ or +#restart+ to executable objects ({GoodJob::Notifier}, {GoodJob::Poller}, {GoodJob::Scheduler}, {GoodJob::MultiScheduler}, {GoodJob::CronManager}, {GoodJob::SharedExecutor})
   # @param executables [Array<Notifier, Poller, Scheduler, MultiScheduler, CronManager, SharedExecutor>] Objects to shut down.
-  # @param method_name [:symbol] Method to call, e.g. +:shutdown+ or +:restart+.
-  # @param timeout [nil,Numeric]
+  # @param method_name [Symbol] Method to call, e.g. +:shutdown+ or +:restart+.
+  # @param timeout [nil, Numeric] Seconds to wait for actively executing jobs to finish.
   # @param after [Array<Notifier, Poller, Scheduler, MultiScheduler, CronManager, SharedExecutor>] Objects to shut down after initial executables shut down.
   # @return [void]
   def self._shutdown_all(executables, method_name = :shutdown, timeout: -1, after: [])
@@ -290,7 +290,7 @@ module GoodJob
   # For use in tests/CI to validate GoodJob is up-to-date.
   # @return [Boolean]
   def self.migrated?
-    true
+    GoodJob::BatchRecord.jobs_finished_at_migrated?
   end
 end
 

--- a/spec/app/models/good_job/batch_spec.rb
+++ b/spec/app/models/good_job/batch_spec.rb
@@ -117,11 +117,15 @@ describe GoodJob::Batch do
 
       batch.retry
 
-      expect(batch.reload).to be_enqueued
+      batch.reload
+      expect(batch).to have_attributes(discarded_at: nil, jobs_finished_at: nil, finished_at: nil)
+      expect(batch).to be_enqueued
 
       GoodJob.perform_inline
 
-      expect(batch.reload).to be_succeeded
+      batch.reload
+      expect(batch).to have_attributes(discarded_at: nil, jobs_finished_at: be_present, finished_at: be_present)
+      expect(batch).to be_succeeded
     end
   end
 


### PR DESCRIPTION
Connects to #1387

Add logic to delete batches only after their callback jobs have completed.