### PR TITLE
Fix a few method redefinition warnings

### DIFF
--- a/app/models/concerns/good_job/error_events.rb
+++ b/app/models/concerns/good_job/error_events.rb
@@ -15,9 +15,9 @@ module GoodJob
         discarded: 5,
       }
       if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.a')
-        enum :error_event, error_event_enum, validate: { allow_nil: true }
+        enum :error_event, error_event_enum, validate: { allow_nil: true }, scopes: false
       else
-        enum error_event: error_event_enum
+        enum error_event: error_event_enum, _scopes: false
       end
     end
   end

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -57,7 +57,11 @@ module GoodJob
     # Execution errored, will run in the future
     scope :retried, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.gt(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).where(params_execution_count.gt(1)) }
     # Immediate/Scheduled time to run has passed, waiting for an available thread run
-    scope :queued, -> { where(performed_at: nil, finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
+    scope :queued, -> { where(performed_at: nil, finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))) }
+    # Advisory locked and executing
+    scope :running, -> { where.not(performed_at: nil).where(finished_at: nil) }
+    # Finished executing (succeeded or discarded)
+    scope :finished, -> { where.not(finished_at: nil) }
     # Completed executing successfully
     scope :succeeded, -> { finished.where(error: nil) }
     # Errored but will not be retried
@@ -135,24 +139,6 @@ module GoodJob
     # @!scope class
     # @return [ActiveRecord::Relation]
     scope :schedule_ordered, -> { order(coalesce_scheduled_at_created_at.asc) }
-
-    # Get completed jobs before the given timestamp. If no timestamp is
-    # provided, get *all* completed jobs. By default, GoodJob
-    # destroys jobs after they're completed, meaning this returns no jobs.
-    # However, if you have changed {GoodJob.preserve_job_records}, this may
-    # find completed Jobs.
-    # @!method finished(timestamp = nil)
-    # @!scope class
-    # @param timestamp (Float)
-    #   Get jobs that finished before this time (in epoch time).
-    # @return [ActiveRecord::Relation]
-    scope :finished, ->(timestamp = nil) { timestamp ? where(arel_table['finished_at'].lteq(bind_value('finished_at', timestamp, ActiveRecord::Type::DateTime))) : where.not(finished_at: nil) }
-
-    # Get Jobs that started but not finished yet.
-    # @!method running
-    # @!scope class
-    # @return [ActiveRecord::Relation]
-    scope :running, -> { where.not(performed_at: nil).where(finished_at: nil) }
 
     # Get Jobs on queues that match the given queue string.
     # @!method queue_string(string)

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -58,10 +58,6 @@ module GoodJob
     scope :retried, -> { where(finished_at: nil).where(coalesce_scheduled_at_created_at.gt(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).where(params_execution_count.gt(1)) }
     # Immediate/Scheduled time to run has passed, waiting for an available thread run
     scope :queued, -> { where(performed_at: nil, finished_at: nil).where(coalesce_scheduled_at_created_at.lteq(bind_value('coalesce', Time.current, ActiveRecord::Type::DateTime))).joins_advisory_locks.where(pg_locks: { locktype: nil }) }
-    # Advisory locked and executing
-    scope :running, -> { where.not(performed_at: nil).where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
-    # Finished executing (succeeded or discarded)
-    scope :finished, -> { where.not(finished_at: nil) }
     # Completed executing successfully
     scope :succeeded, -> { finished.where(error: nil) }
     # Errored but will not be retried

--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -20,9 +20,9 @@ module GoodJob # :nodoc:
       advisory: 0,
     }
     if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.a')
-      enum :lock_type, lock_type_enum, validate: { allow_nil: true }
+      enum :lock_type, lock_type_enum, validate: { allow_nil: true }, scopes: false
     else
-      enum lock_type: lock_type_enum
+      enum lock_type: lock_type_enum, _scopes: false
     end
 
     has_many :locked_jobs, class_name: "GoodJob::Job", foreign_key: :locked_by_id, inverse_of: :locked_by_process, dependent: nil


### PR DESCRIPTION
2 enum values conflict with already existing scopes: "retried" and "discarded" (oops) (#1420)

"running" and "finished" got moved from the discrete execution cleanup (#1427). This change I'm not so certain about which of these two is the correct one. Tests do pass but you'd better check these two anyways, this just removes the earlier definition:

```rb
# first
scope :running, -> { where.not(performed_at: nil).where(finished_at: nil).joins_advisory_locks.where.not(pg_locks: { locktype: nil }) }
# second
scope :running, -> { where.not(performed_at: nil).where(finished_at: nil) }

# first
scope :finished, -> { where.not(finished_at: nil) }
# second
scope :finished, ->(timestamp = nil) { timestamp ? where(arel_table['finished_at'].lteq(bind_value('finished_at', timestamp, ActiveRecord::Type::DateTime))) : where.not(finished_at: nil) }
```