### PR TITLE
Run tests with warnings enabled

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,6 @@ GoodJob::Engine.routes.draw do
 
   scope :frontend, controller: :frontends, defaults: { version: GoodJob::VERSION.tr(".", "-") } do
     get "modules/:version/:id", action: :module, as: :frontend_module, constraints: { format: 'js' }
-    get "static/:version/:id", action: :static, as: :frontend_static, constraints: { format: %w[css js svg] }
+    get "static/:version/:id", action: :static, as: :frontend_static
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,8 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.warnings = true
+
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
   # have no way to turn it off -- the option exists only for backwards
   # compatibility in RSpec 3). It causes shared context metadata to be

--- a/spec/support/reset_rails_queue_adapter.rb
+++ b/spec/support/reset_rails_queue_adapter.rb
@@ -6,12 +6,14 @@ module ActiveJob
   module TestHelper
     # Avoid calling #descendants because JRuby has trouble with it
     # https://github.com/jruby/jruby/issues/6896
+    silence_redefinition_of_method :queue_adapter_changed_jobs
     def queue_adapter_changed_jobs
       []
     end
 
     module TestQueueAdapter
       module ClassMethods
+        silence_redefinition_of_method :queue_adapter
         def queue_adapter # rubocop:disable Lint/UselessMethodDefinition
           super
         end

--- a/spec/support/selenium.rb
+++ b/spec/support/selenium.rb
@@ -7,6 +7,7 @@ require "action_dispatch/system_testing/browser"
 module ActionDispatch
   module SystemTesting
     class Browser # :nodoc:
+      silence_redefinition_of_method :resolve_driver_path
       def resolve_driver_path(namespace)
         # The path method has been deprecated in 4.20.0
         namespace::Service.driver_path = if Gem::Version.new(::Selenium::WebDriver::VERSION) >= Gem::Version.new("4.20.0")


### PR DESCRIPTION
`format` doesn't accept an array. This currently creates a format constraint that looks like this,
and emits a warning because characters appear multiple times in the character class:
`/\A["css", "js", "svg"]\Z/`

The constraint is actually not needed, the controller already handles this. Tests for this are already present.

---

A few test methods are redefined for jruby reasons. That doesn't actually run in CI right now so I'm not sure if this interferes with that, internally `silence_redefinition_of_method` does some aliasing.