### PR TITLE
v5: Update compatibility matrix, remove compatibility code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         pg: [16]
         include:
           - ruby: 3.3
-            pg: 11
+            pg: 12
 
     env:
       PGHOST: localhost

--- a/README.md
+++ b/README.md
@@ -164,9 +164,9 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
 
 ## Compatibility
 
-- **Ruby on Rails:** 6.0+
-- **Ruby:** Ruby 2.6+. JRuby 9.3+
-- **Postgres:** 10.0+
+- **Ruby on Rails:** 6.1+
+- **Ruby:** Ruby 3.0+. JRuby 9.4+
+- **Postgres:** 12.0+
 
 ## Configuration
 

--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -36,18 +36,9 @@ module GoodJob
 
         # TODO: turn this into proper bind parameters in Arel
         tsvector = "(to_tsvector('english', id::text) || to_tsvector('english', COALESCE(active_job_id::text, '')) || to_tsvector('english', serialized_params) || to_tsvector('english', COALESCE(error, '')) || to_tsvector('english', COALESCE(array_to_string(labels, ' '), '')))"
-        to_tsquery_function = database_supports_websearch_to_tsquery? ? 'websearch_to_tsquery' : 'plainto_tsquery'
-        where("#{tsvector} @@ #{to_tsquery_function}(?)", query)
-          .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, #{to_tsquery_function}(?))"), query]) => 'DESC')
+        where("#{tsvector} @@ websearch_to_tsquery(?)", query)
+          .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, websearch_to_tsquery(?))"), query]) => 'DESC')
       end)
-    end
-
-    class_methods do
-      def database_supports_websearch_to_tsquery?
-        return @_database_supports_websearch_to_tsquery if defined?(@_database_supports_websearch_to_tsquery)
-
-        @_database_supports_websearch_to_tsquery = connection.postgresql_version >= 110000
-      end
     end
   end
 end

--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -84,11 +84,7 @@ module GoodJob
       end
     end
 
-    if Rails.gem_version < Gem::Version.new('6.1.0.alpha')
-      # serialize does not yet take a default value, must set via Attributes API
-      attribute :serialized_properties, :json, default: -> { {} }
-      serialize :serialized_properties, PropertySerializer
-    elsif Rails.gem_version < Gem::Version.new('7.1.0.alpha')
+    if Rails.gem_version < Gem::Version.new('7.1.0.alpha')
       serialize :serialized_properties, PropertySerializer, default: -> { {} }
     else
       serialize :serialized_properties, coder: PropertySerializer, default: -> { {} }

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -13,11 +13,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   # Raises error for missing translations.
-  if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')
-    config.action_view.raise_on_missing_translations = true
-  else
-    config.i18n.raise_on_missing_translations = true
-  end
+  config.i18n.raise_on_missing_translations = true
 
   config.colorize_logging = false if ENV["CI"]
   if ActiveModel::Type::Boolean.new.cast(ENV['RAILS_LOG_TO_STDOUT'])

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe GoodJob::AdvisoryLockable do
           SELECT "good_jobs".*
           FROM "good_jobs"
           WHERE "good_jobs"."id" IN (
-            WITH "rows" AS #{'MATERIALIZED' if model_class.supports_cte_materialization_specifiers?} (
+            WITH "rows" AS MATERIALIZED (
               SELECT "good_jobs"."id", "good_jobs"."id"
               FROM "good_jobs"
               WHERE "good_jobs"."priority" = 99
@@ -73,7 +73,7 @@ RSpec.describe GoodJob::AdvisoryLockable do
           SELECT "good_jobs".*
           FROM "good_jobs"
           WHERE "good_jobs"."id" IN (
-            WITH "rows" AS #{'MATERIALIZED' if model_class.supports_cte_materialization_specifiers?} (
+            WITH "rows" AS MATERIALIZED (
               SELECT "good_jobs"."id", "good_jobs"."queue_name"
               FROM "good_jobs"
               ORDER BY "good_jobs"."priority" DESC
@@ -95,7 +95,7 @@ RSpec.describe GoodJob::AdvisoryLockable do
           SELECT "good_jobs".*
           FROM "good_jobs"
           WHERE "good_jobs"."id" IN (
-            WITH "rows" AS #{'MATERIALIZED' if model_class.supports_cte_materialization_specifiers?} (
+            WITH "rows" AS MATERIALIZED (
               SELECT "good_jobs"."id", "good_jobs"."active_job_id"
               FROM "good_jobs"
               LIMIT 1000

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
   end
 
   describe '.good_job_control_concurrency_with' do
-    describe 'total_limit:', :skip_rails_5 do
+    describe 'total_limit:' do
       before do
         TestJob.good_job_control_concurrency_with(
           total_limit: -> { 1 },
@@ -75,7 +75,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
     end
 
-    describe 'enqueue_limit:', :skip_rails_5 do
+    describe 'enqueue_limit:' do
       before do
         TestJob.good_job_control_concurrency_with(
           enqueue_limit: -> { 2 },
@@ -99,10 +99,8 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(GoodJob::Job.where(concurrency_key: "Bob").count).to eq 1
 
         expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Aborted enqueue of TestJob \(Job ID: .*\) because the concurrency key 'Alice' has reached its enqueue limit of 2 jobs/)).exactly(:once)
-        if ActiveJob.gem_version >= Gem::Version.new("6.1.0")
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
-        end
+        expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
+        expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
       end
 
       it 'excludes jobs that are already executing/locked' do

--- a/spec/support/rails_versions.rb
+++ b/spec/support/rails_versions.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |c|
-  less_than_rails_6 = Gem::Version.new(Rails.version) < Gem::Version.new('6')
-  c.filter_run_excluding(:skip_rails_5) if less_than_rails_6
-end


### PR DESCRIPTION
v4 updated what it is compatible with but docs weren't updated. I've based these versions on what is written in the v4 upgrade guide.

Honestly not sure if this is possible to do now. While v4 was supposed to drop older postgres versions, I don't think this is enforced anywhere right now and probably still works with at least postgres 11. The rails and ruby constraint at least is enforced through the gemspec.

v4 has been out for about a month now. I would defer the postgres changes for the next major myself, unless there is a check somewhere I didn't find? Let me know what you think.