### PR TITLE
Update compatibility matrix, remove compatibility code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         pg: [16]
         include:
           - ruby: 3.3
-            pg: 11
+            pg: 10
 
     env:
       PGHOST: localhost

--- a/README.md
+++ b/README.md
@@ -164,8 +164,8 @@ For more of the story of GoodJob, read the [introductory blog post](https://isla
 
 ## Compatibility
 
-- **Ruby on Rails:** 6.0+
-- **Ruby:** Ruby 2.6+. JRuby 9.3+
+- **Ruby on Rails:** 6.1+
+- **Ruby:** Ruby 3.0+. JRuby 9.4+
 - **Postgres:** 10.0+
 
 ## Configuration
@@ -892,7 +892,7 @@ To upgrade:
 
 Notable changes:
 
-- Only supports Rails 6.1+, CRuby 3.0+ and JRuby 9.4+, Postgres 12+. Rails 6.0 is no longer supported. CRuby 2.6 and 2.7 are no longer supported. JRuby 9.3 is no longer supported.
+- Only supports Rails 6.1+, CRuby 3.0+ and JRuby 9.4+. Rails 6.0 is no longer supported. CRuby 2.6 and 2.7 are no longer supported. JRuby 9.3 is no longer supported.
 - Changes job `priority` to give smaller numbers higher priority (default: `0`), in accordance with Active Job's definition of priority.
 - Enqueues and executes jobs via the `GoodJob::Job` model instead of `GoodJob::Execution`
 - Setting `config.good_job.cleanup_interval_jobs`, `GOOD_JOB_CLEANUP_INTERVAL_JOBS`, `config.good_job.cleanup_interval_seconds`, or `GOOD_JOB_CLEANUP_INTERVAL_SECONDS` to `nil` or `""` no longer disables count- or time-based cleanups. Set to `false` to disable, or `-1` to run a cleanup after every job execution.

--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -84,11 +84,7 @@ module GoodJob
       end
     end
 
-    if Rails.gem_version < Gem::Version.new('6.1.0.alpha')
-      # serialize does not yet take a default value, must set via Attributes API
-      attribute :serialized_properties, :json, default: -> { {} }
-      serialize :serialized_properties, PropertySerializer
-    elsif Rails.gem_version < Gem::Version.new('7.1.0.alpha')
+    if Rails.gem_version < Gem::Version.new('7.1.0.alpha')
       serialize :serialized_properties, PropertySerializer, default: -> { {} }
     else
       serialize :serialized_properties, coder: PropertySerializer, default: -> { {} }

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -13,11 +13,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   # Raises error for missing translations.
-  if Gem::Version.new(Rails.version) < Gem::Version.new('6.1')
-    config.action_view.raise_on_missing_translations = true
-  else
-    config.i18n.raise_on_missing_translations = true
-  end
+  config.i18n.raise_on_missing_translations = true
 
   config.colorize_logging = false if ENV["CI"]
   if ActiveModel::Type::Boolean.new.cast(ENV['RAILS_LOG_TO_STDOUT'])

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
   end
 
   describe '.good_job_control_concurrency_with' do
-    describe 'total_limit:', :skip_rails_5 do
+    describe 'total_limit:' do
       before do
         TestJob.good_job_control_concurrency_with(
           total_limit: -> { 1 },
@@ -75,7 +75,7 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
     end
 
-    describe 'enqueue_limit:', :skip_rails_5 do
+    describe 'enqueue_limit:' do
       before do
         TestJob.good_job_control_concurrency_with(
           enqueue_limit: -> { 2 },
@@ -99,10 +99,8 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         expect(GoodJob::Job.where(concurrency_key: "Bob").count).to eq 1
 
         expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Aborted enqueue of TestJob \(Job ID: .*\) because the concurrency key 'Alice' has reached its enqueue limit of 2 jobs/)).exactly(:once)
-        if ActiveJob.gem_version >= Gem::Version.new("6.1.0")
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
-        end
+        expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
+        expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
       end
 
       it 'excludes jobs that are already executing/locked' do

--- a/spec/support/rails_versions.rb
+++ b/spec/support/rails_versions.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |c|
-  less_than_rails_6 = Gem::Version.new(Rails.version) < Gem::Version.new('6')
-  c.filter_run_excluding(:skip_rails_5) if less_than_rails_6
-end


### PR DESCRIPTION
Redo of #1463 without the postgres change.

Readme says postgres 10, CI only tests against postgres 11. CI was changed in #828, while v3 was already long released. Checking if this still even works now, otherwise I'll just change the readme to say postgres 11 instead.