### PR TITLE
Require fugit >= 1.11.1

### DIFF
--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activejob", ">= 6.1.0"
   spec.add_dependency "activerecord", ">= 6.1.0"
   spec.add_dependency "concurrent-ruby", ">= 1.3.1"
-  spec.add_dependency "fugit", ">= 1.11.0"
+  spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
   spec.add_dependency "railties", ">= 6.1.0"
   spec.add_dependency "thor", ">= 1.0.0"
 


### PR DESCRIPTION
https://github.com/floraison/fugit/issues/104

Prevent Fugit::Nat.parse choking on large input, peg at 256 chars

```ruby
  spec.add_dependency "fugit", "~> 1.11", ">= 1.11.1"
```

Which requires fugit from 1.11.0 to 2.x not included and at least 1.11.1