### PR TITLE
fix strict_loading_by_default in BaseRecord

### DIFF
--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -61,7 +61,7 @@ module GoodJob
     end
 
     def show
-      @job = Job.includes(:executions).includes_advisory_locks.find(params[:id])
+      @job = Job.includes_advisory_locks.find(params[:id])
     end
 
     def discard

--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -61,7 +61,7 @@ module GoodJob
     end
 
     def show
-      @job = Job.includes_advisory_locks.find(params[:id])
+      @job = Job.includes(:executions).includes_advisory_locks.find(params[:id])
     end
 
     def discard

--- a/app/models/good_job/base_record.rb
+++ b/app/models/good_job/base_record.rb
@@ -7,6 +7,7 @@ module GoodJob
   #   class BaseRecord < ActiveRecord::Base; end
   class BaseRecord < ActiveRecordParentClass
     self.abstract_class = true
+    self.strict_loading_by_default = false
 
     def self.migration_pending_warning!
       GoodJob.deprecator.warn(<<~DEPRECATION)


### PR DESCRIPTION
Include executions association to prevent `ActiveRecord::StrictLoadingViolationError`

Fixes #1474 