### PR TITLE
Ensure before actions run on root route

### DIFF
--- a/app/controllers/good_job/application_controller.rb
+++ b/app/controllers/good_job/application_controller.rb
@@ -26,8 +26,9 @@ module GoodJob
     end
 
     def index
-      # Redirect to the jobs page
-      redirect_to jobs_path
+      # Redirect to the jobs page, maintaining query parameters. This is
+      # necessary to support the `?poll=1` parameter that enables live polling.
+      redirect_to jobs_path(request.query_parameters)
     end
 
     private

--- a/app/controllers/good_job/application_controller.rb
+++ b/app/controllers/good_job/application_controller.rb
@@ -25,12 +25,6 @@ module GoodJob
       request.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
     end
 
-    def index
-      # Redirect to the jobs page, maintaining query parameters. This is
-      # necessary to support the `?poll=1` parameter that enables live polling.
-      redirect_to jobs_path(request.query_parameters)
-    end
-
     private
 
     def default_url_options(options = {})

--- a/app/controllers/good_job/application_controller.rb
+++ b/app/controllers/good_job/application_controller.rb
@@ -25,6 +25,11 @@ module GoodJob
       request.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
     end
 
+    def index
+      # Redirect to the jobs page
+      redirect_to jobs_path
+    end
+
     private
 
     def default_url_options(options = {})

--- a/app/controllers/good_job/jobs_controller.rb
+++ b/app/controllers/good_job/jobs_controller.rb
@@ -94,6 +94,12 @@ module GoodJob
       redirect_to jobs_path, notice: t(".notice")
     end
 
+    def redirect_to_index
+      # Redirect to the jobs page, maintaining query parameters. This is
+      # necessary to support the `?poll=1` parameter that enables live polling.
+      redirect_to jobs_path(request.query_parameters)
+    end
+
     private
 
     def redirect_on_error(exception)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 GoodJob::Engine.routes.draw do
-  root to: redirect(path: 'jobs')
+  root 'application#index'
 
   resources :jobs, only: %i[index show destroy] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 GoodJob::Engine.routes.draw do
-  root 'application#index'
+  root 'jobs#redirect_to_index'
 
   resources :jobs, only: %i[index show destroy] do
     collection do


### PR DESCRIPTION
When using the recommended method for injecting a before filter into GoodJob the initial root route ignores that filter. In cases where someone is using that before filter to apply security they may want to return a non-301 response code for users who don't pass the authentication check.

For example someone may want to obfuscate that they're using GoodJob by returning a 404 from all GoodJob routes if the user is not logged in. Before this change users would receive the redirect from the root route, then get the 404, essentially "leaking" that the site is running GoodJob.