### PR TITLE
fix: unable to use keyword args when including the `Labels` extension

### DIFF
--- a/lib/good_job/active_job_extensions/labels.rb
+++ b/lib/good_job/active_job_extensions/labels.rb
@@ -6,7 +6,7 @@ module GoodJob
       extend ActiveSupport::Concern
 
       module Prepends
-        def initialize(*arguments)
+        def initialize(...)
           super
           self.good_job_labels = Array(self.class.good_job_labels.dup)
         end


### PR DESCRIPTION
[bug]: https://github.com/bensheldon/good_job/issues/1350

### Description 📖

This pull request fixes a [bug] which is described in:

- #1350

### Background 📜

For backwards compatibility, `activejob` uses `ruby2_keywords` to capture arguments that are passed to `perform_now` and `perform_later`.

That ensures that it can serialize and deserialize keyword arguments differently.

`GoodJob::ActiveJobExtensions::Labels` [overrides the `initialize` method](https://github.com/bensheldon/good_job/blob/b714be6f4ad34a643604c54196d9710b28f58b6f/lib/good_job/active_job_extensions/labels.rb#L9), but it does not use `ruby2_keywords`, so by the time `activejob` receives the arguments, keyword arguments have become a plain `Hash`.

### The Fix 🔨

Passing all arguments as-is, by using `...` instead of `*arguments`, since the module doesn't need to use the parameters.

### Notes ✏️ 

Using `ruby2_keywords(:initialize)` would also work, but since this library no longer supports CRuby 2.6 and 2.7, `...` is the way to go.