### PR TITLE
Remove rack from the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gemspec
 
 gem 'activerecord-jdbcpostgresql-adapter', platforms: [:jruby]
 gem 'pg', platforms: [:mri, :mingw, :x64_mingw]
-gem 'rack', '~> 2.2'
 
 rails_versions = {
   "6.1" => { github: "rails/rails", branch: "6-1-stable" }, # https://github.com/bensheldon/good_job/issues/1280

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -517,7 +517,6 @@ DEPENDENCIES
   memory_profiler
   pg
   puma
-  rack (~> 2.2)
   rack-mini-profiler
   rails
   rbtrace


### PR DESCRIPTION
It was initially added in https://github.com/bensheldon/good_job/pull/987 but the reasoning is lost on me.

Rails 6.1 and 7.0 only work with Rack 2 which causes dependabot update PRs to break CI when it bumps to Rack 3.

Rails head will also switch to be Rack 3 only at some point. Just let bundler resolve to what works.

GoodJob does have to do some version-specific rack handling but I don't think this really needs to be part of the matrix.