### PR TITLE
Fix state update + Add Memory usage 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       activerecord (>= 6.1.0)
       concurrent-ruby (>= 1.3.1)
       fugit (>= 1.11.0)
+      get_process_mem (>= 1.0.0)
       railties (>= 6.1.0)
       thor (>= 1.0.0)
 
@@ -193,6 +194,9 @@ GEM
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     gem-release (2.2.2)
+    get_process_mem (1.0.0)
+      bigdecimal (>= 2.0)
+      ffi (~> 1.0)
     github_changelog_generator (1.16.4)
       activesupport
       async (>= 1.25.0)

--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'socket'
+require 'get_process_mem'
 
 module GoodJob # :nodoc:
   # Active Record model that represents a GoodJob capsule/process (either async or CLI).
@@ -83,6 +84,7 @@ module GoodJob # :nodoc:
       {
         hostname: Socket.gethostname,
         pid: ::Process.pid,
+        memory: GetProcessMem.new.mb.to_i,
         proctitle: $PROGRAM_NAME,
         preserve_job_records: GoodJob.preserve_job_records,
         retry_on_unhandled_error: GoodJob.retry_on_unhandled_error,
@@ -98,8 +100,8 @@ module GoodJob # :nodoc:
     end
 
     def refresh
-      self.state = self.class.process_state
       reload # verify the record still exists in the database
+      self.state = self.class.process_state
       update(state: state, updated_at: Time.current)
     rescue ActiveRecord::RecordNotFound
       @new_record = true

--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -38,6 +38,7 @@
               <span class="badge rounded-pill bg-body-secondary text-secondary"><%= process.state["pid"] %></span>
               <span class="text-muted small">@</span>
               <span class="badge rounded-pill bg-body-secondary text-secondary"><%= process.state["hostname"] %></span>
+              <span class="badge rounded-pill bg-body-secondary text-secondary"><%= process.state["memory"] %>mb</span>
             </div>
           </div>
           <div class="col">

--- a/good_job.gemspec
+++ b/good_job.gemspec
@@ -50,6 +50,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fugit", ">= 1.11.0"
   spec.add_dependency "railties", ">= 6.1.0"
   spec.add_dependency "thor", ">= 1.0.0"
+  spec.add_dependency "get_process_mem", ">= 1.0.0"
 
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "kramdown"

--- a/spec/app/models/good_job/process_spec.rb
+++ b/spec/app/models/good_job/process_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe GoodJob::Process do
       process = described_class.create! state: {}, updated_at: 1.day.ago
       expect do
         expect(process.refresh).to be true
-      end.to change(process, :updated_at).to within(1.second).of(Time.current)
+      end.to change(process, :state)
+         .and change(process, :updated_at).to within(1.second).of(Time.current)
     end
 
     context 'when the record has been deleted elsewhere' do


### PR DESCRIPTION
Hi!

I have found that the code around process refresh was shadowed by the `reload` instruction. So basically state filed was never refreshed in the database. For this case I have added additional line in the spec file.

Initially the idea was to add memory usage to the process state. Like that:
<img width="236" alt="image" src="https://github.com/user-attachments/assets/e8e909d0-1173-4865-a408-938724386f52">

This change uncovered the state update issue.