### PR TITLE
Add vertical legend to performance dashboard

### DIFF
--- a/app/charts/good_job/performance_index_chart.rb
+++ b/app/charts/good_job/performance_index_chart.rb
@@ -56,6 +56,9 @@ module GoodJob
               display: true,
               text: I18n.t("good_job.performance.index.chart_title"),
             },
+            legend: {
+              vertical: true,
+            },
           },
           scales: {
             y: {

--- a/app/frontend/good_job/modules/charts.js
+++ b/app/frontend/good_job/modules/charts.js
@@ -1,3 +1,5 @@
+import htmlLegendPlugin from "html_legend_plugin";
+
 function renderCharts(animate) {
   const charts = document.querySelectorAll('.chart');
 
@@ -5,6 +7,16 @@ function renderCharts(animate) {
     const chartEl = charts[i];
     const chartData = JSON.parse(chartEl.dataset.json);
     chartData.options ||= {};
+
+    if (chartData.options.plugins?.legend?.vertical) {
+      chartData.plugins = [htmlLegendPlugin];
+      chartData.options.plugins = {
+        ...chartData.options.plugins,
+        legend: {
+          display: false,
+        }
+      }
+    }
     chartData.options.animation = animate;
     chartData.options.responsive = true;
     chartData.options.maintainAspectRatio = false;

--- a/app/frontend/good_job/modules/html_legend_plugin.js
+++ b/app/frontend/good_job/modules/html_legend_plugin.js
@@ -1,4 +1,3 @@
-
 const generateListItem = (item) => {
   const li = document.createElement('li');
   li.className = 'd-flex align-items-center text-nowrap mb-2';
@@ -19,38 +18,38 @@ const generateListItem = (item) => {
 
   li.appendChild(boxSpan);
   li.appendChild(textContainer);
-  
+
   return li;
 }
 
 const htmlLegendPlugin = {
   id: 'htmlLegend',
   afterUpdate(chart, _args, _options) {
-      const { type } = chart.config;
-      const ul = document.getElementById('legend-ul');
+    const {type} = chart.config;
+    const ul = document.getElementById('chart-legend-ul');
 
-      // Remove old legend items
-      while (ul.firstChild) {
-        ul.firstChild.remove();
-      }
+    // Remove old legend items
+    while (ul.firstChild) {
+      ul.firstChild.remove();
+    }
 
-      // Reuse the built-in legendItems generator
-      const items = chart.options.plugins.legend.labels.generateLabels(chart);
+    // Reuse the built-in legendItems generator
+    const items = chart.options.plugins.legend.labels.generateLabels(chart);
 
-      items.forEach(item => {
-        const li = generateListItem(item);
-        ul.appendChild(li);
+    items.forEach(item => {
+      const li = generateListItem(item);
+      ul.appendChild(li);
 
-        li.onclick = () => {
-          if (type === 'pie' || type === 'doughnut') {
-            // Pie and doughnut charts only have a single dataset and visibility is per item
-            chart.toggleDataVisibility(item.index);
-          } else {
-            chart.setDatasetVisibility(item.datasetIndex, !chart.isDatasetVisible(item.datasetIndex));
-          }
-          chart.update();
-        };
-      });
+      li.onclick = () => {
+        if (type === 'pie' || type === 'doughnut') {
+          // Pie and doughnut charts only have a single dataset and visibility is per item
+          chart.toggleDataVisibility(item.index);
+        } else {
+          chart.setDatasetVisibility(item.datasetIndex, !chart.isDatasetVisible(item.datasetIndex));
+        }
+        chart.update();
+      };
+    });
   }
 };
 

--- a/app/frontend/good_job/modules/html_legend_plugin.js
+++ b/app/frontend/good_job/modules/html_legend_plugin.js
@@ -1,0 +1,57 @@
+
+const generateListItem = (item) => {
+  const li = document.createElement('li');
+  li.className = 'd-flex align-items-center text-nowrap mb-2';
+
+  const boxSpan = document.createElement('span');
+  boxSpan.className = 'legend-item-color-box';
+  boxSpan.style.background = item.fillStyle;
+  boxSpan.style.borderColor = item.strokeStyle;
+  boxSpan.style.borderWidth = item.lineWidth + 'px';
+
+  const textContainer = document.createElement('p');
+  textContainer.className = 'item-text m-0 small';
+  textContainer.style.color = item.fontColor;
+  textContainer.style.textDecoration = item.hidden ? 'line-through' : '';
+
+  const text = document.createTextNode(item.text);
+  textContainer.appendChild(text);
+
+  li.appendChild(boxSpan);
+  li.appendChild(textContainer);
+  
+  return li;
+}
+
+const htmlLegendPlugin = {
+  id: 'htmlLegend',
+  afterUpdate(chart, _args, _options) {
+      const { type } = chart.config;
+      const ul = document.getElementById('legend-ul');
+
+      // Remove old legend items
+      while (ul.firstChild) {
+        ul.firstChild.remove();
+      }
+
+      // Reuse the built-in legendItems generator
+      const items = chart.options.plugins.legend.labels.generateLabels(chart);
+
+      items.forEach(item => {
+        const li = generateListItem(item);
+        ul.appendChild(li);
+
+        li.onclick = () => {
+          if (type === 'pie' || type === 'doughnut') {
+            // Pie and doughnut charts only have a single dataset and visibility is per item
+            chart.toggleDataVisibility(item.index);
+          } else {
+            chart.setDatasetVisibility(item.datasetIndex, !chart.isDatasetVisible(item.datasetIndex));
+          }
+          chart.update();
+        };
+      });
+  }
+};
+
+export { htmlLegendPlugin as default };

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -33,7 +33,7 @@
   margin-right: 3px;
 }
 
-#legend-container {
+#chart-legend-container {
   height: 200px;
 }
 

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -24,6 +24,19 @@
   height: 200px;
 }
 
+.legend-item-color-box {
+  display: inline-block;
+  flex-shrink: 0;
+  height: 20px;
+  width: 20px;
+  border-style: solid;
+  margin-right: 3px;
+}
+
+#legend-container {
+  height: 200px;
+}
+
 /* Break out of a container */
 .break-out {
   width:100vw;

--- a/app/views/good_job/jobs/index.html.erb
+++ b/app/views/good_job/jobs/index.html.erb
@@ -1,5 +1,5 @@
 <%= render 'good_job/shared/filter', title: t("good_job.shared.navbar.jobs"), filter: @filter %>
-<%= render 'good_job/shared/chart', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
+<%= render 'good_job/shared/chart_container', chart_data: GoodJob::ScheduledByQueueChart.new(@filter).data %>
 
 <div data-live-poll-region="jobs-table">
   <%= render 'good_job/jobs/table', jobs: @filter.records, filter: @filter %>

--- a/app/views/good_job/performance/index.html.erb
+++ b/app/views/good_job/performance/index.html.erb
@@ -2,7 +2,7 @@
   <h2 class="pt-3 pb-2"><%= t ".title" %></h2>
 </div>
 
-<%= render 'good_job/shared/chart', chart_data: GoodJob::PerformanceIndexChart.new.data %>
+<%= render 'good_job/shared/chart_container', chart_data: GoodJob::PerformanceIndexChart.new.data %>
 
 <div class="my-3 card">
   <div class="list-group list-group-flush text-nowrap" role="table">

--- a/app/views/good_job/performance/show.html.erb
+++ b/app/views/good_job/performance/show.html.erb
@@ -2,4 +2,4 @@
   <h2 class="pt-3 pb-2"><%= t ".title" %> - <%= @job_class %></h2>
 </div>
 
-<%= render 'good_job/shared/chart', chart_data: GoodJob::PerformanceShowChart.new(@job_class).data %>
+<%= render 'good_job/shared/chart_container', chart_data: GoodJob::PerformanceShowChart.new(@job_class).data %>

--- a/app/views/good_job/shared/_chart.erb
+++ b/app/views/good_job/shared/_chart.erb
@@ -1,5 +1,5 @@
 <div class="py-4" data-live-poll-region="chart">
-  <div class="chart-wrapper container-fluid">
+  <div class="chart-wrapper">
     <canvas class="chart" data-json="<%= chart_data.to_json %>"></canvas>
   </div>
 </div>

--- a/app/views/good_job/shared/_chart.erb
+++ b/app/views/good_job/shared/_chart.erb
@@ -1,4 +1,4 @@
-<div class="py-4" data-live-poll-region="chart">
+<div class="" data-live-poll-region="chart">
   <div class="chart-wrapper">
     <canvas class="chart" data-json="<%= chart_data.to_json %>"></canvas>
   </div>

--- a/app/views/good_job/shared/_chart_container.erb
+++ b/app/views/good_job/shared/_chart_container.erb
@@ -5,16 +5,17 @@
     <% if vertical_legend %>
       <div class="row d-flex">
         <div class="col-md-10">
-            <%= render 'good_job/shared/chart', chart_data: %>
+          <%= render 'good_job/shared/chart', chart_data: chart_data %>
         </div>
         <div class="col-md-2 d-flex flex-column">
-            <div id="legend-container" class="flex-fill overflow-auto">
-            <ul id="legend-ul" class="list-unstyled p-0 m-0">
+          <div id="chart-legend-container" class="flex-fill overflow-auto">
+            <ul id="chart-legend-ul" class="list-unstyled p-0 mx-0 py-2">
             </ul>
-            </div>
+          </div>
         </div>
       </div>
     <% else %>
-        <%= render 'good_job/shared/chart', chart_data: %>
+      <%= render 'good_job/shared/chart', chart_data: chart_data %>
     <% end %>
+  </div>
 </div>

--- a/app/views/good_job/shared/_chart_container.erb
+++ b/app/views/good_job/shared/_chart_container.erb
@@ -1,0 +1,20 @@
+<% vertical_legend = chart_data.dig(:options, :plugins, :legend, :vertical) %>
+
+<div class="container-fluid">
+  <div class="row d-flex">
+    <% if vertical_legend %>
+      <div class="row d-flex">
+        <div class="col-md-10">
+            <%= render 'good_job/shared/chart', chart_data: %>
+        </div>
+        <div class="col-md-2 d-flex flex-column">
+            <div id="legend-container" class="flex-fill overflow-auto">
+            <ul id="legend-ul" class="list-unstyled p-0 m-0">
+            </ul>
+            </div>
+        </div>
+      </div>
+    <% else %>
+        <%= render 'good_job/shared/chart', chart_data: %>
+    <% end %>
+</div>


### PR DESCRIPTION
## Problem

The Performance Dashboard legend and chart become unreadable if you have greater than ~40 job classes

<img width="1611" alt="overflow" src="https://github.com/user-attachments/assets/44137fe0-5628-443f-8124-dbef62a7a649">

## Solution Description
- Introduces a custom vertical legend and uses it in the Performance Dashboard chart.
- Does not use the vertical legend anywhere else

### Screenshot of Performance Dashboard
<img width="1624" alt="Screenshot 2024-10-13 at 10 42 32 PM" src="https://github.com/user-attachments/assets/2f806114-585b-4945-a79c-fc46bce13265">


### Screenshot of Jobs Dashboard
_Shows that there was no regression_
<img width="1625" alt="Screenshot 2024-10-13 at 10 42 24 PM" src="https://github.com/user-attachments/assets/358c880e-31ad-4d20-9677-392bb4b179c3">

## Solution Reflections
- There may be a better approach across graphs to have a hybrid (horizontal graph for < X items, vertical, scrollable graph for N items)
- It may be worth implementing something like the [sidekiq metrics dashboard](https://raw.githubusercontent.com/sidekiq/sidekiq/main/examples/metrics.png) where the table items have a checkbox that controls what appears on the chart.

## Implementation Details
- Added `vertical: true` plugin option to charts and followed the general guidance in [Chart.js HTML Legend](https://www.chartjs.org/docs/latest/samples/legend/html.html) to implement a custom legend
- Add a `chart_container` partial which checks for whether the legend is vertical and modifies the layout