### PR TITLE
Fix badge color for running jobs

### DIFF
--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -35,13 +35,13 @@
               </div>
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.attempts" %></div>
-                <% if job.executions_count > 0 && job.status != :finished %>
+                <% if job.error && job.status != :finished %>
                   <%= tag.span job.executions_count, class: "badge rounded-pill bg-danger",
                     data: {
                       bs_toggle: "popover",
                       bs_trigger: "hover focus click",
                       bs_placement: "bottom",
-                      bs_content: job.recent_error,
+                      bs_content: job.display_error,
                     }
                   %>
                 <% else %>

--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -35,7 +35,7 @@
               </div>
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.attempts" %></div>
-                <% if job.error && job.status != :finished %>
+                <% if job.error %>
                   <%= tag.span job.executions_count, class: "badge rounded-pill bg-danger",
                     data: {
                       bs_toggle: "popover",
@@ -45,7 +45,8 @@
                     }
                   %>
                 <% else %>
-                  <span class="badge bg-secondary rounded-pill"><%= job.executions_count %></span>
+                  <% executions_badge_color = job.executions_count > 1 ? "bg-warning" : "bg-secondary" %>
+                  <span class="badge rounded-pill <%= executions_badge_color %>"><%= job.executions_count %></span>
                 <% end %>
               </div>
               <div class="mt-3 mt-lg-0 col d-flex gap-3 align-items-center justify-content-end">
@@ -79,7 +80,7 @@
                       <% end %>
                     </li>
                     <li>
-                      <%= link_to job_path(job.id), method: :delete, class: "dropdown-item #{'disabled' unless job.status.in? [:discarded, :finished]}", title: t(".actions.destroy"), data: { confirm: t(".actions.confirm_destroy"), disable: true } do %>
+                      <%= link_to job_path(job.id), method: :delete, class: "dropdown-item #{'disabled' unless job.finished?}", title: t(".actions.destroy"), data: { confirm: t(".actions.confirm_destroy"), disable: true } do %>
                         <%= render_icon "trash" %>
                         <%= t "good_job.actions.destroy" %>
                       <% end %>

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -84,7 +84,7 @@
               </div>
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.attempts" %></div>
-                <% if job.executions_count > 0 && job.status != :succeeded %>
+                <% if job.error && job.status != :finished %>
                   <%= tag.span job.executions_count, class: "badge rounded-pill bg-danger",
                     data: {
                       bs_toggle: "popover",

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -84,7 +84,7 @@
               </div>
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.attempts" %></div>
-                <% if job.error && job.status != :finished %>
+                <% if job.error %>
                   <%= tag.span job.executions_count, class: "badge rounded-pill bg-danger",
                     data: {
                       bs_toggle: "popover",
@@ -94,7 +94,8 @@
                     }
                   %>
                 <% else %>
-                  <span class="badge bg-secondary rounded-pill"><%= job.executions_count %></span>
+                  <% executions_badge_color = job.executions_count > 1 ? "bg-warning" : "bg-secondary" %>
+                  <span class="badge rounded-pill <%= executions_badge_color %>"><%= job.executions_count %></span>
                 <% end %>
               </div>
               <div class="mt-3 mt-lg-0 col">


### PR DESCRIPTION
## Problem
When a job is running and has 1 attempt, the badge with Attempts has an error color
<img width="1860" alt="Screenshot 2024-10-14 at 7 45 38 AM" src="https://github.com/user-attachments/assets/885f1cce-3c06-49a3-91f1-64f8fad70092">

## Solution Implementation
- Resolves #1518 by only using the error badge pill when a job has an attached error (from previous execution)
- Removes usage of `GoodJob::Job#recent_error` from Batches show page and applies the same logic there

## Screenshots

### Running Jobs Tab
<img width="1618" alt="Screenshot 2024-10-17 at 9 09 15 PM" src="https://github.com/user-attachments/assets/6e40756b-a48d-4b2f-863e-1a8823a93c8c">

### Batch Jobs Page
<img width="1623" alt="Screenshot 2024-10-17 at 9 12 43 PM" src="https://github.com/user-attachments/assets/1bc29f96-1126-4f6e-af59-56ac92ea5abf">
