### PR TITLE
Deprecate GoodJob::Job#recent_error

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -390,7 +390,12 @@ module GoodJob
     # If the job has been retried, the error will be fetched from the previous {Execution} record.
     # @return [String]
     def recent_error
-      error || executions[-2]&.error
+      GoodJob.deprecator.warn(<<~DEPRECATION)
+        The `GoodJob::Job#recent_error` method is deprecated and will be removed in the next major release.
+        
+        Replace usage of GoodJob::Job#recent_error with `GoodJob::Job#error`.
+      DEPRECATION
+      error
     end
 
     # Errors for the job to be displayed in the Dashboard.

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -392,7 +392,7 @@ module GoodJob
     def recent_error
       GoodJob.deprecator.warn(<<~DEPRECATION)
         The `GoodJob::Job#recent_error` method is deprecated and will be removed in the next major release.
-        
+
         Replace usage of GoodJob::Job#recent_error with `GoodJob::Job#error`.
       DEPRECATION
       error


### PR DESCRIPTION
## Merge Notes
#1525 removes the only remaining usage of `#recent_error` in `good_job`

## Details
Change made based on discussion in #1518:
> I think recent_error is vestigial of GoodJob <v4 and should be deprecated and aliased to error. It used to be necessary because a Job was simply the most recent Execution but that's no longer the case and [previous error from a job is not cleared](https://github.com/bensheldon/good_job/blob/62af353b863c22301fe20d663e5b798b9477d6cd/app/models/good_job/job.rb#L589-L589) when the job is re-executed.

## Screenshot
<img width="1238" alt="Screenshot 2024-10-17 at 9 17 00 PM" src="https://github.com/user-attachments/assets/44ff1271-baf1-47ff-bf6c-cb239dc5add8">
