### PR TITLE
Remove unneeded include of pg_locks in query when displaying jobs table

### DIFF
--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -39,7 +39,7 @@ module GoodJob
         when 'scheduled'
           query = query.scheduled
         when 'running'
-          query = query.running.select("#{GoodJob::Job.table_name}.*", 'pg_locks.locktype')
+          query = query.running
         when 'queued'
           query = query.queued
         end
@@ -55,7 +55,7 @@ module GoodJob
     private
 
     def query_for_records
-      filtered_query.includes_advisory_locks
+      filtered_query
     end
 
     def default_base_query


### PR DESCRIPTION
Related to https://github.com/bensheldon/good_job/issues/1540

* Removes an (unused?) join of the pg_locks table which was slow

@bensheldon regarding your comments

> * The pg_locks could be replaced with a locked_at IS NOT NULL query

I'm not sure but I found that the joined table was not being used for constraints but for including the `locktype` which seems to be unused(?). I removed it and browsed around the dashboard and found to errors 🤷 

> * The COALESCE can be replaced solely with good_jobs.scheduled_at because now all jobs should have a scheduled_at regardless of whether they are expect to run immediately or in the future.

Can you elaborate? There's multiple places where we use `coalesce(scheduled_at, created_at)` so if that's not needed in general anymore I feel there's a lot of cleanup that could be done and I can do that in this PR with your guidance :)