### PR TITLE
Fix compatibility with `rails-head` when duplicated advisory lockable column

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -41,8 +41,16 @@ module GoodJob
       scope :advisory_lock, (lambda do |column: _advisory_lockable_column, function: advisory_lockable_function, select_limit: nil|
         original_query = self
 
+        primary_key_for_select = primary_key.to_sym
+        column_for_select = column.to_sym
+
         cte_table = Arel::Table.new(:rows)
-        cte_query = original_query.select(*[primary_key.to_sym, column.to_sym].uniq).except(:limit)
+        cte_query = original_query.except(:limit)
+        cte_query = if primary_key_for_select == column_for_select
+                      cte_query.select(primary_key_for_select)
+                    else
+                      cte_query.select(primary_key_for_select, column_for_select)
+                    end
         cte_query = cte_query.limit(select_limit) if select_limit
         cte_type = supports_cte_materialization_specifiers? ? :MATERIALIZED : :""
         composed_cte = Arel::Nodes::As.new(cte_table, Arel::Nodes::UnaryOperation.new(cte_type, cte_query.arel))

--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -42,7 +42,7 @@ module GoodJob
         original_query = self
 
         cte_table = Arel::Table.new(:rows)
-        cte_query = original_query.select(primary_key, column).except(:limit)
+        cte_query = original_query.select(*[primary_key.to_sym, column.to_sym].uniq).except(:limit)
         cte_query = cte_query.limit(select_limit) if select_limit
         cte_type = supports_cte_materialization_specifiers? ? :MATERIALIZED : :""
         composed_cte = Arel::Nodes::As.new(cte_table, Arel::Nodes::UnaryOperation.new(cte_type, cte_query.arel))

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe GoodJob::AdvisoryLockable do
           FROM "good_jobs"
           WHERE "good_jobs"."id" IN (
             WITH "rows" AS #{'MATERIALIZED' if model_class.supports_cte_materialization_specifiers?} (
-              SELECT "good_jobs"."id", "good_jobs"."id"
+              SELECT "good_jobs"."id"
               FROM "good_jobs"
               WHERE "good_jobs"."priority" = 99
               ORDER BY "good_jobs"."priority" DESC


### PR DESCRIPTION
The primary key and column may be identical. Current rails head will select this column twice, which confuses postgres.

Draft for now, let's first see how https://github.com/rails/rails/issues/53747 goes.