### PR TITLE
Allow cron configuration `class` value to be a proc

### DIFF
--- a/app/models/good_job/cron_entry.rb
+++ b/app/models/good_job/cron_entry.rb
@@ -101,8 +101,12 @@ module GoodJob # :nodoc:
         current_thread.cron_key = key
         current_thread.cron_at = cron_at
 
-        configured_job = job_class.constantize.set(set_value)
         I18n.with_locale(I18n.default_locale) do
+          job_klass = job_class_value
+          job_klass = job_klass.constantize if job_klass.is_a?(String)
+          next unless job_klass.is_a?(Class)
+
+          configured_job = job_klass.set(set_value)
           kwargs_value.present? ? configured_job.perform_later(*args_value, **kwargs_value) : configured_job.perform_later(*args_value)
         end
       end
@@ -118,6 +122,7 @@ module GoodJob # :nodoc:
         set: display_property(set),
         description: display_property(description),
       }.tap do |properties|
+        properties[:class] = display_property(job_class) if job_class.present?
         properties[:args] = display_property(args) if args.present?
         properties[:kwargs] = display_property(kwargs) if kwargs.present?
       end
@@ -158,6 +163,11 @@ module GoodJob # :nodoc:
 
     def fugit
       @_fugit ||= Fugit.parse(cron)
+    end
+
+    def job_class_value
+      value = job_class || nil
+      value.respond_to?(:call) ? value.call : value
     end
 
     def set_value


### PR DESCRIPTION
I noticed this would be nice when working on labels and wanted to be able to use the same `set` value as an `arg` too.

It could be a backdoor way to run a script, though any code here is not guarded against parallel execution on multiple processes. Trying to enqueue multiple jobs will raise a duplicate key database error because the cron-key timestamp is set via a thread-local variable which wraps the proc. In other words: just use it to enqueue a job directly, or return a dynamic job class.