### PR TITLE
Expect `Job#scheduled_at` to always be present; remove nil checks

### DIFF
--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -15,11 +15,11 @@ module GoodJob
       #   Display records after this ID for keyset pagination
       # @return [ActiveRecord::Relation]
       scope :display_all, (lambda do |after_scheduled_at: nil, after_id: nil|
-        query = order(Arel.sql('COALESCE(scheduled_at, created_at) DESC, id DESC'))
+        query = order(Arel.sql('scheduled_at DESC, id DESC'))
         if after_scheduled_at.present? && after_id.present?
-          query = query.where Arel::Nodes::Grouping.new([coalesce_scheduled_at_created_at, arel_table["id"]]).lt(Arel::Nodes::Grouping.new([bind_value('coalesce', after_scheduled_at, ActiveRecord::Type::DateTime), bind_value('id', after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)]))
+          query = query.where Arel::Nodes::Grouping.new([arel_table["scheduled_at"], arel_table["id"]]).lt(Arel::Nodes::Grouping.new([bind_value('scheduled_at', after_scheduled_at, ActiveRecord::Type::DateTime), bind_value('id', after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)]))
         elsif after_scheduled_at.present?
-          query = query.where coalesce_scheduled_at_created_at.lt(bind_value('coalesce', after_scheduled_at, ActiveRecord::Type::DateTime))
+          query = query.where arel_table["scheduled_at"].lt(bind_value('scheduled_at', after_scheduled_at, ActiveRecord::Type::DateTime))
         end
         query
       end)

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -494,7 +494,7 @@ RSpec.describe GoodJob::Job do
 
       context "with multiple jobs and ordered queues" do
         def job_params
-          { active_job_id: SecureRandom.uuid, queue_name: "default", priority: 0, serialized_params: { job_class: "TestJob" } }
+          { active_job_id: SecureRandom.uuid, scheduled_at: Time.current, queue_name: "default", priority: 0, serialized_params: { job_class: "TestJob" } }
         end
 
         let(:parsed_queues) { { include: %w{one two}, ordered_queues: true } }
@@ -1067,7 +1067,7 @@ RSpec.describe GoodJob::Job do
     describe '.schedule_ordered' do
       it 'orders by scheduled or created (oldest first)' do
         query = described_class.schedule_ordered
-        expect(query.to_sql).to include('ORDER BY COALESCE')
+        expect(query.to_sql).to include('ORDER BY')
       end
     end
 


### PR DESCRIPTION
As of GoodJob v4, `scheduled_at` should always be set. This removes the final places that are guarded against it being nil.

Details in explanation of Discrete Jobs in #928

Validation that this is true in #1332; discussion in #1574.