### PR TITLE
Fix passing a block to `advisory_lock` in tests

### DIFF
--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -483,9 +483,8 @@ RSpec.describe GoodJob::AdvisoryLockable do
 
       it "locks and unlocks" do
         GoodJob::Job.transaction do
-          job.advisory_lock(function: "pg_advisory_xact_lock") do
-            expect(job.advisory_locked?).to be true
-          end
+          job.advisory_lock(function: "pg_advisory_xact_lock")
+          expect(job.advisory_locked?).to be true
         end
         expect(job.advisory_locked?).to be false
       end


### PR DESCRIPTION
This method does not take a block. As such, the expectation is never executed