### PR TITLE
Ensure that executions are properly ordered in the dashboard

### DIFF
--- a/app/views/good_job/jobs/show.html.erb
+++ b/app/views/good_job/jobs/show.html.erb
@@ -84,4 +84,4 @@
   <%= tag.pre JSON.pretty_generate(@job.display_serialized_params) %>
 <% end %>
 
-<%= render 'executions', executions: @job.executions.reverse %>
+<%= render 'executions', executions: @job.executions.sort_by(&:number).reverse %>


### PR DESCRIPTION
They are not ordered, so postgres may return them in any order. I encounter this on postgres 17, checked the demo app to link to but didn't find any. For reference, locally:

![image](https://github.com/user-attachments/assets/1bd0dce1-dc68-4f9c-aa32-c96d02264af9)
