### PR TITLE
Order Dashboard jobs in more "natural" order

### DIFF
--- a/app/filters/good_job/base_filter.rb
+++ b/app/filters/good_job/base_filter.rb
@@ -13,13 +13,15 @@ module GoodJob
     end
 
     def records
-      after_scheduled_at = params[:after_scheduled_at].present? ? Time.zone.parse(params[:after_scheduled_at]) : nil
+      after_at = params[:after_at].present? ? Time.zone.parse(params[:after_at]) : nil
+      after_id = params[:after_id] if after_at
+      limit = params.fetch(:limit, DEFAULT_LIMIT)
 
       query_for_records.display_all(
-        state: params[:state],
-        after_scheduled_at: after_scheduled_at,
-        after_id: params[:after_id]
-      ).limit(params.fetch(:limit, DEFAULT_LIMIT))
+        ordered_by: ordered_by,
+        after_at: after_at,
+        after_id: after_id
+      ).limit(limit)
     end
 
     def last
@@ -65,6 +67,19 @@ module GoodJob
 
     def filtered_count
       filtered_query.count
+    end
+
+    def ordered_by
+      %w[created_at desc]
+    end
+
+    def next_page_params
+      order_column = ordered_by.first
+
+      {
+        after_at: records.last&.send(order_column),
+        after_id: records.last&.id,
+      }.merge(to_params)
     end
 
     private

--- a/app/filters/good_job/base_filter.rb
+++ b/app/filters/good_job/base_filter.rb
@@ -16,6 +16,7 @@ module GoodJob
       after_scheduled_at = params[:after_scheduled_at].present? ? Time.zone.parse(params[:after_scheduled_at]) : nil
 
       query_for_records.display_all(
+        state: params[:state],
         after_scheduled_at: after_scheduled_at,
         after_id: params[:after_id]
       ).limit(params.fetch(:limit, DEFAULT_LIMIT))

--- a/app/filters/good_job/batches_filter.rb
+++ b/app/filters/good_job/batches_filter.rb
@@ -2,17 +2,12 @@
 
 module GoodJob
   class BatchesFilter < BaseFilter
-    def records
-      after_created_at = params[:after_created_at].present? ? Time.zone.parse(params[:after_created_at]) : nil
-
-      filtered_query.display_all(
-        after_created_at: after_created_at,
-        after_id: params[:after_id]
-      ).limit(params.fetch(:limit, DEFAULT_LIMIT))
-    end
-
     def filtered_query(_filtered_params = params)
       base_query
+    end
+
+    def query_for_records
+      default_base_query
     end
 
     def default_base_query

--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -53,6 +53,19 @@ module GoodJob
       @_filtered_count ||= filtered_query.unscope(:select).count
     end
 
+    def ordered_by
+      case params[:state]
+      when "scheduled", "retried", "pending", "queued"
+        %w[scheduled_at asc]
+      when "running"
+        %w[performed_at desc]
+      when "finished", "discarded"
+        %w[finished_at desc]
+      else
+        %w[created_at desc]
+      end
+    end
+
     private
 
     def query_for_records

--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -7,29 +7,27 @@ module GoodJob
 
     included do
       # Get records in display order with optional keyset pagination.
-      # @!method display_all(after_scheduled_at: nil, after_id: nil)
+      # @!method display_all(ordered_by: ["created_at", "desc"], after_at: nil, after_id: nil)
       # @!scope class
-      # @param after_scheduled_at [DateTime, String, nil]
-      #   Display records scheduled after this time for keyset pagination
+      # @param ordered_by [Array<String>]
+      #   Order to display records, from Filter#ordered_by
+      # @param after_at [DateTime, String, nil]
+      #   Display records after this time for keyset pagination
       # @param after_id [Numeric, String, nil]
       #   Display records after this ID for keyset pagination
       # @return [ActiveRecord::Relation]
-      scope :display_all, (lambda do |state: nil, after_scheduled_at: nil, after_id: nil|
-        query = if state == 'scheduled'
-                  order(Arel.sql('scheduled_at ASC, id DESC'))
-                else
-                  order(Arel.sql('scheduled_at DESC, id DESC'))
-                end
-        if after_scheduled_at.present? && after_id.present?
-          query = if state == 'scheduled'
-                    query.where Arel::Nodes::Grouping.new([arel_table["scheduled_at"], arel_table["id"]]).gteq(Arel::Nodes::Grouping.new([bind_value('scheduled_at', after_scheduled_at, ActiveRecord::Type::DateTime), bind_value('id', after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)]))
-                  else
-                    query.where Arel::Nodes::Grouping.new([arel_table["scheduled_at"], arel_table["id"]]).lt(Arel::Nodes::Grouping.new([bind_value('scheduled_at', after_scheduled_at, ActiveRecord::Type::DateTime), bind_value('id', after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)]))
-                  end
-        elsif after_scheduled_at.present?
-          query = query.where arel_table["scheduled_at"].lt(bind_value('scheduled_at', after_scheduled_at, ActiveRecord::Type::DateTime))
+      scope :display_all, (lambda do |ordered_by: %w[created_at desc], after_at: nil, after_id: nil|
+        order_column, order_direction = ordered_by
+        query = self
+
+        if after_at.present? && after_id.present?
+          query = query.where Arel::Nodes::Grouping.new([arel_table[order_column], arel_table[primary_key]]).send(
+            order_direction == 'asc' ? :gteq : :lt,
+            Arel::Nodes::Grouping.new([bind_value(order_column, after_at, ActiveRecord::Type::DateTime), bind_value(primary_key, after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)])
+          )
         end
-        query
+
+        query.order Arel.sql("#{order_column} #{order_direction}, #{primary_key} #{order_direction}")
       end)
 
       # Search records by text query.

--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -24,7 +24,7 @@ module GoodJob
     alias_attribute :discarded?, :discarded_at
     alias_attribute :finished?, :finished_at
 
-    scope :display_all, (lambda do |_state: nil, after_created_at: nil, after_id: nil|
+    scope :display_all, (lambda do |state: nil, after_created_at: nil, after_id: nil| # rubocop:disable Lint/UnusedBlockArgument
       query = order(created_at: :desc, id: :desc)
       if after_created_at.present? && after_id.present?
         query = if Gem::Version.new(Rails.version) < Gem::Version.new('7.0.0.a') || Concurrent.on_jruby?

--- a/app/models/good_job/batch_record.rb
+++ b/app/models/good_job/batch_record.rb
@@ -24,7 +24,7 @@ module GoodJob
     alias_attribute :discarded?, :discarded_at
     alias_attribute :finished?, :finished_at
 
-    scope :display_all, (lambda do |after_created_at: nil, after_id: nil|
+    scope :display_all, (lambda do |_state: nil, after_created_at: nil, after_id: nil|
       query = order(created_at: :desc, id: :desc)
       if after_created_at.present? && after_id.present?
         query = if Gem::Version.new(Rails.version) < Gem::Version.new('7.0.0.a') || Concurrent.on_jruby?

--- a/app/views/good_job/batches/index.html.erb
+++ b/app/views/good_job/batches/index.html.erb
@@ -7,7 +7,7 @@
   <nav aria-label="Batch pagination" class="mt-3">
     <ul class="pagination">
       <li class="page-item">
-        <%= link_to(@filter.to_params(after_created_at: @filter.last.created_at, after_id: @filter.last.id), class: "page-link") do %>
+        <%= link_to(@filter.next_page_params, class: "page-link") do %>
           <%= t ".older_batches" %> <span aria-hidden="true">&raquo;</span>
         <% end %>
       </li>

--- a/app/views/good_job/jobs/index.html.erb
+++ b/app/views/good_job/jobs/index.html.erb
@@ -7,7 +7,7 @@
     <nav aria-label="<%= t ".job_pagination" %>" class="mt-3">
       <ul class="pagination">
         <li class="page-item">
-          <%= link_to(@filter.to_params(after_scheduled_at: @filter.last.scheduled_at || @filter.last.created_at, after_id: @filter.last.id), class: "page-link") do %>
+          <%= link_to(@filter.next_page_params, class: "page-link") do %>
             <%= t ".older_jobs" %> <span aria-hidden="true">&raquo;</span>
           <% end %>
         </li>

--- a/spec/app/models/good_job/batch_record_spec.rb
+++ b/spec/app/models/good_job/batch_record_spec.rb
@@ -24,7 +24,7 @@ describe GoodJob::BatchRecord do
       second_job = described_class.create(id: '3732d706-fd5a-4c39-b1a5-a9bc6d265811')
       last_job = described_class.create(id: '4fbae77c-6f22-488f-ad42-5bd20f39c28c')
 
-      result = described_class.display_all(after_created_at: last_job.created_at, after_id: last_job.id)
+      result = described_class.display_all(after_at: last_job.created_at, after_id: last_job.id)
 
       expect(result).to eq [second_job, first_job]
     end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -618,7 +618,7 @@ RSpec.describe GoodJob::Job do
       it 'does not return jobs after last scheduled at' do
         described_class.enqueue(active_job, scheduled_at: '2021-05-14 09:33:16 +0200')
 
-        expect(described_class.display_all(after_scheduled_at: Time.zone.parse('2021-05-14 09:33:16 +0200')).count).to eq(0)
+        expect(described_class.display_all.count).to eq(1)
       end
 
       it 'does not return jobs after last scheduled at and job id' do
@@ -626,7 +626,7 @@ RSpec.describe GoodJob::Job do
         job_id = described_class.last!.id
 
         expect(
-          described_class.display_all(after_scheduled_at: Time.zone.parse('2021-05-14 09:33:16 +0200'), after_id: job_id).count
+          described_class.display_all(after_at: Time.zone.parse('2021-05-14 09:33:16 +0200'), after_id: job_id).count
         ).to eq(0)
       end
     end


### PR DESCRIPTION
"Next-job-first" makes more sense for the scheduled tab.

Closes #1580.