### PR TITLE
Update `form_with` calls to be compatible with Rails 8

### DIFF
--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: mass_update_jobs_path(filter.to_params), method: :put, local: true, data: { "checkbox-toggle": "job_ids" }) do |form| %>
+<%= form_with(model: false, url: mass_update_jobs_path(filter.to_params), method: :put, local: true, data: { "checkbox-toggle": "job_ids" }) do |form| %>
   <div class="my-3 card" data-gj-poll-replace id="jobs-table">
     <div class="list-group list-group-flush text-nowrap table-jobs" role="table">
       <header class="list-group-item bg-body-tertiary">

--- a/app/views/good_job/shared/_filter.erb
+++ b/app/views/good_job/shared/_filter.erb
@@ -4,7 +4,7 @@
       <h2 class="pt-3 pb-2"><%= title %></h2>
     </div>
 
-    <%= form_with(url: "", method: :get, local: true, id: "filter_form", class: "") do |form| %>
+    <%= form_with(model: false, url: "", method: :get, local: true, id: "filter_form", class: "") do |form| %>
       <%= hidden_field_tag :poll, params[:poll] %>
       <%= hidden_field_tag :state, params[:state] %>
       <%= hidden_field_tag :locale, params[:locale] if params[:locale] %>


### PR DESCRIPTION
[Rails 8 removed deprecated support to passing `nil` to the `model:` argument of `form_with`.](https://github.com/rails/rails/blob/8-0-stable/actionview/CHANGELOG.md#rails-800rc1-october-19-2024)

To make the good job dashboard views compatible with Rails 8, this adds `model: false` to forms in both  `app/views/good_job/jobs/_table.erb` and `app/views/good_job/shared/_filter.erb`.

Without these changes, loading the dashboard in a Rails 8 application causes `ArgumentError (Passed nil to the :model argument, expect an object or false)`.