### PR TITLE
Improve dashboard performance when searching for job ID

### DIFF
--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -2,6 +2,8 @@
 
 module GoodJob
   class JobsFilter < BaseFilter
+    UUID_REGEX = /\A[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\z/i
+
     def state_names
       %w[scheduled retried queued running succeeded discarded]
     end
@@ -25,14 +27,16 @@ module GoodJob
 
       query = query.job_class(filter_params[:job_class]) if filter_params[:job_class].present?
       query = query.where(queue_name: filter_params[:queue_name]) if filter_params[:queue_name].present?
-      query = case filter_params[:query].presence
-              when /\A[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\z/i
-                query.where(active_job_id: filter_params[:query])
-              when nil
-                query # no query parameter were specified
-              else
-                query.search_text(filter_params[:query])
-              end
+
+      search_query = filter_params[:query]&.strip
+      if search_query.present?
+        query = if query_is_uuid_and_job_exists?(search_query)
+                  query.where(active_job_id: search_query)
+                else
+                  query.search_text(search_query)
+                end
+      end
+
       query = query.where(cron_key: filter_params[:cron_key]) if filter_params[:cron_key].present?
       query = query.where(finished_at: finished_since(filter_params[:finished_since])..) if filter_params[:finished_since].present?
 
@@ -96,6 +100,10 @@ module GoodJob
       when '7_days_ago'
         7.days.ago
       end
+    end
+
+    def query_is_uuid_and_job_exists?(search_query)
+      @_query_is_uuid_and_job_exists ||= search_query&.match?(UUID_REGEX) && base_query.exists?(active_job_id: search_query)
     end
   end
 end

--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -25,7 +25,14 @@ module GoodJob
 
       query = query.job_class(filter_params[:job_class]) if filter_params[:job_class].present?
       query = query.where(queue_name: filter_params[:queue_name]) if filter_params[:queue_name].present?
-      query = query.search_text(filter_params[:query]) if filter_params[:query].present?
+      query = case filter_params[:query].presence
+              when /\A[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\z/i
+                query.where(active_job_id: filter_params[:query])
+              when nil
+                query # no query parameter were specified
+              else
+                query.search_text(filter_params[:query])
+              end
       query = query.where(cron_key: filter_params[:cron_key]) if filter_params[:cron_key].present?
       query = query.where(finished_at: finished_since(filter_params[:finished_since])..) if filter_params[:finished_since].present?
 

--- a/spec/app/filters/good_job/jobs_filter_spec.rb
+++ b/spec/app/filters/good_job/jobs_filter_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe GoodJob::JobsFilter do
           expect(filter.records.size).to eq 1
         end
       end
+
+      describe 'Job ID query' do
+        before do
+          params[:query] = GoodJob::Job.last.id
+        end
+
+        it 'returns the job' do
+          expect(filter.records.size).to eq 1
+          expect(filter.records.first).to eq GoodJob::Job.last
+        end
+      end
     end
 
     context 'when filtered by cron_key' do


### PR DESCRIPTION
Because there are no indices for full-text search, searching for a job ID takes an inordinate amount of time. This commit examines the search query and if the only item is a UUID, it specifically searches for a job matching that ID.

Fixes #1618