### PR TITLE
Fix enqueue_after_transaction_commit config

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -367,6 +367,7 @@ module GoodJob
     # @return [Boolean]
     def enqueue_after_transaction_commit
       return options[:enqueue_after_transaction_commit] unless options[:enqueue_after_transaction_commit].nil?
+      return rails_config[:enqueue_after_transaction_commit] unless rails_config[:enqueue_after_transaction_commit].nil?
 
       DEFAULT_ENQUEUE_AFTER_TRANSACTION_COMMIT
     end


### PR DESCRIPTION
Hey Ben 👋 first of all, thanks for this great gem, we chose it as the default for our base app https://github.com/rootstrap/rails_api_base.

I was trying to configure `enqueue_after_transaction_commit = true` by default so that we don't get different behaviors when using the same DB for jobs and the app, or multiple DBs.

I did some testing but couldn't make the config work, I guess it's because I added like:
```ruby

```
Rails.application.configure do
  # Don't depend on transactions
  config.good_job.enqueue_after_transaction_commit = true
```

and that lives in `rails_config` not in `options`. Is that right or did I miss something?