### PR TITLE
Preserve job locale when retrying on dashboard

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -524,7 +524,10 @@ module GoodJob
           current_thread.retry_now = true
 
           transaction do
-            new_active_job = active_job.retry_job(wait: 0, error: error)
+            # NOTE: Required until fixed in rails https://github.com/rails/rails/pull/52121
+            I18n.with_locale(active_job.locale) do
+              new_active_job = active_job.retry_job(wait: 0, error: error)
+            end
             self.error_event = :retried if error
             save!
           end

--- a/spec/requests/good_job/jobs_controller_spec.rb
+++ b/spec/requests/good_job/jobs_controller_spec.rb
@@ -175,4 +175,25 @@ describe GoodJob::JobsController do
       end
     end
   end
+
+  describe 'PUT #retry_job' do
+    let!(:job) do
+      I18n.with_locale("es") do
+        ExampleJob.perform_later(ExampleJob::ERROR_ONCE_TYPE)
+      end
+      job = GoodJob::Job.first
+      job.discard_job("discard!")
+      job
+    end
+
+    it 'preserves the locale' do
+      I18n.with_locale("en") do
+        put good_job.retry_job_path(job.id)
+      end
+
+      executions = job.reload.executions
+      expect(executions[0].serialized_params["locale"]).to eq("es")
+      expect(executions[1].serialized_params["locale"]).to eq("es")
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1630. On the rails side, the locale is not pulled out of the job payload. There is currently a open PR (https://github.com/rails/rails/pull/52121), work around it for now