### PR TITLE
Include error location in formatted errors

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -417,7 +417,11 @@ module GoodJob
     def self.format_error(error)
       raise ArgumentError unless error.is_a?(Exception)
 
-      [error.class.to_s, ERROR_MESSAGE_SEPARATOR, error.message].join
+      [
+        error.class.to_s,
+        error.message,
+        error.backtrace_locations.first
+      ].join(ERROR_MESSAGE_SEPARATOR)
     end
 
     # TODO: it would be nice to enforce these values at the model


### PR DESCRIPTION
In order to debug discarded jobs, the error message alone doesn't necessarily lead to the problem. However, accommodating the complete backtrace is non-trivial as discussed earlier:

https://github.com/bensheldon/good_job/discussions/1123

This PR simply adds the first location off the backtrace only and adds it to the formatted error. In the UI, this will cause at least one additional line on normally sized screens, but it's still very readable in the vast majority of cases. With this location shown on the dashboard, it's much easier to find where the error bubbled up to and then take it from there e.g. by placing a breakpoint and studying the complete backtrace.

I'm monkey patching this in a Rails project, but it may be useful for everybody. Still, this is just a suggestion, so I didn't go through the hassle to set up a fully working development copy incl db and then check whether this breaks tests or whether tests should be added for this.