### PR TITLE
Do not heartbeat when transactional tests / shared connections are in use

### DIFF
--- a/lib/good_job/capsule_tracker.rb
+++ b/lib/good_job/capsule_tracker.rb
@@ -178,6 +178,11 @@ module GoodJob # :nodoc:
 
             @refresh_task = nil
             create_refresh_task
+
+            # This is indicative that transactional tests / shared connections
+            # are used and issuing a heartbeat is unnecessary or a deadlock risk.
+            next if @record && @record.class.connection.open_transactions.positive?
+
             renew(silent: true)
           end
         end


### PR DESCRIPTION
This is somewhat speculative. I'm experiencing a deadlock in:

- A test
- That's using transactional fixtures
- And GoodJob is running inline with `GoodJob.perform_inline_jobs`
