### PR TITLE
Add customisable job index details partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ GoodJob exposes some views that are intended to be overriden by placing views in
 
 - [`app/views/good_job/jobs/_custom_job_details.html.erb`](app/views/good_job/_custom_job_details.html.erb): content added to this partial will be displayed above the argument list on the good_job/jobs#show page.
 - [`app/views/good_job/jobs/_custom_execution_details.html.erb`](app/views/good_job/_custom_execution_details.html.erb): content added to this partial will be displayed above each execution on the good_job/jobs#show page.
+- [`app/views/good_job/_custom_job_index_details.html.erb`](app/views/good_job/_custom_job_index_details.html.erb): content added to this partial will be displayed in the job row on the jobs index page.
 
 **Warning:** these partials expose classes (such as `GoodJob::Job`) that are considered internal implementation details of GoodJob. You should always test your custom partials after upgrading GoodJob.
 

--- a/app/views/good_job/_custom_job_index_details.html.erb
+++ b/app/views/good_job/_custom_job_index_details.html.erb
@@ -1,0 +1,10 @@
+<%#
+Content added to this partial will be displayed in the job row on the jobs index page.
+
+You can make use of the following variables:
+
+- `job`: The `GoodJob::Job` instance.
+- `main_app`: Use this to access helpers (e.g. route helpers) from your application.
+
+Note: the `GoodJob::Job` class is considered an internal implementation detail and may change at any time. Please test your view extensions when upgrading.
+%>

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -67,6 +67,7 @@
                 <div class="ms-2">
                   <%= tag.code link_to(job.id, job_path(job), class: "small text-muted text-decoration-none") %>
                   <%= tag.h5 tag.code(link_to(job.display_name, job_path(job), class: "text-reset text-decoration-none")), class: "text-reset mb-0" %>
+                  <%= render 'good_job/custom_job_index_details', job: job %>
                   <% if job.error %>
                     <div class="mt-1 small">
                       <strong class="small text-danger"><%= t "good_job.shared.error" %>:</strong>

--- a/demo/app/views/good_job/_custom_job_index_details.html.erb
+++ b/demo/app/views/good_job/_custom_job_index_details.html.erb
@@ -1,0 +1,1 @@
+<div class="custom-job-index-details-for-demo"></div>

--- a/spec/system/custom_partials_spec.rb
+++ b/spec/system/custom_partials_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe 'Custom partials' do
     visit good_job.job_path(job.id)
     expect(page).to have_css ".custom-execution-details-for-demo"
   end
+
+  it 'renders custom job index details partial on the jobs index page' do
+    visit good_job.jobs_path
+    expect(page).to have_content 'ExampleJob'
+    expect(page).to have_css '.custom-job-index-details-for-demo'
+  end
 end


### PR DESCRIPTION
Adds a new extension point to the GoodJob dashboard that allows applications to customise the job index page. The new `_custom_job_index_details.html.erb` partial is rendered in each job row providing the same customisation capabilities as the existing job and execution details partials.

An extension of https://github.com/bensheldon/good_job/pull/1200