### PR TITLE
order by scheduled_at instead of created_at when dequeueing job

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -145,7 +145,7 @@ module GoodJob
     scope :dequeueing_ordered, (lambda do |parsed_queues|
       relation = self
       relation = relation.queue_ordered(parsed_queues[:include]) if parsed_queues && parsed_queues[:ordered_queues] && parsed_queues[:include]
-      relation = relation.priority_ordered.creation_ordered
+      relation = relation.priority_ordered.schedule_ordered
 
       relation
     end)

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -97,6 +97,9 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_job_executions, [:active_job_id, :created_at], name: :index_good_job_executions_on_active_job_id_and_created_at
     add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
       where: "finished_at IS NULL AND locked_by_id IS NULL", name: :index_good_jobs_on_priority_scheduled_at_unfinished_unlocked
+    add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_priority_scheduled_at_unfinished"
+
     add_index :good_jobs, :locked_by_id,
       where: "locked_by_id IS NOT NULL", name: "index_good_jobs_on_locked_by_id"
     add_index :good_job_executions, [:process_id, :created_at], name: :index_good_job_executions_on_process_id_and_created_at

--- a/lib/generators/good_job/templates/update/migrations/04_add_index_good_jobs_priority_scheduled_at.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/04_add_index_good_jobs_priority_scheduled_at.rb.erb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsPriorityScheduledAt < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_exists? :good_jobs, [:priority, :scheduled_at], name: "index_good_jobs_on_priority_scheduled_at_unfinished"
+      end
+    end
+
+    add_index :good_jobs, [:priority, :scheduled_at], order: { priority: "ASC NULLS LAST", scheduled_at: :asc },
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_priority_scheduled_at_unfinished",
+                                                      algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
In our production environment, we have a largish number of jobs (approx 70,000) that are scheduled to run in the future.

When performing the query to select a job as part of `perform_with_advisory_lock` in our production environment, we have noticed that the query can be quite slow (p50 is around 50ms). 

The query is using the `index_good_job_jobs_for_candidate_lookup` index on priority and created_at even though the vast majority of the records are not eligible to be returned due to the condition on the scheduled_at column. 

This PR changes the order that is used when finding a job to use the `scheduled_at` instead of the `created_at` and adds an index for this query. This allows the same index to be used for ordering the records as well as finding ones that are eligible to execute and is now performing this query much faster (p50 is 2ms).

It is not clear to me if there is any reason to prefer created_at over scheduled_at when ordering jobs to perform, so this PR just changes the order, but if there is a case where created_at is strongly preferred this could be changed to a configuration option instead.

There may be indexes that are no longer required once this index and query change is in place, but I think that they would needy to be removed seperately in a later version so that the indexes aren't removed while the queries that use them could still be running.
