### PR TITLE
Make the processes page more responsive by extracting queues and max_threads

### DIFF
--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -44,8 +44,9 @@
           <div class="col mw-100 text-truncate">
             <% process.schedulers.each do |scheduler| %>
               <%- scheduler_name = scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>
-              <pre class="text-truncate mb-0" title="<%= scheduler_name %>">
-                <%= scheduler_name %>
+              <%- scheduler_details = scheduler_name.match(/\(([^)]+)\)/)&.[](1) || scheduler_name %>
+              <pre class="text-truncate mb-0" title="<%= scheduler_details %>">
+                <%= scheduler_details %>
               </pre>
             <% end %>
           </div>

--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -41,13 +41,9 @@
               <span class="badge rounded-pill bg-body-secondary text-secondary"><%= (process.state["memory"] / 1024).to_i %> MB</span>
             </div>
           </div>
-          <div class="col mw-100 text-truncate">
-            <% process.schedulers.each do |scheduler| %>
-              <%- scheduler_name = scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>
-              <%- scheduler_details = scheduler_name.match(/\(([^)]+)\)/)&.[](1) || scheduler_name %>
-              <pre class="text-truncate mb-0" title="<%= scheduler_details %>">
-                <%= scheduler_details %>
-              </pre>
+          <div class="col mw-100">
+            <% process.schedulers.each do |scheduler_data| %>
+              <pre class="mb-0" title="<%= scheduler_data %>">queues=<%= scheduler_data["queues"] %> max_threads=<%= scheduler_data["max_threads"] %></pre>
             <% end %>
           </div>
           <div class="col-2 small"><%= t(ActiveModel::Type::Boolean.new.cast(process.state["cron_enabled"]), scope: "good_job.shared.boolean") %></div>

--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -43,8 +43,9 @@
           </div>
           <div class="col mw-100 text-truncate">
             <% process.schedulers.each do |scheduler| %>
-              <pre class="text-truncate mb-0" title="<%= scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>">
-                <%= scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>
+              <%- scheduler_name = scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>
+              <pre class="text-truncate mb-0" title="<%= scheduler_name %>">
+                <%= scheduler_name %>
               </pre>
             <% end %>
           </div>

--- a/app/views/good_job/processes/index.html.erb
+++ b/app/views/good_job/processes/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class="card my-3" data-live-poll-region="processes">
-  <div class="list-group list-group-flush text-nowrap" role="table">
+  <div class="list-group list-group-flush" role="table">
     <header class="list-group-item bg-body-tertiary">
       <div class="row small text-muted text-uppercase align-items-center">
         <div class="col"><%= t ".process" %></div>
@@ -41,9 +41,11 @@
               <span class="badge rounded-pill bg-body-secondary text-secondary"><%= (process.state["memory"] / 1024).to_i %> MB</span>
             </div>
           </div>
-          <div class="col">
+          <div class="col mw-100 text-truncate">
             <% process.schedulers.each do |scheduler| %>
-              <pre class="mb-0"><%= scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %></pre>
+              <pre class="text-truncate mb-0" title="<%= scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>">
+                <%= scheduler.is_a?(Hash) ? scheduler['name'] : scheduler %>
+              </pre>
             <% end %>
           </div>
           <div class="col-2 small"><%= t(ActiveModel::Type::Boolean.new.cast(process.state["cron_enabled"]), scope: "good_job.shared.boolean") %></div>


### PR DESCRIPTION
Hey 👋🏻 

I noticed that on my Macbook 14, the processes page looks off

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/624029b9-14f4-46cf-98b3-e48ca6d4d5ff" />



I played around a bit with the view (though I'm not really versed in Bootstrap) and managed to get to this (this is around 1300px but looks like this, even under 1000px)

<img width="915" alt="image" src="https://github.com/user-attachments/assets/0d0e9cde-a873-4896-a151-b2038eb3500c" />


because I truncated the schedulers, I had to add `title` to it so we can see what's going on when we leave the cursor on top of it
