### PR TITLE
Add state column to cron entries table

### DIFF
--- a/app/views/good_job/cron_entries/index.html.erb
+++ b/app/views/good_job/cron_entries/index.html.erb
@@ -6,12 +6,13 @@
   <div class="list-group list-group-flush text-nowrap" role="table">
     <header class="list-group-item body-secondary">
       <div class="row small text-muted text-uppercase align-items-center">
-        <div class="col-12 col-lg-2"></div>
-        <div class="col-6 col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.class" %></div>
-        <div class="col-6 col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.schedule" %></div>
-        <div class="col-6 col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.next_scheduled" %></div>
-        <div class="col-6 col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.last_run" %></div>
-        <div class="col text-end">
+        <div class="col-lg-2"></div>
+        <div class="col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.class" %></div>
+        <div class="col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.schedule" %></div>
+        <div class="col-lg-2 d-none d-lg-block"><%= t "good_job.models.cron.next_scheduled" %></div>
+        <div class="col-lg-1 d-none d-lg-block"><%= t "good_job.models.cron.last_run" %></div>
+        <div class="col-lg-1 d-none d-lg-block"><%= t "good_job.models.cron.state" %></div>
+        <div class="col-lg-2 text-end">
           <%= tag.button type: "button", class: "btn btn-sm text-muted", role: "button",
                          data: { bs_toggle: "collapse", bs_target: ".cron-entry-properties" },
                          aria: { expanded: false, controls: @cron_entries.map { |cron_entry| "##{dom_id(cron_entry, 'properties')}" }.join(" ") } do %>
@@ -37,13 +38,21 @@
             <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.cron.next_scheduled" %></div>
             <%= relative_time cron_entry.next_at %>
           </div>
-          <div class="col-6 col-lg-2 text-wrap small">
+          <div class="col-6 col-lg-1 text-wrap small">
             <% if cron_entry.last_job.present? %>
               <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.cron.last_run" %></div>
               <%= link_to relative_time(cron_entry.last_job_at), cron_entry_path(cron_entry), title: "Job #{cron_entry.last_job.id}" %>
             <% end %>
           </div>
-          <div class="col d-flex gap-3 justify-content-end">
+          <div class="col-6 col-lg-1 text-wrap small">
+            <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.cron.state" %></div>
+            <% if cron_entry.enabled? %>
+              <span class="text-success"><%= t "good_job.models.cron.states.active" %></span>
+            <% else %>
+              <span class="text-muted"><%= t "good_job.models.cron.states.paused" %></span>
+            <% end %>
+          </div>
+          <div class="col-lg-2 d-flex gap-3 justify-content-end">
             <%= button_to enqueue_cron_entry_path(cron_entry), method: :post, class: "btn btn-sm btn-outline-primary", form_class: "d-inline-block", aria: { label: t("good_job.cron_entries.actions.enqueue") }, title: t("good_job.cron_entries.actions.enqueue"), data: { confirm: t("good_job.cron_entries.actions.confirm_enqueue") } do %>
               <%= render_icon "skip_forward" %>
             <% end %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -191,6 +191,10 @@ de:
         last_run: Letzter Lauf
         next_scheduled: Als nächstes geplant
         schedule: Zeitplan
+        state: Status
+        states:
+          active: Aktiv
+          paused: Pausiert
       job:
         arguments: Argumente
         attempts: Versuche

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,6 +191,10 @@ en:
         last_run: Last run
         next_scheduled: Next scheduled
         schedule: Schedule
+        state: State
+        states:
+          active: Active
+          paused: Paused
       job:
         arguments: Arguments
         attempts: Attempts

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -191,6 +191,10 @@ es:
         last_run: Última ejecución
         next_scheduled: Próxima ejecución
         schedule: Cronograma
+        state: Estado
+        states:
+          active: Activo
+          paused: Pausado
       job:
         arguments: Argumentos
         attempts: Intentos

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -191,6 +191,10 @@ fr:
         last_run: Dernière exécution
         next_scheduled: Prochaine exécution
         schedule: Planification
+        state: État
+        states:
+          active: Actif
+          paused: En pause
       job:
         arguments: Paramètres
         attempts: Tentatives

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -191,6 +191,10 @@ it:
         last_run: Ultima esecuzione
         next_scheduled: Prossima pianificazione
         schedule: Pianificazione
+        state: Stato
+        states:
+          active: Attivo
+          paused: In pausa
       job:
         arguments: Argomenti
         attempts: Tentativi

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -191,6 +191,10 @@ ja:
         last_run: 前回実行日時
         next_scheduled: 次回予定日時
         schedule: スケジュール
+        state: 状態
+        states:
+          active: アクティブ
+          paused: 一時停止
       job:
         arguments: 引数
         attempts: 試行回数

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -191,6 +191,10 @@ ko:
         last_run: 마지막 실행 일시
         next_scheduled: 다음 예정 일시
         schedule: 스케줄
+        state: 상태
+        states:
+          active: 활성
+          paused: 일시정지
       job:
         arguments: 인수
         attempts: 시도 횟수

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -191,6 +191,10 @@ nl:
         last_run: Laatste ronde
         next_scheduled: Volgende gepland
         schedule: Schema
+        state: Status
+        states:
+          active: Actief
+          paused: Gepauzeerd
       job:
         arguments: Argumenten
         attempts: Pogingen

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -191,6 +191,10 @@ pt-BR:
         last_run: Última execução
         next_scheduled: Próximo agendamento
         schedule: Agendamento
+        state: Estado
+        states:
+          active: Ativo
+          paused: Pausado
       job:
         arguments: Argumentos
         attempts: Tentativas

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -217,6 +217,10 @@ ru:
         last_run: Последний запуск
         next_scheduled: Следующий по расписанию
         schedule: Расписание
+        state: Состояние
+        states:
+          active: Активно
+          paused: Приостановлено
       job:
         arguments: Параметры
         attempts: Попытки

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -191,6 +191,10 @@ tr:
         last_run: Son çalıştırma
         next_scheduled: Sonraki planlama
         schedule: Program
+        state: Durum
+        states:
+          active: Aktif
+          paused: Duraklatıldı
       job:
         arguments: Argümanlar
         attempts: Denemeler

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -217,6 +217,10 @@ uk:
         last_run: Останній запуск
         next_scheduled: Наступне заплановане
         schedule: Розклад
+        state: Стан
+        states:
+          active: Активний
+          paused: Призупинено
       job:
         arguments: Аргументи
         attempts: Спроби


### PR DESCRIPTION
## Summary
- Adds a new "State" column to the cron entries table showing Active/Paused status
- Makes cron entry state more visible alongside the existing play/pause action buttons
- Includes translations for all 12 supported languages

## Changes
1. **UI Enhancement**: Added state column to cron entries index view
2. **Translations**: Added "State", "Active", and "Paused" labels in all supported languages:
   - German (de)
   - Spanish (es)
   - French (fr)
   - Italian (it)
   - Japanese (ja)
   - Korean (ko)
   - Dutch (nl)
   - Portuguese-BR (pt-BR)
   - Russian (ru)
   - Turkish (tr)
   - Ukrainian (uk)

## Test plan
- [ ] View cron entries page and verify state column displays correctly
- [ ] Test with different locales to ensure translations work
- [ ] Verify column layout remains responsive on different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)