### PR TITLE
Remove circular dependency of requiring good_job in engine

### DIFF
--- a/lib/good_job/engine.rb
+++ b/lib/good_job/engine.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails"
-require "good_job"
 
 module GoodJob
   # Ruby on Rails integration.


### PR DESCRIPTION
Fixes issue I introduced in #1653 

https://github.com/bensheldon/good_job/pull/1653#discussion_r2177176077