### PR TITLE
Docufix: correct connects_to statement for multiple databases setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Good Job’s general behavior can also be configured via attributes directly on 
     ```ruby
     # config/initializers/good_job.rb
     GoodJob.configure_active_record do
-      connects_to database: :special_database
+      connects_to database: { writing: :special_database }
       self.table_name_prefix = "special_application_"
     end
     ```


### PR DESCRIPTION
As layed out [in an issue comment](https://github.com/bensheldon/good_job/issues/1254#issuecomment-1952899071), the documentation for a configuring a separate good_job database connection was wrong.