### PR TITLE
UI: Add `.text-wrap` to the Cron Entry key

### DIFF
--- a/app/views/good_job/cron_entries/index.html.erb
+++ b/app/views/good_job/cron_entries/index.html.erb
@@ -25,7 +25,7 @@
       <div id="<%= dom_id(cron_entry) %>" class="list-group-item py-3" role="row">
         <div class="row align-items-center">
           <div class="col-12 col-lg-2">
-            <div class="small font-monospace"><%= cron_entry.key %></div>
+            <div class="small font-monospace text-wrap"><%= cron_entry.key %></div>
             <div class="small text-muted text-wrap"><%= cron_entry.description %></div>
           </div>
           <div class="col-12 col-lg-2 text-wrap"><%= tag.span tag.code(cron_entry.job_class), class: "fs-5 mb-0" %></div>


### PR DESCRIPTION
Add the `.text-wrap` class to the cell that renders the `cron_entry.key` value.

Before
---

<img width="573" height="96" alt="Screenshot 2025-08-06 at 12 17 05 PM" src="https://github.com/user-attachments/assets/4b5e7169-3cce-4a6b-9cdd-508b3590e7a0" />

After
---

<img width="573" height="96" alt="Screenshot 2025-08-06 at 12 22 10 PM" src="https://github.com/user-attachments/assets/16c49dc9-f907-43f6-8de8-22226efdf896" />

