### PR TITLE
Remove obsolete property from tests

### DIFF
--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -567,7 +567,6 @@ RSpec.describe GoodJob::Job do
       let!(:large_priority_job) { described_class.create!(priority: 50) }
 
       it 'orders with smaller number being HIGHER priority' do
-        allow(Rails.application.config).to receive(:good_job).and_return({ smaller_number_is_higher_priority: true })
         expect(described_class.priority_ordered.pluck(:priority)).to eq([-50, 50])
       end
     end


### PR DESCRIPTION
It was removed in #1453

Side note: please bring this option back!! I'm currently monkeypatching it in, but I don't like doing so.