### PR TITLE
Improve warning color contrast

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -528,9 +528,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
+  arm64-darwin
   universal-java-11
   universal-java-20
   x86_64-darwin-23

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -64,3 +64,9 @@
   height: 1rem;
   width: 1rem;
 }
+
+/* Improve warning color contrast by using orange instead of yellow */
+:root {
+  --bs-warning: var(--bs-orange);
+  --bs-warning-rgb: 253, 126, 20;
+}


### PR DESCRIPTION
The current yellow color is quite difficult to see, since the text is white. This makes it a lot more readable and accessible for users who have vision impairments.

Also, when I ran `bundler install`, it tried to add `arm64-darwin-25` to the lockfile. I switched it to be version-independent, so that this won't happen again in the future. See also: https://github.com/rubygems/rubygems/issues/7407

<table border=0>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="352" height="119" alt="Screenshot 2025-09-22 at 9 28 23 AM" src="https://github.com/user-attachments/assets/fe7b15a9-8f5c-4bdb-bf0d-122e97c5e25d" />

</td>
<td>
<img width="351" height="234" alt="Screenshot 2025-09-22 at 9 28 04 AM" src="https://github.com/user-attachments/assets/4e94e1af-1194-4c47-99d8-1ec83357174e" />

</td>
</tr>

<tr>
<td>
<img width="344" height="117" alt="Screenshot 2025-09-22 at 9 28 20 AM" src="https://github.com/user-attachments/assets/07984b81-627d-4a1b-9cc3-a1f714037ef1" />

</td>

<td>
<img width="362" height="244" alt="Screenshot 2025-09-22 at 9 28 10 AM" src="https://github.com/user-attachments/assets/c7ce3fcc-7d12-4822-8940-a47ab42f53d6" />

</td>
</tr>
</tbody>
</table>