### PR TITLE
Add CI for Rails 8.1 (rc) and use postgres 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       DISABLE_SPRING: 1
     services:
       postgres:
-        image: postgres:17
+        image: postgres:18
         env:
           POSTGRES_USER: good_job
           POSTGRES_DB: good_job_test
@@ -93,8 +93,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.0", 3.1, 3.2, 3.3, 3.4]
-        gemfile: [rails_6.1, rails_7.0, rails_7.1, rails_7.2, rails_8.0, rails_head]
-        pg: [17]
+        gemfile: [rails_6.1, rails_7.0, rails_7.1, rails_7.2, rails_8.0, rails_8.1, rails_head]
+        pg: [18]
         include:
           - ruby: 3.4
             gemfile: rails_7.2
@@ -108,6 +108,11 @@ jobs:
             gemfile: rails_8.0
           - ruby: 3.1
             gemfile: rails_8.0
+          # Rails 8.1 is >= 3.2
+          - ruby: "3.0"
+            gemfile: rails_8.1
+          - ruby: 3.1
+            gemfile: rails_8.1
           # Rails head is >= 3.2
           - ruby: "3.0"
             gemfile: rails_head

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ rails_versions = {
   "7.1" => "~> 7.1.0",
   "7.2" => "~> 7.2.0",
   "8.0" => "~> 8.0.0",
+  "8.1" => "~> 8.1.0.rc1",
   "head" => { github: "rails/rails", branch: "main" },
 }
 gem 'rails', rails_versions[ENV.fetch("RAILS_VERSION", "8.0")]

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+ENV["RAILS_VERSION"] = "8.1"
+
+eval_gemfile "../Gemfile"


### PR DESCRIPTION
Rails 8.1 is not to far of from being released. Postgres 18 is also available now (still testing against pg10 in the matrix)