### PR TITLE
Add title to Good Job Dashboard layout

### DIFF
--- a/app/views/layouts/good_job/application.html.erb
+++ b/app/views/layouts/good_job/application.html.erb
@@ -32,6 +32,8 @@
 
     <%= tag.script "import \"application\";".html_safe, type: "module", nonce: content_security_policy_nonce %>
 
+    <title>Good Job Dashboard</title>
+    <%= tag.link rel: "icon", href: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="10 0 100 100"><text y=".90em" font-size="90">👍</text></svg>' %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 


### PR DESCRIPTION
This was removed in [this PR][pr], though it looks like it might not
have been intentional. A `<title>` element helps the page meet
[accessibility requirements][ar].

This also restores the favicon which was unintentionally removed.

[pr]: https://github.com/bensheldon/good_job/pull/1658
[ar]: https://dequeuniversity.com/rules/axe/4.11/document-title?application=axeAPI