### PR TITLE
Check for graceful shutdown inside job cleanup loops

### DIFF
--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -217,6 +217,8 @@ module GoodJob
       jobs_query = GoodJob::Job.finished_before(timestamp).order(finished_at: :asc).limit(in_batches_of)
       jobs_query = jobs_query.succeeded unless include_discarded
       loop do
+        break if GoodJob.current_thread_shutting_down?
+
         active_job_ids = jobs_query.pluck(:active_job_id)
         break if active_job_ids.empty?
 
@@ -230,6 +232,8 @@ module GoodJob
       batches_query = GoodJob::BatchRecord.finished_before(timestamp).limit(in_batches_of)
       batches_query = batches_query.succeeded unless include_discarded
       loop do
+        break if GoodJob.current_thread_shutting_down?
+
         deleted = batches_query.delete_all
         break if deleted.zero?
 


### PR DESCRIPTION
This is really just following our own advice :) https://github.com/bensheldon/good_job/blob/main/README.md#Interrupts-graceful-shutdown-and-SIGKILL

We are planning to do some significant cleanup of old jobs and I want to make ensure I'm not going to run into a SIGKILL.