### PR TITLE
Update suggested Puma config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,16 +1302,18 @@ Depending on your application configuration, you may need to take additional ste
     ```ruby
     # config/puma.rb
 
-    before_fork do
-      GoodJob.shutdown
-    end
+    if ENV.fetch("WEB_CONCURRENCY", 0).to_i > 0
+      before_fork do
+        GoodJob.shutdown
+      end
 
-    on_worker_boot do
-      GoodJob.restart
-    end
+      before_worker_boot do
+        GoodJob.restart
+      end
 
-    on_worker_shutdown do
-      GoodJob.shutdown
+      before_worker_shutdown do
+        GoodJob.shutdown
+      end
     end
 
     MAIN_PID = Process.pid


### PR DESCRIPTION
- Do not use deprecated hooks
- Do not apply the configuration when Puma is not in Cluster mode

Prevents the following warnings:

```
Use 'before_worker_boot', 'on_worker_boot' is deprecated and will be removed in v8
Use 'before_worker_shutdown', 'on_worker_shutdown' is deprecated and will be removed in v8
Warning: The code in the `before_fork` block will not execute in the current Puma configuration. The `before_fork` block only executes in Puma's cluster mode. To fix this, either remove the `before_fork` call or increase Puma's worker count above zero. 
Warning: The code in the `before_worker_boot` block will not execute in the current Puma configuration. The `before_worker_boot` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_boot` call or increase Puma's worker count above zero. 
Warning: The code in the `before_worker_shutdown` block will not execute in the current Puma configuration. The `before_worker_shutdown` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_shutdown` call or increase Puma's worker count above zero. 
Warning: The code in the `before_fork` block will not execute in the current Puma configuration. The `before_fork` block only executes in Puma's cluster mode. To fix this, either remove the `before_fork` call or increase Puma's worker count above zero. 
Warning: The code in the `before_worker_boot` block will not execute in the current Puma configuration. The `before_worker_boot` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_boot` call or increase Puma's worker count above zero. 
Warning: The code in the `before_worker_shutdown` block will not execute in the current Puma configuration. The `before_worker_shutdown` block only executes in Puma's cluster mode. To fix this, either remove the `before_worker_shutdown` call or increase Puma's worker count above zero. 
```