### PR TITLE
Fix search_text scope using mismatched text search configurations

### DIFF
--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -43,8 +43,8 @@ module GoodJob
         # TODO: turn this into proper bind parameters in Arel
         tsvector = "(to_tsvector('english', id::text) || to_tsvector('english', COALESCE(active_job_id::text, '')) || to_tsvector('english', serialized_params) || to_tsvector('english', COALESCE(serialized_params->>'arguments', '')) || to_tsvector('english', COALESCE(error, '')) || to_tsvector('english', COALESCE(array_to_string(labels, ' '), '')))"
         to_tsquery_function = database_supports_websearch_to_tsquery? ? 'websearch_to_tsquery' : 'plainto_tsquery'
-        where("#{tsvector} @@ #{to_tsquery_function}(?)", query)
-          .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, #{to_tsquery_function}(?))"), query]) => 'DESC')
+        where("#{tsvector} @@ #{to_tsquery_function}('english', ?)", query)
+          .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, #{to_tsquery_function}('english', ?))"), query]) => 'DESC')
       end)
     end
 


### PR DESCRIPTION
The search_text scope builds tsvectors with an explicit 'english' configuration but calls websearch_to_tsquery/plainto_tsquery without one, falling back to the server's default_text_search_config. When that default is not 'english', the differing stemming rules cause the @@ operator to return no matches.

Pass 'english' explicitly to the tsquery function calls to match the tsvector configuration.