### PR TITLE
Introduce cleanup_preserved_jobs_max_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Available configuration options are:
 - `cron` (hash) cron configuration. Defaults to `{}`. You can also set this as a JSON string with the environment variable `GOOD_JOB_CRON`
 - `cleanup_discarded_jobs` (boolean) whether to destroy discarded jobs when cleaning up preserved jobs using the `$ good_job cleanup_preserved_jobs` CLI command or calling `GoodJob.cleanup_preserved_jobs`. Defaults to `true`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_DISCARDED_JOBS`. _This configuration is only used when {GoodJob.preserve_job_records} is `true`._
 - `cleanup_preserved_jobs_before_seconds_ago` (integer) number of seconds to preserve jobs when using the `$ good_job cleanup_preserved_jobs` CLI command or calling `GoodJob.cleanup_preserved_jobs`. Defaults to `1209600` (14 days). Can also be set with  the environment variable `GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO`.  _This configuration is only used when {GoodJob.preserve_job_records} is `true`._
+- `cleanup_preserved_jobs_max_count` (integer) maximum number of preserved jobs and executions to keep. Defaults to `nil` (disabled). Can also be set with the environment variable `GOOD_JOB_CLEANUP_PRESERVED_JOBS_MAX_COUNT`.
 - `cleanup_interval_jobs` (integer) Number of jobs a Scheduler will execute before cleaning up preserved jobs. Defaults to `1000`. Disable with `false`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_JOBS` and disabled with `0`).
 - `cleanup_interval_seconds` (integer) Number of seconds a Scheduler will wait before cleaning up preserved jobs. Defaults to `600` (10 minutes). Disable with `false`. Can also be set with  the environment variable `GOOD_JOB_CLEANUP_INTERVAL_SECONDS` and disabled with `0`).
 - `inline_execution_respects_schedule` (boolean) Opt-in to future behavior of inline execution respecting scheduled jobs. Defaults to `false`.
@@ -1397,6 +1398,7 @@ GoodJob will automatically delete preserved job records after 14 days. The reten
 
 ```ruby
 config.good_job.cleanup_preserved_jobs_before_seconds_ago = 14.days
+config.good_job.cleanup_preserved_jobs_max_count = 1_000 # Hard cap for preserved jobs/executions.
 config.good_job.cleanup_interval_jobs = 1_000 # Number of executed jobs between deletion sweeps.
 config.good_job.cleanup_interval_seconds = 10.minutes # Number of seconds between deletion sweeps.
 ```

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -204,8 +204,14 @@ module GoodJob
   # destroy old records and preserve space in your database.
   # @param older_than [nil,Numeric,ActiveSupport::Duration] Jobs older than this will be destroyed (default: +86400+).
   # @param include_discarded [Boolean] Whether or not to destroy discarded jobs (default: per +cleanup_discarded_jobs+ config option)
+  # @param max_count [Integer, nil] Maximum number of preserved jobs/executions to keep. +nil+ disables count-based cleanup.
   # @return [Integer] Number of job execution records and batches that were destroyed.
-  def self.cleanup_preserved_jobs(older_than: nil, in_batches_of: 1_000, include_discarded: GoodJob.configuration.cleanup_discarded_jobs?)
+  def self.cleanup_preserved_jobs(
+    older_than: nil,
+    in_batches_of: 1_000,
+    include_discarded: GoodJob.configuration.cleanup_discarded_jobs?,
+    max_count: GoodJob.configuration.cleanup_preserved_jobs_max_count
+  )
     older_than ||= GoodJob.configuration.cleanup_preserved_jobs_before_seconds_ago
     timestamp = Time.current - older_than
 
@@ -238,6 +244,34 @@ module GoodJob
         break if deleted.zero?
 
         deleted_batches_count += deleted
+      end
+
+      if max_count&.positive?
+        loop do
+          break if GoodJob.current_thread_shutting_down?
+
+          capped_jobs_query = GoodJob::Job.finished.order(finished_at: :desc)
+          capped_jobs_query = capped_jobs_query.succeeded unless include_discarded
+
+          active_job_ids = capped_jobs_query.offset(max_count).limit(in_batches_of).pluck(:active_job_id)
+          break if active_job_ids.empty?
+
+          deleted_executions = GoodJob::Execution.where(active_job_id: active_job_ids).delete_all
+          deleted_executions_count += deleted_executions
+
+          deleted_jobs = GoodJob::Job.where(active_job_id: active_job_ids).delete_all
+          deleted_jobs_count += deleted_jobs
+        end
+
+        loop do
+          break if GoodJob.current_thread_shutting_down?
+
+          execution_ids = GoodJob::Execution.finished.order(finished_at: :desc).offset(max_count).limit(in_batches_of).pluck(:id)
+          break if execution_ids.empty?
+
+          deleted_executions = GoodJob::Execution.where(id: execution_ids).delete_all
+          deleted_executions_count += deleted_executions
+        end
       end
 
       payload[:destroyed_batches_count] = deleted_batches_count

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -25,6 +25,8 @@ module GoodJob
     DEFAULT_CLEANUP_INTERVAL_JOBS = 1_000
     # Default number of seconds to wait between preserved job cleanup runs
     DEFAULT_CLEANUP_INTERVAL_SECONDS = 10.minutes.to_i
+    # Default cap for preserved job and execution records. nil disables count-based cleanup.
+    DEFAULT_CLEANUP_PRESERVED_JOBS_MAX_COUNT = nil
     # Default to always wait for jobs to finish for {Adapter#shutdown}
     DEFAULT_SHUTDOWN_TIMEOUT = -1
     # Default to not running cron
@@ -270,6 +272,25 @@ module GoodJob
           env['GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO'] ||
           DEFAULT_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO
       ).to_i
+    end
+
+    # Maximum number of preserved jobs and executions to keep.
+    # nil/false/0 disables count-based cleanup.
+    # @return [Integer, nil]
+    def cleanup_preserved_jobs_max_count
+      value = if options.key?(:cleanup_preserved_jobs_max_count)
+                options[:cleanup_preserved_jobs_max_count]
+              elsif rails_config.key?(:cleanup_preserved_jobs_max_count)
+                rails_config[:cleanup_preserved_jobs_max_count]
+              elsif env.key?('GOOD_JOB_CLEANUP_PRESERVED_JOBS_MAX_COUNT')
+                env['GOOD_JOB_CLEANUP_PRESERVED_JOBS_MAX_COUNT']
+              end
+
+      if value.in? [nil, "", false, "false", 0, "0"]
+        DEFAULT_CLEANUP_PRESERVED_JOBS_MAX_COUNT
+      else
+        value.to_i
+      end
     end
 
     # Number of jobs a {Scheduler} will execute before automatically cleaning up preserved jobs.

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -247,6 +247,38 @@ RSpec.describe GoodJob::Configuration do
     end
   end
 
+  describe '#cleanup_preserved_jobs_max_count' do
+    it 'defaults to nil' do
+      configuration = described_class.new({})
+      expect(configuration.cleanup_preserved_jobs_max_count).to be_nil
+    end
+
+    context 'when rails config is set' do
+      it 'uses rails config value' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ cleanup_preserved_jobs_max_count: 1_000 })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_preserved_jobs_max_count).to eq 1_000
+      end
+    end
+
+    context 'when environment variable is set' do
+      it 'uses environment variable' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_PRESERVED_JOBS_MAX_COUNT' => '2000' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_preserved_jobs_max_count).to eq 2000
+      end
+
+      it 'coerces 0 to nil' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_CLEANUP_PRESERVED_JOBS_MAX_COUNT' => '0' })
+
+        configuration = described_class.new({})
+        expect(configuration.cleanup_preserved_jobs_max_count).to be_nil
+      end
+    end
+  end
+
   describe '#cron' do
     let(:cron) { { some_task: { cron: "every day", class: "FooJob" } } }
 

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -134,6 +134,18 @@ describe GoodJob do
       described_class.cleanup_preserved_jobs
       expect { old_batch.reload }.to raise_error ActiveRecord::RecordNotFound
     end
+
+    it "caps preserved jobs and executions by count" do
+      destroyed_records_count = described_class.cleanup_preserved_jobs(older_than: 100.years, include_discarded: true, max_count: 1, in_batches_of: 1)
+
+      expect(destroyed_records_count).to eq 3
+
+      expect { recent_job.reload }.not_to raise_error
+      expect { old_finished_job.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { old_discarded_job.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { old_finished_job_execution.reload }.to raise_error ActiveRecord::RecordNotFound
+      expect { old_batch.reload }.not_to raise_error
+    end
   end
 
   describe '.perform_inline' do


### PR DESCRIPTION
Hi!

Here's patch suggestion to add hard cap on jobs/executions records by amount.

Database starts behaving quite slow after crossing 500k records and this number is quite hard to control during peak times when load is inevitable. Especially surprising to see advisory locks acting as global locks and making all queries wait.

Quick fix without patching good_job internals was to introduce scheduled job that does clean up mandatory without waiting:

```ruby
  def perform
    loop do;
      deleted = 0;
      deleted += GoodJob::Job.connection.execute("DELETE FROM good_jobs WHERE id IN (SELECT id FROM good_jobs WHERE finished_at IS NOT NULL AND finished_at < (current_timestamp - interval '#{KEEP_JOBS_HOURS} hours') LIMIT 1000);").cmd_tuples;
      deleted += GoodJob::Execution.connection.execute("DELETE FROM good_job_executions WHERE id IN (SELECT id FROM good_job_executions WHERE finished_at IS NOT NULL AND finished_at < (current_timestamp - interval '#{KEEP_JOBS_HOURS} hours') LIMIT 1000);").cmd_tuples;
      Rails.logger.info "Deleted #{deleted} rows from good_jobs and good_job_executions";
      break if deleted == 0;
    end;
  end
```

This patch in the Pull Request should help solving the problem within core without introducing additional custom code. Changes follow patterns within the code base, although I've seen discussions about column indexes and it would be nice to handle it too (separately) as I have observed significant performance issues depending on amount of "hot data".

I don't see much need in "historical data" within these tables, metrics should be collected separately and to another service which is suitable for the purpose, e.g. CloudWatch.

Thank you!