### PR TITLE
Double single-thread scheduler integration test timeout on JRuby

### DIFF
--- a/spec/integration/scheduler_spec.rb
+++ b/spec/integration/scheduler_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe 'Schedule Integration' do
       scheduler = GoodJob::Scheduler.new(performer, max_threads: max_threads)
       scheduler.create_thread
 
-      sleep_until(max: 10, increments_of: 0.5) do
+      max_wait = Concurrent.on_jruby? ? 20 : 10
+      sleep_until(max: max_wait, increments_of: 0.5) do
         GoodJob::Job.unfinished.none?
       end
       scheduler.shutdown


### PR DESCRIPTION
JRuby is slower than MRI, causing the single-thread scheduler integration test's 10-second `sleep_until` window to flake when running 50 jobs. This doubles the timeout to 20 seconds on JRuby using the same `Concurrent.on_jruby?` pattern introduced in #1737.