### PR TITLE
Use annotated git tag in release script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ task :release_good_job, [:version_bump] do |_t, args|
   puts "\n== Creating git commit  =="
   system! "git add lib/good_job/version.rb CHANGELOG.md Gemfile.lock checksums"
   system! "git commit -m \"Release good_job v#{GoodJob::VERSION}\""
-  system! "git tag v#{GoodJob::VERSION}"
+  system! "git tag -a v#{GoodJob::VERSION} -m \"v#{GoodJob::VERSION}\""
 
   require 'cgi'
   changelog_anchor = "v#{GoodJob::VERSION.delete('.')}-#{Time.now.utc.strftime('%Y-%m-%d')}"


### PR DESCRIPTION
Switch `git tag` to `git tag -a -m` in the `release_good_job` Rake task so that an annotated tag is created non-interactively. Previously, a `tag.gpgSign` or `tag.annotate` git config could cause Git to open an editor prompting for a commit message during the release process. Annotated tags are also preferred for releases as they carry tagger metadata and work correctly with `git describe`.