### PR TITLE
Development: Strip pg_catalog namespace from enable_extension in schema.rb

### DIFF
--- a/demo/Rakefile
+++ b/demo/Rakefile
@@ -9,12 +9,16 @@ Rails.application.load_tasks
   db:migrate
   db:rollback
   db:prepare
+  db:schema:dump
 ].each do |task_name|
   Rake::Task[task_name].enhance do
-    puts "GoodJob: Sanitizing Rails version from schema.rb...\n"
+    puts "GoodJob: Sanitizing schema.rb...\n"
     schema_rb = Rails.root.join("db/schema.rb").to_s
     contents = File.read(schema_rb)
+    # Strip the Rails version so the schema.rb is stable across Rails upgrades.
     contents.sub!(/ActiveRecord::Schema\[\d\.\d\]/, "ActiveRecord::Schema")
+    # Strip the pg_catalog namespace because it breaks in CI sometimes.
+    contents.gsub!(/enable_extension "pg_catalog\./, 'enable_extension "')
     File.write(schema_rb, contents)
   end
 end


### PR DESCRIPTION
PostgreSQL 14+ places some built-in extensions (e.g. `plpgsql`) in the `pg_catalog` schema, causing Rails to dump them as `enable_extension "pg_catalog.plpgsql"` in schema.rb. This breaks in CI sometimes.

This adds a post-processing step to the schema dump (alongside the existing Rails version stripping) that removes the `pg_catalog.` namespace prefix from `enable_extension` calls. The `db:schema:dump` task is also added to the list of tasks that trigger post-processing.