### PR TITLE
Show split enabled/paused badge for cron schedules in navbar

### DIFF
--- a/app/controllers/good_job/metrics_controller.rb
+++ b/app/controllers/good_job/metrics_controller.rb
@@ -5,7 +5,10 @@ module GoodJob
     def primary_nav
       jobs_count = GoodJob::Job.count
       batches_count = GoodJob::BatchRecord.all.size
-      cron_entries_count = GoodJob::CronEntry.all.size
+      cron_entries = GoodJob::CronEntry.all
+      cron_entries_count = cron_entries.size
+      cron_entries_enabled_count = cron_entries.count(&:enabled?)
+      cron_entries_paused_count = cron_entries_count - cron_entries_enabled_count
       pauses_count = GoodJob::Setting.paused.values.sum(&:count)
       processes_count = GoodJob::Process.active.count
       discarded_count = GoodJob::Job.discarded.count
@@ -14,6 +17,8 @@ module GoodJob
         jobs_count: helpers.number_to_human(jobs_count),
         batches_count: helpers.number_to_human(batches_count),
         cron_entries_count: helpers.number_to_human(cron_entries_count),
+        cron_entries_enabled_count: helpers.number_to_human(cron_entries_enabled_count),
+        cron_entries_paused_count: helpers.number_to_human(cron_entries_paused_count),
         pauses_count: helpers.number_to_human(pauses_count),
         processes_count: helpers.number_to_human(processes_count),
         discarded_count: helpers.number_to_human(discarded_count),

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -64,3 +64,38 @@
   height: 1rem;
   width: 1rem;
 }
+
+.badge-group {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.badge-group > .badge {
+  position: relative;
+  flex: 1 1 auto;
+}
+
+.badge-group > .badge:has(+ .badge:not(.d-none)) {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.badge-group > .badge:not(.d-none) + .badge:not(.d-none) {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}
+
+.badge-group.rounded-pill > .badge {
+  border-radius: 50rem !important;
+}
+
+.badge-group.rounded-pill > .badge:has(+ .badge:not(.d-none)) {
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.badge-group.rounded-pill > .badge:not(.d-none) + .badge:not(.d-none) {
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+}

--- a/app/views/good_job/cron_entries/index.html.erb
+++ b/app/views/good_job/cron_entries/index.html.erb
@@ -49,9 +49,9 @@
           <div class="col-6 col-lg-1 text-wrap small">
             <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.cron.status" %></div>
             <% if @enabled_states[cron_entry.key.to_s] %>
-              <span class="text-success"><%= t "good_job.models.cron.states.active" %></span>
+              <span class="badge text-bg-success rounded-pill"><%= t "good_job.models.cron.states.active" %></span>
             <% else %>
-              <span class="text-muted"><%= t "good_job.models.cron.states.paused" %></span>
+              <span class="badge text-bg-warning rounded-pill"><%= t "good_job.models.cron.states.paused" %></span>
             <% end %>
           </div>
           <div class="col-lg-2 d-flex gap-3 justify-content-end">

--- a/app/views/good_job/shared/_navbar.erb
+++ b/app/views/good_job/shared/_navbar.erb
@@ -30,7 +30,9 @@
         <li class="nav-item">
           <%= link_to cron_entries_path, class: ["nav-link", ("active" if controller_name == 'cron_entries')] do %>
             <%= t(".cron_schedules") %>
-            <span data-async-values-target="value" data-async-values-key="cron_entries_count" class="badge text-bg-secondary rounded-pill d-none" id="navbar_cron_entries_count" data-turbo-permanent></span>
+            <span class="badge-group rounded-pill" id="navbar_cron_entries_count" data-turbo-permanent>
+              <span data-async-values-target="value" data-async-values-key="cron_entries_enabled_count" class="badge text-bg-secondary d-none"></span><span data-async-values-target="value" data-async-values-key="cron_entries_paused_count" data-async-values-zero-class="d-none" class="badge text-bg-warning d-none"></span>
+            </span>
         <% end %>
         </li>
         <li class="nav-item">

--- a/spec/requests/good_job/metrics_controller_spec.rb
+++ b/spec/requests/good_job/metrics_controller_spec.rb
@@ -12,6 +12,8 @@ describe GoodJob::MetricsController do
           jobs_count: '0',
           batches_count: '0',
           cron_entries_count: '1',
+          cron_entries_enabled_count: '1',
+          cron_entries_paused_count: '0',
           pauses_count: '0',
           processes_count: '0',
           discarded_count: '0',


### PR DESCRIPTION

<img width="343" height="114" alt="Screenshot 2026-04-16 at 5 53 05 PM" src="https://github.com/user-attachments/assets/80d1a38e-0e5e-453e-80ae-42575e525ce8" />

👌🏻 


Closes #1313

Adds a split pill badge to the navbar cron count that shows active (gray) and paused (yellow) counts separately, rather than a single total. Also updates the status column in the cron entries table from plain colored text to green/yellow pill badges for visual consistency.

Custom `.badge-group` CSS joins two adjacent Bootstrap badges into a single split pill, using `:has()` to only flatten inner radii when both badges are visible.