### PR TITLE
Allow adding the currently executing job to a batch

### DIFF
--- a/app/models/good_job/batch.rb
+++ b/app/models/good_job/batch.rb
@@ -277,9 +277,16 @@ module GoodJob
 
       if persisted_jobs.any?
         job_ids = persisted_jobs.map(&:provider_job_id)
-        GoodJob::Job.where(id: job_ids, batch_id: nil).update_all(batch_id: id) # rubocop:disable Rails/SkipsModelValidations
 
-        CurrentThread.job.batch_id = id if CurrentThread.job && job_ids.include?(CurrentThread.job.id)
+        if CurrentThread.job && job_ids.include?(CurrentThread.job.id)
+          CurrentThread.job.batch_id = id
+          CurrentThread.job.save!
+          other_job_ids = job_ids - [CurrentThread.job.id]
+        else
+          other_job_ids = job_ids
+        end
+
+        GoodJob::Job.where(id: other_job_ids).update_all(batch_id: id) if other_job_ids.any? # rubocop:disable Rails/SkipsModelValidations
       end
 
       buffer.active_jobs

--- a/app/models/good_job/batch.rb
+++ b/app/models/good_job/batch.rb
@@ -254,18 +254,32 @@ module GoodJob
       active_jobs
     end
 
-    # Enqueue jobs and add them to the batch
+    # Enqueue jobs and add them to the batch.
+    # Already-enqueued jobs (those with a +provider_job_id+, e.g. the currently
+    # executing job passed as +self+ from within +perform+) are added by updating
+    # their +batch_id+ directly rather than re-enqueueing them.
+    # @param active_jobs [Array<ActiveJob::Base>, ActiveJob::Base, nil]
     # @param block [Proc] Enqueue jobs within the block to add them to the batch
     # @return [Array<ActiveJob::Base>] Active jobs added to the batch
     def add(active_jobs = nil, &block)
       record.save if record.new_record?
 
+      active_jobs_array = Array(active_jobs).compact
+      persisted_jobs, unpersisted_jobs = active_jobs_array.partition { |job| job.provider_job_id.present? }
+
       buffer = Bulk::Buffer.new
-      buffer.add(active_jobs)
+      buffer.add(unpersisted_jobs)
       buffer.capture(&block) if block
 
       self.class.within_thread(batch_id: id) do
         buffer.enqueue
+      end
+
+      if persisted_jobs.any?
+        job_ids = persisted_jobs.map(&:provider_job_id)
+        GoodJob::Job.where(id: job_ids, batch_id: nil).update_all(batch_id: id) # rubocop:disable Rails/SkipsModelValidations
+
+        CurrentThread.job.batch_id = id if CurrentThread.job && job_ids.include?(CurrentThread.job.id)
       end
 
       buffer.active_jobs

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -45,6 +45,8 @@ module ::SomeClass; end
 module ::ErrorJob::Error; end
 module ::TestRecord; end
 module ::WrapperJob; end
+module ::ChildJob; end
+module ::ParentJob; end
 module GoodJob::Job::ERROR_EVENT_INTERRUPTED; end
 module GoodJob::Job::ERROR_EVENT_RETRIED; end
 module Rails::Server; end

--- a/spec/app/models/good_job/batch_spec.rb
+++ b/spec/app/models/good_job/batch_spec.rb
@@ -256,6 +256,21 @@ describe GoodJob::Batch do
       expect(batch).to be_persisted
       expect(batch.active_jobs.count).to eq 2
     end
+
+    it 'adds an already-enqueued job by updating its batch_id' do
+      active_job = TestJob.perform_later
+      good_job = GoodJob::Job.find_by(active_job_id: active_job.job_id)
+
+      GoodJob::CurrentThread.job = good_job
+      batch.add(active_job)
+
+      expect(good_job.batch_id).to eq batch.id
+      expect(good_job.batch&.id).to eq batch.id
+      expect(GoodJob::CurrentThread.job.batch_id).to eq batch.id
+      expect(GoodJob::CurrentThread.job.batch&.id).to eq batch.id
+    ensure
+      GoodJob::CurrentThread.job = nil
+    end
   end
 
   describe '#enqueue' do

--- a/spec/integration/batch_spec.rb
+++ b/spec/integration/batch_spec.rb
@@ -350,9 +350,11 @@ RSpec.describe 'Batches' do
           new_batch = GoodJob::Batch.new(on_finish: 'BatchCallbackJob')
           new_batch.add(self)
 
-          # Check that the batch extension accessor
-          # shows the updated batch.
+          # Check that the batch extension accessor and the underlying
+          # GoodJob::Job record both reflect the updated batch.
           RESULTS << batch&.id
+          RESULTS << GoodJob::CurrentThread.job.batch_id
+          RESULTS << GoodJob::CurrentThread.job.batch&.id
 
           new_batch.add(ChildJob.new)
           new_batch.enqueue
@@ -366,7 +368,7 @@ RSpec.describe 'Batches' do
 
       parent_good_job = GoodJob::Job.find_by(active_job_id: parent_active_job.job_id)
       expect(parent_good_job.batch_id).to be_present
-      expect(RESULTS).to eq [parent_good_job.batch_id]
+      expect(RESULTS).to eq [parent_good_job.batch_id, parent_good_job.batch_id, parent_good_job.batch_id]
 
       child_good_job = GoodJob::Job.where(job_class: 'ChildJob').first
       expect(child_good_job.batch_id).to eq parent_good_job.batch_id
@@ -382,9 +384,10 @@ RSpec.describe 'Batches' do
         include GoodJob::ActiveJobExtensions::Batches
 
         def perform
-          new_batch = GoodJob::Batch.new
+          new_batch = GoodJob::Batch.new(on_finish: 'BatchCallbackJob')
           new_batch.add(self)
           RESULTS << batch&.id
+          new_batch.enqueue
         end
       end)
 
@@ -394,6 +397,10 @@ RSpec.describe 'Batches' do
 
       parent_good_job = GoodJob::Job.where(job_class: 'ParentJob').first
       expect(RESULTS.first).to eq parent_good_job.batch_id
+
+      batch = GoodJob::Batch.find(parent_good_job.batch_id)
+      expect(batch).to be_finished
+      expect(GoodJob::Job.where(job_class: 'BatchCallbackJob').count).to eq 1
     end
   end
 

--- a/spec/integration/batch_spec.rb
+++ b/spec/integration/batch_spec.rb
@@ -335,6 +335,68 @@ RSpec.describe 'Batches' do
     end
   end
 
+  describe 'adding the currently executing job to a new batch' do
+    it 'assigns the currently executing job and child jobs to a new batch' do
+      stub_const 'RESULTS', Concurrent::Array.new
+      stub_const 'ChildJob', (Class.new(ActiveJob::Base) do
+        def perform
+        end
+      end)
+
+      stub_const 'ParentJob', (Class.new(ActiveJob::Base) do
+        include GoodJob::ActiveJobExtensions::Batches
+
+        def perform
+          new_batch = GoodJob::Batch.new(on_finish: 'BatchCallbackJob')
+          new_batch.add(self)
+
+          # Check that the batch extension accessor
+          # shows the updated batch.
+          RESULTS << batch&.id
+
+          new_batch.add(ChildJob.new)
+          new_batch.enqueue
+        end
+      end)
+
+      parent_active_job = ParentJob.perform_later
+      expect(GoodJob::Job.find_by(active_job_id: parent_active_job.job_id).batch_id).to be_nil
+
+      GoodJob.perform_inline
+
+      parent_good_job = GoodJob::Job.find_by(active_job_id: parent_active_job.job_id)
+      expect(parent_good_job.batch_id).to be_present
+      expect(RESULTS).to eq [parent_good_job.batch_id]
+
+      child_good_job = GoodJob::Job.where(job_class: 'ChildJob').first
+      expect(child_good_job.batch_id).to eq parent_good_job.batch_id
+
+      batch = GoodJob::Batch.find(parent_good_job.batch_id)
+      expect(batch).to be_finished
+      expect(batch.active_jobs.count).to eq 2
+      expect(GoodJob::Job.where(job_class: 'BatchCallbackJob').count).to eq 1
+    end
+
+    it 'makes the batch accessible via self.batch within perform' do
+      stub_const 'ParentJob', (Class.new(ActiveJob::Base) do
+        include GoodJob::ActiveJobExtensions::Batches
+
+        def perform
+          new_batch = GoodJob::Batch.new
+          new_batch.add(self)
+          RESULTS << batch&.id
+        end
+      end)
+
+      stub_const 'RESULTS', Concurrent::Array.new
+      ParentJob.perform_later
+      GoodJob.perform_inline
+
+      parent_good_job = GoodJob::Job.where(job_class: 'ParentJob').first
+      expect(RESULTS.first).to eq parent_good_job.batch_id
+    end
+  end
+
   describe 'adding to an existing batch' do
     it 'adds jobs to the existing batch' do
       batch = GoodJob::Batch.new(metadata: 'foo')


### PR DESCRIPTION
Closes #1611 (partially — the specific case of adding the currently executing job to a batch).

`Batch#add` now accepts already-enqueued jobs (those with a `provider_job_id`).

Specific Use here is using GoodJob Cron to enqueue a job that creates a batch and adds itself to the batch to see the whole lifecycle via the batch.

Note: I guess jobs can now be moved between batches too, but I dunno why you'd want to do that.

```ruby
class MyJob < ApplicationJob
  include GoodJob::ActiveJobExtensions::Batches

  def perform
    new_batch = GoodJob::Batch.new(on_finish: "MyCallbackJob")
    new_batch.add(self)         # adds the currently executing job
    new_batch.add(ChildJob.new) # adds a new child job
    new_batch.enqueue           # marks the batch as ready
    batch.id == new_batch.id    # => true
  end
end
```

In the example above, you'd probably want to do like `batch || Batch.new` so that if the job errors+retries after making the batch, you reuse the batch rather than making another one.