### PR TITLE
Add GoodJob.handled_exceptions config; include NotImplementedError by default

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -821,7 +821,7 @@ module GoodJob
               error_event: error_event
             )
             ExecutionResult.new(value: value, active_job: active_job, handled_error: handled_error, error_event: error_event, retried_job: current_thread.retried_job)
-          rescue StandardError => e
+          rescue *GoodJob.handled_exception_classes => e
             active_job ||= current_thread.active_job
             error_event = if e.is_a?(GoodJob::InterruptError)
                             ErrorEvents::INTERRUPTED

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -90,12 +90,28 @@ module GoodJob
 
   # @!attribute [rw] retry_on_unhandled_error
   #   @!scope class
-  #   Whether to re-perform a job when a type of +StandardError+ is raised to GoodJob (default: +false+).
-  #   If +true+, causes jobs to be re-queued and retried if they raise an instance of +StandardError+.
-  #   If +false+, jobs will be discarded or marked as finished if they raise an instance of +StandardError+.
-  #   Instances of +Exception+, like +SIGINT+, will *always* be retried, regardless of this attribute's value.
+  #   Whether to re-perform a job when a handled (rescued) error is raised to GoodJob (default: +false+).
+  #   If +true+, causes jobs to be re-queued and retried if they raise an instance of a handled exception.
+  #   If +false+, jobs will be discarded or marked as finished if they raise an instance of a handled exception.
+  #   @see GoodJob.handled_exceptions
   #   @return [Boolean, nil]
   mattr_accessor :retry_on_unhandled_error, default: false
+
+  # @!attribute [rw] handled_exceptions
+  #   @!scope class
+  #   Exception classes that GoodJob will rescue during job execution (default: +[StandardError]+).
+  #   Accepts class objects or strings that will be constantized at runtime.
+  #   Exceptions not in this list will propagate and crash the executing thread.
+  #   @example Also rescue ScriptError
+  #     GoodJob.handled_exceptions = [StandardError, NotImplementedError, ScriptError]
+  #   @return [Array<Class, String>]
+  mattr_accessor :handled_exceptions, default: [StandardError, NotImplementedError]
+
+  # Resolved exception classes from {handled_exceptions}.
+  # @return [Array<Class>]
+  def self.handled_exception_classes
+    handled_exceptions.map { |e| e.is_a?(String) ? e.constantize : e }
+  end
 
   # @!attribute [rw] on_thread_error
   #   @!scope class

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -1125,6 +1125,45 @@ RSpec.describe GoodJob::Job do
         end
       end
 
+      context 'when GoodJob.handled_exceptions includes a non-StandardError class' do
+        before do
+          TestJob.define_method(:perform) { |*_args, **_kwargs| raise NotImplementedError, "Not implemented" }
+        end
+
+        it 'rescues the exception and returns an unhandled_error result' do
+          result = good_job.perform(lock_id: process_id)
+
+          expect(result.value).to be_nil
+          expect(result.unhandled_error).to be_a(NotImplementedError)
+        end
+
+        it 'discards the job by default (retry_on_unhandled_error is false)' do
+          allow(GoodJob).to receive(:preserve_job_records).and_return(false)
+
+          good_job.perform(lock_id: process_id)
+          expect { good_job.reload }.to raise_error ActiveRecord::RecordNotFound
+        end
+
+        it 'retries the job when retry_on_unhandled_error is true' do
+          allow(GoodJob).to receive_messages(retry_on_unhandled_error: true, preserve_job_records: true)
+
+          good_job.perform(lock_id: process_id)
+
+          expect(good_job.reload).to have_attributes(
+            error: /NotImplementedError/,
+            performed_at: nil,
+            finished_at: nil
+          )
+        end
+      end
+
+      context 'when ActiveJob raises an exception not in GoodJob.handled_exceptions' do
+        it 'propagates the exception' do
+          allow(ActiveJob::Base).to receive(:execute).and_raise(ScriptError, "not handled")
+          expect { good_job.perform(lock_id: process_id) }.to raise_error(ScriptError, "not handled")
+        end
+      end
+
       context 'when Discrete' do
         before do
           ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)


### PR DESCRIPTION
Fixes #1670.

Introduces `GoodJob.handled_exceptions` (default: `[StandardError, NotImplementedError]`), an array of exception classes GoodJob rescues during job execution. The rescue clause in job execution now uses this list instead of the hardcoded `StandardError`, so `NotImplementedError` (which inherits from `ScriptError`, not `StandardError`) is properly caught and discarded rather than crashing the thread and causing infinite retries disguised as `GoodJob::InterruptError`.

Accepts class objects or constantizable strings. Exceptions outside the list propagate normally.