### PR TITLE
Fix dashboard pagination omitting jobs created in the same second

### DIFF
--- a/app/filters/good_job/base_filter.rb
+++ b/app/filters/good_job/base_filter.rb
@@ -13,8 +13,8 @@ module GoodJob
     end
 
     def records
+      after_id = params[:after_id]
       after_at = params[:after_at].present? ? Time.zone.parse(params[:after_at]) : nil
-      after_id = params[:after_id] if after_at
       limit = params.fetch(:limit, DEFAULT_LIMIT)
 
       query_for_records.display_all(
@@ -76,10 +76,11 @@ module GoodJob
 
     def next_page_params
       order_column = ordered_by.first
+      last_record = records.last
 
       {
-        after_at: records.last&.send(order_column),
-        after_id: records.last&.id,
+        after_at: last_record&.send(order_column)&.iso8601(6),
+        after_id: last_record&.id,
       }.merge(to_params)
     end
 

--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -11,8 +11,6 @@ module GoodJob
       # @!scope class
       # @param ordered_by [Array<String>]
       #   Order to display records, from Filter#ordered_by
-      # @param after_at [DateTime, String, nil]
-      #   Display records after this time for keyset pagination
       # @param after_id [Numeric, String, nil]
       #   Display records after this ID for keyset pagination
       # @return [ActiveRecord::Relation]
@@ -20,11 +18,37 @@ module GoodJob
         order_column, order_direction = ordered_by
         query = self
 
-        if after_at.present? && after_id.present?
-          query = query.where Arel::Nodes::Grouping.new([arel_table[order_column], arel_table[primary_key]]).send(
-            order_direction == 'asc' ? :gteq : :lt,
-            Arel::Nodes::Grouping.new([bind_value(order_column, after_at, ActiveRecord::Type::DateTime), bind_value(primary_key, after_id, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid)])
-          )
+        if after_id.present?
+          op = order_direction == 'asc' ? Arel::Nodes::GreaterThan : Arel::Nodes::LessThan
+          uuid_type = ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid
+
+          cursor_subquery = unscoped.select(arel_table[order_column], arel_table[primary_key]).where(primary_key => after_id)
+
+          # Fall back to after_at if the cursor record has been destroyed.
+          # UNION ALL returns the exact DB row first; the fallback row is only used when the subquery is empty.
+          # The resulting WHERE clause looks like:
+          #   WHERE (created_at, id) < (
+          #     SELECT _cursor.* FROM (
+          #       SELECT created_at, id FROM good_jobs WHERE id = $after_id  -- exact from DB
+          #       UNION ALL
+          #       SELECT $after_at, $after_id                                -- fallback if destroyed
+          #     ) AS _cursor LIMIT 1
+          #   )
+          fallback = Arel::SelectManager.new.tap do |m|
+            m.project(bind_value(order_column, after_at, ActiveRecord::Type::DateTime),
+                      bind_value(primary_key, after_id, uuid_type))
+          end
+          union = cursor_subquery.arel.union(:all, fallback)
+          cursor_arel = Arel::SelectManager.new.tap do |m|
+            m.from(Arel::Nodes::As.new(Arel::Nodes::Grouping.new([union]), Arel.sql("_cursor")))
+            m.project(Arel.sql("_cursor.*"))
+            m.take(1)
+          end
+
+          query = query.where(op.new(
+                                Arel::Nodes::Grouping.new([arel_table[order_column], arel_table[primary_key]]),
+                                Arel::Nodes::Grouping.new([cursor_arel])
+                              ))
         end
 
         query.order Arel.sql("#{order_column} #{order_direction}, #{primary_key} #{order_direction}")

--- a/spec/app/filters/good_job/jobs_filter_spec.rb
+++ b/spec/app/filters/good_job/jobs_filter_spec.rb
@@ -139,6 +139,26 @@ RSpec.describe GoodJob::JobsFilter do
     end
   end
 
+  describe '#next_page_params' do
+    it 'paginates correctly when jobs share the same timestamp' do
+      GoodJob::Job.update_all(created_at: Time.zone.parse('2024-01-01 12:00:00.500000')) # rubocop:disable Rails/SkipsModelValidations
+
+      first_page_filter = described_class.new(params.merge(limit: 2))
+      first_page = first_page_filter.records.to_a
+      expect(first_page.size).to eq 2
+
+      next_params = first_page_filter.next_page_params
+      expect(next_params[:after_id]).to be_present
+
+      second_page_filter = described_class.new(next_params.merge(limit: 10))
+      second_page = second_page_filter.records.to_a
+      expect(second_page).not_to be_empty
+
+      all_ids = (first_page + second_page).map(&:id)
+      expect(all_ids).to eq(all_ids.uniq)
+    end
+  end
+
   describe '#filtered_count' do
     it 'returns a count of unlimited items' do
       expect(filter.filtered_count).to eq 5


### PR DESCRIPTION
Fixes #1725.

Dashboard keyset pagination uses `(order_column, id)` as the cursor. When multiple jobs share a sub-second timestamp, serializing the cursor to URL params loses sub-second precision, causing the row comparison's equality check to miss all records in that same second on the next page.

The fix rewrites the `display_all` scope to look up the cursor record's exact timestamp from the database via a subquery, bypassing serialization precision entirely. A `UNION ALL` fallback to the serialized `after_at` value (stored with microsecond precision via `iso8601(6)`) handles the case where the cursor record has been destroyed between page loads. This also fixes the ascending sort case, which incorrectly used `>=` instead of `>`, causing the cursor record to appear on both pages.