### PR TITLE
Make bulk action buttons responsive to job state filter

### DIFF
--- a/app/helpers/good_job/application_helper.rb
+++ b/app/helpers/good_job/application_helper.rb
@@ -7,6 +7,16 @@ module GoodJob
     # We can't rely on +config.action_controller.include_all_helpers = true+ in the host app.
     include IconsHelper
 
+    def job_action_states
+      {
+        reschedule: %w[scheduled retried queued],
+        retry: %w[discarded],
+        discard: %w[scheduled retried queued],
+        force_discard: %w[running],
+        destroy: %w[discarded succeeded],
+      }
+    end
+
     def format_duration(sec)
       return unless sec
       return "" if sec.is_a?(String) # pg interval support added in Rails 6.1

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -11,29 +11,43 @@
               <%= check_box_tag('toggle_job_ids', "1", false, data: { "checkbox-toggle-target": "all", action: "change->checkbox-toggle#toggleAll" }) %>
               <%= label_tag('toggle_job_ids', t(".toggle_all_jobs"), class: "visually-hidden") %>
             </div>
-            <%= form.button type: 'submit', name: 'mass_action', value: 'reschedule', class: 'ms-1 btn btn-sm btn-outline-secondary', title: t(".actions.reschedule_all"), data: { turbo_confirm: t(".actions.confirm_reschedule_all") } do %>
-              <span class="me-1"><%= render_icon "skip_forward" %></span> <%= t "good_job.actions.reschedule" %>
+            <% if filter.params[:state].nil? || filter.params[:state].in?(%w[scheduled retried]) %>
+              <%= form.button type: 'submit', name: 'mass_action', value: 'reschedule', class: 'ms-1 btn btn-sm btn-outline-secondary', title: t(".actions.reschedule_all"), data: { turbo_confirm: t(".actions.confirm_reschedule_all") } do %>
+                <span class="me-1"><%= render_icon "skip_forward" %></span> <%= t "good_job.actions.reschedule" %>
+              <% end %>
             <% end %>
 
-            <%= form.button type: 'submit', name: 'mass_action', value: 'retry', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.retry_all"), data: { turbo_confirm: t(".actions.confirm_retry_all") } do %>
-              <span class="me-1"><%= render_icon "arrow_clockwise" %></span> <%= t "good_job.actions.retry" %>
+            <% if filter.params[:state].nil? || filter.params[:state] == 'discarded' %>
+              <%= form.button type: 'submit', name: 'mass_action', value: 'retry', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.retry_all"), data: { turbo_confirm: t(".actions.confirm_retry_all") } do %>
+                <span class="me-1"><%= render_icon "arrow_clockwise" %></span> <%= t "good_job.actions.retry" %>
+              <% end %>
             <% end %>
 
-            <div class="btn-group" role="group">
+            <% if filter.params[:state].nil? %>
+              <div class="btn-group" role="group">
+                <%= form.button type: 'submit', name: 'mass_action', value: 'discard', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.discard_all"), data: { turbo_confirm: t(".actions.confirm_discard_all") } do %>
+                  <span class="me-1"><%= render_icon "stop" %></span> <%= t "good_job.actions.discard" %>
+                <% end %>
+                <button id="destroy-dropdown-toggle" type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                  <span class="visually-hidden"><%= t ".toggle_actions" %></span>
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="destroy-dropdown-toggle">
+                  <li>
+                    <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn dropdown-item', title: t(".actions.destroy_all"), data: { turbo_confirm: t(".actions.confirm_destroy_all") } do %>
+                      <span class="me-1"><%= render_icon "trash" %></span> <%= t "good_job.actions.destroy" %>
+                    <% end %>
+                  </li>
+                </ul>
+              </div>
+            <% elsif filter.params[:state].in?(%w[scheduled retried queued]) %>
               <%= form.button type: 'submit', name: 'mass_action', value: 'discard', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.discard_all"), data: { turbo_confirm: t(".actions.confirm_discard_all") } do %>
                 <span class="me-1"><%= render_icon "stop" %></span> <%= t "good_job.actions.discard" %>
               <% end %>
-              <button id="destroy-dropdown-toggle" type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-                <span class="visually-hidden"><%= t ".toggle_actions" %></span>
-              </button>
-              <ul class="dropdown-menu" aria-labelledby="destroy-dropdown-toggle">
-                <li>
-                  <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn dropdown-item', title: t(".actions.destroy_all"), data: { turbo_confirm: t(".actions.confirm_destroy_all") } do %>
-                    <span class="me-1"><%= render_icon "trash" %></span> <%= t "good_job.actions.destroy" %>
-                  <% end %>
-                </li>
-              </ul>
-            </div>
+            <% elsif filter.params[:state].in?(%w[discarded succeeded]) %>
+              <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.destroy_all"), data: { turbo_confirm: t(".actions.confirm_destroy_all") } do %>
+                <span class="me-1"><%= render_icon "trash" %></span> <%= t "good_job.actions.destroy" %>
+              <% end %>
+            <% end %>
 
           </div>
           <div class="d-none d-lg-block col-lg-1 text-lg-center"><%= t "good_job.models.job.queue" %></div>

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -11,19 +11,20 @@
               <%= check_box_tag('toggle_job_ids', "1", false, data: { "checkbox-toggle-target": "all", action: "change->checkbox-toggle#toggleAll" }) %>
               <%= label_tag('toggle_job_ids', t(".toggle_all_jobs"), class: "visually-hidden") %>
             </div>
-            <% if filter.params[:state].nil? || filter.params[:state].in?(%w[scheduled retried]) %>
+            <% filter_state = filter.params[:state] %>
+            <% if filter_state.nil? || filter_state.in?(job_action_states[:reschedule]) %>
               <%= form.button type: 'submit', name: 'mass_action', value: 'reschedule', class: 'ms-1 btn btn-sm btn-outline-secondary', title: t(".actions.reschedule_all"), data: { turbo_confirm: t(".actions.confirm_reschedule_all") } do %>
                 <span class="me-1"><%= render_icon "skip_forward" %></span> <%= t "good_job.actions.reschedule" %>
               <% end %>
             <% end %>
 
-            <% if filter.params[:state].nil? || filter.params[:state] == 'discarded' %>
+            <% if filter_state.nil? || filter_state.in?(job_action_states[:retry]) %>
               <%= form.button type: 'submit', name: 'mass_action', value: 'retry', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.retry_all"), data: { turbo_confirm: t(".actions.confirm_retry_all") } do %>
                 <span class="me-1"><%= render_icon "arrow_clockwise" %></span> <%= t "good_job.actions.retry" %>
               <% end %>
             <% end %>
 
-            <% if filter.params[:state].nil? %>
+            <% if filter_state.nil? %>
               <div class="btn-group" role="group">
                 <%= form.button type: 'submit', name: 'mass_action', value: 'discard', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.discard_all"), data: { turbo_confirm: t(".actions.confirm_discard_all") } do %>
                   <span class="me-1"><%= render_icon "stop" %></span> <%= t "good_job.actions.discard" %>
@@ -39,11 +40,11 @@
                   </li>
                 </ul>
               </div>
-            <% elsif filter.params[:state].in?(%w[scheduled retried queued]) %>
+            <% elsif filter_state.in?(job_action_states[:discard]) %>
               <%= form.button type: 'submit', name: 'mass_action', value: 'discard', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.discard_all"), data: { turbo_confirm: t(".actions.confirm_discard_all") } do %>
                 <span class="me-1"><%= render_icon "stop" %></span> <%= t "good_job.actions.discard" %>
               <% end %>
-            <% elsif filter.params[:state].in?(%w[discarded succeeded]) %>
+            <% elsif filter_state.in?(job_action_states[:destroy]) %>
               <%= form.button type: 'submit', name: 'mass_action', value: 'destroy', class: 'btn btn-sm btn-outline-secondary', title: t(".actions.destroy_all"), data: { turbo_confirm: t(".actions.confirm_destroy_all") } do %>
                 <span class="me-1"><%= render_icon "trash" %></span> <%= t "good_job.actions.destroy" %>
               <% end %>
@@ -141,34 +142,32 @@
                     </button>
                     <ul class="dropdown-menu shadow" aria-labelledby="<%= dom_id(job, :actions) %>">
                       <li>
-                        <% job_reschedulable = job.status.in? [:scheduled, :retried, :queued] %>
-                        <%= tag.button form: "job_action_form", formaction: reschedule_job_path(job.id), class: "dropdown-item #{'disabled' unless job_reschedulable}", title: t("good_job.jobs.actions.reschedule"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_reschedule") } do %>
+                        <% job_status = job.status.to_s %>
+                        <%= tag.button form: "job_action_form", formaction: reschedule_job_path(job.id), class: "dropdown-item #{'disabled' unless job_status.in?(job_action_states[:reschedule])}", title: t("good_job.jobs.actions.reschedule"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_reschedule") } do %>
                           <%= render_icon "skip_forward" %>
                           <%= t "good_job.actions.reschedule" %>
                         <% end %>
                       </li>
                       <li>
-                        <% job_discardable = job.status.in? [:scheduled, :retried, :queued] %>
-                        <%= tag.button form: "job_action_form", formaction: discard_job_path(job.id), class: "dropdown-item #{'disabled' unless job_discardable}", title: t("good_job.jobs.actions.discard"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_discard") } do %>
+                        <%= tag.button form: "job_action_form", formaction: discard_job_path(job.id), class: "dropdown-item #{'disabled' unless job_status.in?(job_action_states[:discard])}", title: t("good_job.jobs.actions.discard"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_discard") } do %>
                           <%= render_icon "stop" %>
                           <%= t "good_job.actions.discard" %>
                         <% end %>
                       </li>
                       <li>
-                        <% job_force_discardable = job.status.in? [:running] %>
-                        <%= tag.button form: "job_action_form", formaction: force_discard_job_path(job.id), class: "dropdown-item #{'disabled' unless job_force_discardable}", title: t("good_job.jobs.actions.force_discard"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_force_discard") } do %>
+                        <%= tag.button form: "job_action_form", formaction: force_discard_job_path(job.id), class: "dropdown-item #{'disabled' unless job_status.in?(job_action_states[:force_discard])}", title: t("good_job.jobs.actions.force_discard"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_force_discard") } do %>
                           <%= render_icon "eject" %>
                           <%= t "good_job.actions.force_discard" %>
                         <% end %>
                       </li>
                       <li>
-                        <%= tag.button form: "job_action_form", formaction: retry_job_path(job.id), class: "dropdown-item #{'disabled' unless job.status == :discarded}", title: t("good_job.jobs.actions.retry"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_retry") } do %>
+                        <%= tag.button form: "job_action_form", formaction: retry_job_path(job.id), class: "dropdown-item #{'disabled' unless job_status.in?(job_action_states[:retry])}", title: t("good_job.jobs.actions.retry"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_retry") } do %>
                           <%= render_icon "arrow_clockwise" %>
                           <%= t "good_job.actions.retry" %>
                         <% end %>
                       </li>
                       <li>
-                        <%= tag.button form: "job_destroy_form", formaction: job_path(job.id), class: "dropdown-item #{'disabled' unless job.status.in? [:discarded, :succeeded]}", title: t("good_job.jobs.actions.destroy"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_destroy") } do %>
+                        <%= tag.button form: "job_destroy_form", formaction: job_path(job.id), class: "dropdown-item #{'disabled' unless job_status.in?(job_action_states[:destroy])}", title: t("good_job.jobs.actions.destroy"), data: { turbo_confirm: t("good_job.jobs.actions.confirm_destroy") } do %>
                           <%= render_icon "trash" %>
                           <%= t "good_job.actions.destroy" %>
                         <% end %>


### PR DESCRIPTION
Fixes #1624 and address generalized confusion about what actions are appropriate for which job states.

- Bulk action buttons in the jobs table header are now conditionally shown based on the active state filter
- **Reschedule** appears only for `scheduled` and `retried` states (or All)
- **Retry** appears only for `discarded` state (or All)
- **Discard** appears only for `scheduled`, `retried`, and `queued` states (or All)
- **Destroy** appears only for `discarded` and `succeeded` states (or All); on the All state it remains grouped with Discard in a split button; on specific destroyable states it renders as a standalone button; on `running` no bulk actions are shown