### PR TITLE
Replace AR attributes API with explicit accessors; add breaking migration guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+Go read the technical notes in CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,16 @@ All contributions, from feedback to code and beyond, are welcomed and appreciate
 - Financially support the project via [Sponsorship](https://github.com/sponsors/bensheldon).
 
 For gem development and debugging information, please review the [README's Gem Development section](/README.md#gem-development).
+
+## Development Guidelines
+
+- **Gem database migrations must be non-breaking if not applied.** Any new column added via a GoodJob update migration must function as a progressive enhancement: GoodJob must work correctly without it, and applying the migration only unlocks additional functionality. This keeps update migrations optional until the next major GoodJob release, so that applying them is never a breaking change.
+  - Update the singular install migration template, then add a new numbered update migration. Migrations should be a no-op if the install migration already applied the change (`up` can be a no-op), but the update migration must be rollbackable (`down` must always be applicable).
+  - In model or behavioral code, guard anything that requires the new column so that if the migration hasn't run, the code does not raise. Use `has_attribute?`, `column_names.include?`, or similar guards.
+  - Update `GoodJob.migrated?` to check for the latest migration change. It only needs to check the last change because migrations are expected to run in order.
+  - Add an entry to `spec/integration/breaking_migrations_spec.rb` to smoke-test that the new column is handled gracefully when absent.
+  - Some Active Record features are difficult to make safe, e.g. `enum`, which raises at schema load time when the backing column does not exist.
+
+## Other Errata
+
+- **Active Record `attribute` cannot be used.** Calling `attribute` (the AR attributes API) necessitates a database connection when Tapioca runs its DSL compilers, which breaks Tapioca's type generation. Use explicit accessor methods instead.

--- a/app/models/good_job/execution.rb
+++ b/app/models/good_job/execution.rb
@@ -14,7 +14,14 @@ module GoodJob # :nodoc:
     alias_attribute :performed_at, :created_at
 
     # TODO: Remove when support for Rails 6.1 is dropped
-    attribute :duration, :interval if ActiveJob.version.canonical_segments.take(2) == [6, 1]
+    if ActiveJob.version.canonical_segments.take(2) == [6, 1]
+      def duration
+        value = read_attribute(:duration)
+        return value if value.nil? || value.is_a?(::ActiveSupport::Duration)
+
+        value.to_f.seconds
+      end
+    end
 
     def number
       serialized_params.fetch('executions', 0) + 1

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -34,19 +34,30 @@ module GoodJob
     self.implicit_order_column = 'created_at'
     self.ignored_columns += %w[is_discrete retried_good_job_id]
 
-    lock_type_enum = {
-      advisory: 0,
-      skiplocked: 1,
-      hybrid: 2,
-    }
-    # Declare the attribute explicitly so the enum can be defined even before the
-    # lock_type column migration has run (zero-downtime deployment safety).
-    attribute :lock_type, :integer
-    if Gem::Version.new(Rails.version) >= Gem::Version.new('7.1.0.a')
-      enum :lock_type, lock_type_enum, validate: { allow_nil: true }, scopes: false
-    else
-      enum lock_type: lock_type_enum, _scopes: false
+    module LockTypeAccessor
+      LOCK_TYPES = { "advisory" => 0, "skiplocked" => 1, "hybrid" => 2 }.freeze
+
+      def self.included(klass)
+        klass.define_singleton_method(:lock_types) { LockTypeAccessor::LOCK_TYPES }
+      end
+
+      def lock_type
+        return nil unless has_attribute?(:lock_type)
+
+        LockTypeAccessor::LOCK_TYPES.key(read_attribute(:lock_type))
+      end
+
+      def lock_type=(value)
+        return unless has_attribute?(:lock_type)
+
+        write_attribute(:lock_type, case value
+                                    when Symbol then LockTypeAccessor::LOCK_TYPES[value.to_s]
+                                    when String then LockTypeAccessor::LOCK_TYPES[value]
+                                    else value
+                                    end)
+      end
     end
+    include LockTypeAccessor
 
     define_model_callbacks :perform
     define_model_callbacks :perform_unlocked, only: :after
@@ -295,6 +306,11 @@ module GoodJob
         return @_lock_type_column_exists if defined?(@_lock_type_column_exists)
 
         @_lock_type_column_exists = connection_pool.with_connection { |conn| conn.column_exists?(:good_jobs, :lock_type) }
+      end
+
+      def reset_column_information
+        remove_instance_variable(:@_lock_type_column_exists) if instance_variable_defined?(:@_lock_type_column_exists)
+        super
       end
 
       # Returns the effective lock strategy, falling back to :advisory if the

--- a/spec/integration/breaking_migrations_spec.rb
+++ b/spec/integration/breaking_migrations_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# GoodJob's packaged update migrations add new columns that must remain optional
+# until the next major release, so that running them is not a breaking change
+# requiring a Semver major version bump. These tests verify that GoodJob continues
+# to function correctly when those columns are absent.
+#
+# To add a new column, append an entry: { model: GoodJob::SomeModel, column: :column_name }
+NEW_OPTIONAL_COLUMNS = [
+  { model: GoodJob::Job, column: :lock_type },
+  { model: GoodJob::BatchRecord, column: :jobs_finished_at },
+].freeze
+
+RSpec.describe 'Breaking migrations' do
+  around do |example|
+    dropped = []
+    NEW_OPTIONAL_COLUMNS.each do |scenario|
+      col = scenario[:model].columns_hash.fetch(scenario[:column].to_s)
+      col_options = { limit: col.limit, precision: col.precision, null: col.null, default: col.default }.compact
+      scenario[:model].connection_pool.with_connection { |c| c.remove_column(scenario[:model].table_name, scenario[:column]) }
+      scenario[:model].reset_column_information
+      dropped << scenario.merge(col_type: col.type, col_options: col_options)
+    end
+
+    example.run
+  ensure
+    dropped.each do |scenario|
+      scenario[:model].connection_pool.with_connection do |c|
+        c.add_column(scenario[:model].table_name, scenario[:column], scenario[:col_type], **scenario[:col_options]) unless c.column_exists?(scenario[:model].table_name, scenario[:column])
+      end
+      scenario[:model].reset_column_information
+    end
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    GoodJob.preserve_job_records = true
+
+    stub_const "RUN_JOBS", Concurrent::Array.new
+    stub_const 'TestJob', (Class.new(ActiveJob::Base) do
+      def perform
+        RUN_JOBS << provider_job_id
+      end
+    end)
+  end
+
+  it 'can enqueue and perform a job' do
+    TestJob.perform_later
+
+    performer = GoodJob::JobPerformer.new('*')
+    scheduler = GoodJob::Scheduler.new(performer, max_threads: 1)
+    scheduler.create_thread
+
+    wait_until(max: 5, increments_of: 0.1) { expect(GoodJob::Job.last.finished_at).to be_present }
+    scheduler.shutdown
+
+    expect(RUN_JOBS.size).to eq 1
+  end
+
+  it 'can enqueue and complete a batch' do
+    batch = GoodJob::Batch.enqueue { TestJob.perform_later }
+
+    GoodJob.perform_inline
+
+    batch.reload
+    expect(batch).to be_finished
+    expect(batch).to be_succeeded
+  end
+end


### PR DESCRIPTION
Replaces `attribute :lock_type, :integer` and `enum :lock_type` in `GoodJob::Job`, add a test for optional migrations.

Also updated CONTRIBUTING.md with migration documentation, and added an AGENTS.md.

Fixes #1752
