### PR TITLE
Add dashboard indexes for queue_name, created_at, and discarded jobs

### DIFF
--- a/demo/db/migrate/20260418000001_add_index_good_jobs_queue_name.rb
+++ b/demo/db/migrate/20260418000001_add_index_good_jobs_queue_name.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsQueueName < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :queue_name,
+      name: :index_good_jobs_on_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/migrate/20260418000002_add_index_good_jobs_created_at.rb
+++ b/demo/db/migrate/20260418000002_add_index_good_jobs_created_at.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsCreatedAt < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :created_at,
+      name: :index_good_jobs_on_created_at,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/migrate/20260418000003_add_index_good_jobs_discarded.rb
+++ b/demo/db/migrate/20260418000003_add_index_good_jobs_discarded.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDiscarded < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_14_000000) do
+ActiveRecord::Schema.define(version: 2026_04_18_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
@@ -96,9 +96,11 @@ ActiveRecord::Schema.define(version: 2026_04_14_000000) do
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
     t.index ["concurrency_key", "created_at"], name: "index_good_jobs_on_concurrency_key_and_created_at"
     t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["created_at"], name: "index_good_jobs_on_created_at"
     t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_on_discarded", order: { finished_at: :desc }, where: "(finished_at IS NOT NULL AND error IS NOT NULL)"
     t.index ["job_class"], name: "index_good_jobs_on_job_class"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
     t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
@@ -107,6 +109,7 @@ ActiveRecord::Schema.define(version: 2026_04_14_000000) do
     t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_for_candidate_dequeue_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_on_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name"], name: "index_good_jobs_on_queue_name"
     t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -111,5 +111,12 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       name: :index_good_jobs_for_candidate_dequeue_unlocked,
       order: { priority: "ASC NULLS LAST", scheduled_at: :asc, id: :asc },
       where: "finished_at IS NULL AND locked_by_id IS NULL"
+
+    add_index :good_jobs, :queue_name, name: :index_good_jobs_on_queue_name
+    add_index :good_jobs, :created_at, name: :index_good_jobs_on_created_at
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL"
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/10_add_index_good_jobs_queue_name.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/10_add_index_good_jobs_queue_name.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsQueueName < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :queue_name,
+      name: :index_good_jobs_on_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/generators/good_job/templates/update/migrations/11_add_index_good_jobs_created_at.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/11_add_index_good_jobs_created_at.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsCreatedAt < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :created_at,
+      name: :index_good_jobs_on_created_at,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/generators/good_job/templates/update/migrations/12_add_index_good_jobs_discarded.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/12_add_index_good_jobs_discarded.rb.erb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDiscarded < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -315,7 +315,7 @@ module GoodJob
   # @return [Boolean]
   def self.migrated?
     GoodJob::Job.lock_type_migrated? &&
-      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished")
+      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_discarded")
   end
 
   # Pause job execution for a given queue or job class.


### PR DESCRIPTION
_**Note: AI assisted PR, with careful human review and testing.**_

This PR adds three btree indexes that speed up dashboard queries on large `good_jobs` tables:

| Query | Endpoint | Cold | Warm |
|---|---|---:|---:|
| `queue_name = ?` | queue filter + dropdown counts | 30× | 35× |
| `ORDER BY created_at DESC LIMIT 25` | default jobs list + pagination | 6,231× | 348,403× |
| discarded `COUNT(*)` | nav badge + state tab count + cleaner | 1,568× | 2,707× |
| discarded `ORDER BY finished_at DESC LIMIT 25` | `?state=discarded` list | 1,461× | 313,090× |

Two of these queries fire on every dashboard page load (`BaseFilter#queues` for the queue dropdown, `MetricsController#primary_nav` for the discarded nav badge), so the win applies to every page, not just a specific filter.

This change is in production for days at https://milkstraw.ai, and it works without any issues.

## Indexes

- `index_good_jobs_on_queue_name`: the existing partial `(queue_name, scheduled_at) WHERE finished_at IS NULL` handles the worker dequeue path but skips finished rows, so it can't serve the dashboard. This adds an unconditional column-only btree usable by `JobsFilter#filter_by_queue_name`, the queue dropdown (`BaseFilter#queues`), and `ScheduledByQueueChart`.
- `index_good_jobs_on_created_at`: covers the default jobs list's `ORDER BY created_at DESC LIMIT 25` and its keyset pagination. There's no existing index on `created_at` alone. The schema has `(active_job_id, created_at)`, `(concurrency_key, created_at)`, `(cron_key, created_at)`, and `(priority, created_at)` partials, but Postgres can't use any of them for a plain ordering (leading-column rule).
- `index_good_jobs_on_discarded`: partial btree on `finished_at DESC` with predicate `finished_at IS NOT NULL AND error IS NOT NULL`. That matches the `discarded` scope exactly, so it serves both `COUNT(*)` via index-only scan and `ORDER BY finished_at DESC LIMIT 25` on `?state=discarded` without a separate sort (`JobsFilter#ordered_by` returns `%w[finished_at desc]` for that state). The existing `index_good_jobs_jobs_on_finished_at_only` has a broader predicate (`finished_at IS NOT NULL` only) and still requires heap fetches to check `error IS NOT NULL`.

### Why not `(queue_name, created_at DESC)`?

You might wonder why I didn't use a compound index to serve `WHERE queue_name = ? ORDER BY created_at DESC LIMIT 25` directly. I tried. The plain index handles that query well, and the compound isn't a free upgrade.

With plain, the planner walks `index_good_jobs_on_created_at` backward and filters inline for a common queue (51% of our rows are in `default`, so it finds 25 matches almost immediately). For a rare queue like `latency_10s` (1,536 rows total) it scans `index_good_jobs_on_queue_name` and does a small in-memory sort. Both are sub-millisecond warm. The compound gets them to ~0.02 ms, which nobody will notice.

The cost is real, though. The compound is 247 MB versus 43 MB. And the queries that fire on every page load get slower: `GROUP BY queue_name` (dropdown) goes from 286 ms warm to 439 ms, and the queue-filter `COUNT(*)` from 96 ms to 102 ms. Wider keys mean more pages per scan.

Trading every-page-load wins for imperceptible filter-view wins didn't seem worth it.

Sizes at 6.4M rows (heap 5,450 MB):

| Index | Size | % of heap |
|---|---:|---:|
| `index_good_jobs_on_queue_name` | 43 MB | 0.79% |
| `index_good_jobs_on_created_at` | 120 MB | 2.20% |
| `index_good_jobs_on_discarded` | 440 kB | 0.01% |

The discarded partial is tiny because its predicate matches only a small fraction of rows. The other two are btrees over the full table, so they scale linearly with row count.

All three migrations use `disable_ddl_transaction!` and `algorithm: :concurrently`, which is how existing update migrations 03–09 add indexes online. They also pass `if_not_exists: true` the way migration 08 does.

## Benchmarks

I ran these on a production copy from https://milkstraw.ai with ~6.4M rows (6,402,296), where the most common `queue_name` is `"default"`.

Each query ran three times to separate cold (disk) from warm (buffer cache) performance. Full `EXPLAIN (ANALYZE, BUFFERS)` output below.

<details>
<summary>Per-index details, plans, and call sites</summary>

### 1. `index_good_jobs_on_queue_name`

Call sites:

| File | Query |
|---|---|
| `app/filters/good_job/jobs_filter.rb:64` | `WHERE queue_name = ?` (dashboard queue filter) |
| `app/filters/good_job/base_filter.rb:32` | `GROUP BY queue_name` (queue dropdown, every page load) |
| `app/charts/good_job/scheduled_by_queue_chart.rb:26` | `GROUP BY date_trunc('hour', scheduled_at), queue_name` |

Plan change:

- Without: `Parallel Seq Scan` with `Filter: (queue_name = 'default')`, ~688k pages (≈5.5 GB).
- With: `Parallel Index Only Scan`, `Heap Fetches: 0`, ~2,800 pages.

`SELECT COUNT(*) FROM good_jobs WHERE queue_name = 'default'`:

| | Cold (run 1) | Warm (run 3) |
|---|---:|---:|
| Without | 4,950.5 ms | 5,110.6 ms |
| With    |   162.2 ms |   146.6 ms |
| Speedup | **30.5×** | **34.9×** |

### 2. `index_good_jobs_on_created_at`

Call sites:

| File | Query |
|---|---|
| `app/filters/good_job/base_filter.rb:73-74` | `ordered_by` returns `%w[created_at desc]` by default (used by `JobsFilter#ordered_by` when no `state` filter is set). |
| `app/filters/good_job/base_filter.rb:15-25` | `ORDER BY created_at DESC LIMIT 25` + keyset pagination `WHERE created_at < ? OR (created_at = ? AND id < ?)`. |

Plan change:

- Without: `Parallel Seq Scan`, `Gather Merge`, top-N heapsort, ~688k pages.
- With: `Index Scan Backward`; LIMIT 25 stops after ~26 index pages.

`SELECT id, created_at FROM good_jobs ORDER BY created_at DESC LIMIT 25`:

| | Cold (run 1) | Warm (run 3) |
|---|---:|---:|
| Without | 4,667.0 ms | 5,226.0 ms |
| With    |     0.75 ms |     0.02 ms |
| Speedup | **6,231×** | **348,403×** |

The baseline is slower warm than cold because the 5.5 GB working set exceeds the buffer cache, so repeated runs keep evicting and refetching. The indexed variant's working set (~200 KB) stays in cache.

### 3. `index_good_jobs_on_discarded`

Call sites (every call site of `GoodJob::Job.discarded`, defined at `app/models/good_job/job.rb:84` as `finished.where.not(error: nil)`):

| File | Query |
|---|---|
| `app/controllers/good_job/metrics_controller.rb:14` | `GoodJob::Job.discarded.count`, nav badge, polled on every page load |
| `app/filters/good_job/jobs_filter.rb:20` | `query.discarded.count`, "discarded" state tab count |
| `app/filters/good_job/jobs_filter.rb:98` | `GoodJob::Job.discarded` when `?state=discarded` |
| `app/controllers/good_job/cleaner_controller.rb:9, 23` | Cleaner page (discarded-by-exception, discarded-by-class) |
| `app/models/good_job/batch.rb:304` | `record.jobs.discarded` |

Index shape: `btree(finished_at DESC) WHERE finished_at IS NOT NULL AND error IS NOT NULL`. Serves the nav-badge count via index-only scan and the `?state=discarded` list (which orders by `finished_at DESC`) without a sort.

Plan change (count):

- Without: `Parallel Seq Scan` with `Filter: ((finished_at IS NOT NULL) AND (error IS NOT NULL))`, ~688k pages.
- With: `Index Only Scan`, `Heap Fetches: 0`, ~670 pages.

`SELECT COUNT(*) FROM good_jobs WHERE finished_at IS NOT NULL AND error IS NOT NULL`:

| | Cold (run 1) | Warm (run 3) |
|---|---:|---:|
| Without | 3,721.9 ms | 4,009.0 ms |
| With    |     2.4 ms |     1.5 ms |
| Speedup | **1,568×** | **2,707×** |

Plan change (list):

- Without: `Parallel Seq Scan`, top-N heapsort by `finished_at`, ~688k pages.
- With: `Index Scan` on `index_good_jobs_on_discarded`; LIMIT 25 stops after ~27 index pages. No sort step.

`SELECT id FROM good_jobs WHERE finished_at IS NOT NULL AND error IS NOT NULL ORDER BY finished_at DESC LIMIT 25`:

| | Cold (run 1) | Warm (run 3) |
|---|---:|---:|
| Without | 3,509.5 ms | 4,696.4 ms |
| With    |     2.4 ms |     0.02 ms |
| Speedup | **1,461×** | **313,090×** |

</details>
