### PR TITLE
Fix concurrent PG connection access in ProcessHeartbeat#refresh_process

### DIFF
--- a/lib/good_job/notifier/process_heartbeat.rb
+++ b/lib/good_job/notifier/process_heartbeat.rb
@@ -23,10 +23,8 @@ module GoodJob # :nodoc:
 
       def refresh_process
         Rails.application.executor.wrap do
-          GoodJob::Process.override_connection(connection) do
-            GoodJob::Process.with_logger_silenced do
-              @capsule.tracker.renew
-            end
+          GoodJob::Process.with_logger_silenced do
+            @capsule.tracker.renew
           end
         end
       end


### PR DESCRIPTION
`CapsuleTracker#renew` only needs a regular pool connection; there is no reason to route it through the Notifier's dedicated LISTEN connection. The previous `override_connection(connection)` wrapper caused `Persistence#reload` (called inside `renew`) to touch the LISTEN connection — which had been removed from the pool — concurrently with `wait_for_notify`/keepalive `async_exec` on the same socket, producing `PG::UnableToSend: server sent data ("D" message) without prior row description ("T" message)` errors. Removing `override_connection` from `refresh_process` lets `renew` use the standard pool connection as intended.

Connects to #1745 