### PR TITLE
Speed up ScheduledByQueueChart with inner-query pushdown and (scheduled_at, queue_name) index

### DIFF
--- a/app/charts/good_job/scheduled_by_queue_chart.rb
+++ b/app/charts/good_job/scheduled_by_queue_chart.rb
@@ -8,6 +8,25 @@ module GoodJob
     end
 
     def data
+      binds = start_end_binds
+      start_time, end_time = binds.map(&:value)
+
+      # Align the inner range predicate to the same hour buckets the outer generate_series
+      # produces. Doing the truncation in SQL (rather than in Ruby with beginning_of_hour)
+      # keeps both sides on the same grid even when the app's time zone has a fractional
+      # offset from UTC (e.g. IST +05:30). AR serializes Time binds as UTC, so the outer
+      # date_trunc operates in UTC, and this predicate must match that.
+      pushdown = <<~SQL.squish
+        "good_jobs"."scheduled_at" >= date_trunc('hour', ?::timestamp)
+        AND "good_jobs"."scheduled_at" < date_trunc('hour', ?::timestamp) + interval '1 hour'
+      SQL
+
+      inner_sql = @filter.filtered_query
+                         .except(:select, :order)
+                         .where(pushdown, start_time, end_time)
+                         .select(:queue_name, :scheduled_at)
+                         .to_sql
+
       count_query = <<~SQL.squish
         SELECT *
         FROM generate_series(
@@ -20,15 +39,13 @@ module GoodJob
               date_trunc('hour', scheduled_at) AS scheduled_at,
               queue_name,
               count(*) AS count
-            FROM (
-              #{@filter.filtered_query.except(:select, :order).select(:queue_name, :scheduled_at).to_sql}
-            ) sources
+            FROM (#{inner_sql}) sources
             GROUP BY date_trunc('hour', scheduled_at), queue_name
         ) sources ON sources.scheduled_at = timestamp
         ORDER BY timestamp ASC
       SQL
 
-      executions_data = GoodJob::Job.connection_pool.with_connection { |conn| conn.exec_query(GoodJob::Job.pg_or_jdbc_query(count_query), "GoodJob Dashboard Chart", start_end_binds) }
+      executions_data = GoodJob::Job.connection_pool.with_connection { |conn| conn.exec_query(GoodJob::Job.pg_or_jdbc_query(count_query), "GoodJob Dashboard Chart", binds) }
 
       queue_names = executions_data.reject { |d| d['count'].nil? }.map { |d| d['queue_name'] || BaseFilter::EMPTY }.uniq
       labels = []

--- a/demo/db/migrate/20260418000004_add_index_good_jobs_scheduled_at_and_queue_name.rb
+++ b/demo/db/migrate/20260418000004_add_index_good_jobs_scheduled_at_and_queue_name.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsScheduledAtAndQueueName < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:scheduled_at, :queue_name],
+      name: :index_good_jobs_on_scheduled_at_and_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_18_000003) do
+ActiveRecord::Schema.define(version: 2026_04_18_000004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2026_04_18_000003) do
     t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at", "queue_name"], name: "index_good_jobs_on_scheduled_at_and_queue_name"
   end
 
   create_table "pghero_query_stats", force: :cascade do |t|

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -118,5 +118,6 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       name: :index_good_jobs_on_discarded,
       order: { finished_at: :desc },
       where: "finished_at IS NOT NULL AND error IS NOT NULL"
+    add_index :good_jobs, [:scheduled_at, :queue_name], name: :index_good_jobs_on_scheduled_at_and_queue_name
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/13_add_index_good_jobs_scheduled_at_and_queue_name.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/13_add_index_good_jobs_scheduled_at_and_queue_name.rb.erb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsScheduledAtAndQueueName < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:scheduled_at, :queue_name],
+      name: :index_good_jobs_on_scheduled_at_and_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -315,7 +315,7 @@ module GoodJob
   # @return [Boolean]
   def self.migrated?
     GoodJob::Job.lock_type_migrated? &&
-      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_discarded")
+      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_scheduled_at_and_queue_name")
   end
 
   # Pause job execution for a given queue or job class.


### PR DESCRIPTION
_**Note: AI assisted PR, with careful human review and testing.**_

The `ScheduledByQueueChart` on the jobs index page was taking ~5 seconds to render against our 6.4M-row `good_jobs` table. This PR gets it down to ~120 ms (roughly 48× faster) by pushing the time filter into the inner query and adding a btree index that covers the chart's columns.

The chart runs on every load of `/good_job/jobs`. It counts jobs scheduled in each queue over the last 24 hours, bucketed by hour.

## The problem

`ScheduledByQueueChart#data` builds a query that looks like this:

```sql
SELECT *
FROM generate_series(<start>, <end>, '1 hour') timestamp
LEFT JOIN (
  SELECT date_trunc('hour', scheduled_at), queue_name, count(*)
  FROM (
    SELECT queue_name, scheduled_at FROM good_jobs  -- inner query
  ) sources
  GROUP BY date_trunc('hour', scheduled_at), queue_name
) sources ON sources.scheduled_at = timestamp
```

The `$1` and `$2` time binds are referenced only by the outer `generate_series`. The inner `SELECT queue_name, scheduled_at FROM good_jobs` has no `WHERE` clause, so Postgres has to read every row in the table, group by `date_trunc('hour', scheduled_at), queue_name`, and *then* the outer join discards everything outside the 24-hour window.

Two things go wrong:

1. The planner can't prune by `scheduled_at` because the inner query doesn't mention it. On a large table that's a full seq scan.
2. Even after the scan, the GROUP BY operates on the full materialized set instead of just the 24 hours that will survive the outer join.

## The fix

You need both pieces. Either one on its own is disappointing:

- Index alone (~6× on median): without a `WHERE` clause the planner can't do an index range scan, but it can do a full index-only scan of the composite. That's 245 MB to read instead of the 5,450 MB heap, and no heap fetches. The GROUP BY still runs over all 6.4M rows, so this caps out around a second.
- Pushdown alone (neutral, sometimes slightly worse): the planner sees the `scheduled_at` range but has no unconditional `scheduled_at` index to use, so it still seq-scans. The hash aggregate now spills to disk because the pre-groupby set isn't pre-sorted.
- Both together (~48× on median): the planner switches to an index range scan on ~504k rows for the 25-hour window, and the groupby stays in memory.

### 1. Push the `scheduled_at` range into the inner query

`app/charts/good_job/scheduled_by_queue_chart.rb` now applies a `WHERE` on the filtered query before stringifying:

```ruby
.where(
  "\"good_jobs\".\"scheduled_at\" >= date_trunc('hour', ?::timestamp) AND " \
  "\"good_jobs\".\"scheduled_at\" < date_trunc('hour', ?::timestamp) + interval '1 hour'",
  start_time, end_time,
)
```

The range has to line up with the hour buckets the outer `generate_series` emits. The original LEFT JOIN kept any row whose `date_trunc('hour', scheduled_at)` fell in the bucket list, which is equivalent to `scheduled_at ∈ [date_trunc('hour', start), date_trunc('hour', end) + 1.hour)`. Doing the truncation in SQL (not in Ruby with `beginning_of_hour`) keeps both sides on the same grid no matter what the app's time zone is. This matters for fractional-offset zones like IST (+05:30) where Ruby-side alignment and Postgres-side UTC alignment would otherwise drift by 30 minutes.

### 2. Add `index_good_jobs_on_scheduled_at_and_queue_name`

An unconditional btree on `(scheduled_at, queue_name)`. With the pushdown in place, the planner does an index range scan on `scheduled_at`, and since both columns the chart projects are in the index, it runs as an index-only scan with zero heap fetches:

```
Index Only Scan using index_good_jobs_on_scheduled_at_and_queue_name
  Index Cond: ((scheduled_at >= date_trunc('hour', $1::timestamp))
           AND (scheduled_at <  date_trunc('hour', $2::timestamp) + interval '1 hour'))
  Heap Fetches: 0
```

## Why this index and not the existing ones

The existing schema has several `scheduled_at` indexes, all partial on `finished_at IS NULL`:

- `index_good_jobs_on_scheduled_at` — `(scheduled_at) WHERE finished_at IS NULL`
- `index_good_jobs_on_queue_name_and_scheduled_at` — `(queue_name, scheduled_at) WHERE finished_at IS NULL`
- `index_good_jobs_on_priority_scheduled_at_unfinished` — `(priority, scheduled_at, id) WHERE finished_at IS NULL`

All three serve the worker dequeue path, where only unfinished rows can be picked up, so the `WHERE finished_at IS NULL` predicate is correct for that use case. But the chart counts every job scheduled in the window, finished or not, so none of these indexes can serve it. The column order also has to be `(scheduled_at, queue_name)` and not `(queue_name, scheduled_at)`. A range scan on `scheduled_at` needs `scheduled_at` to be the leading key.

## Benchmarks

Measured on a production copy from https://milkstraw.ai with ~6.4M rows in `good_jobs` (~504k in the 24-hour chart window). Timings via `EXPLAIN (ANALYZE, BUFFERS)`.

| Scenario | Chart render |
|---|---:|
| Vanilla (upstream) | ~5,600 ms |
| Index alone | ~960 ms |
| Pushdown alone | ~5,100 ms |
| **Both** | **~120 ms** |

The index alone buys ~6× by reading 245 MB of index instead of 5,450 MB of heap, but the GROUP BY still processes all 6.4M rows. Pushdown alone is a wash because the hash aggregate spills to disk without an index to feed it. With both in place the inner query becomes an index-only scan over ~9,775 buffer pages.

## Index size

At 6.4M rows (heap 5,450 MB):

| Index | Size | % of heap |
|---|---:|---:|
| `index_good_jobs_on_scheduled_at_and_queue_name` | 245 MB | 4.50% |

Bigger than the indexes from the previous dashboard PR. It's a full-table btree carrying both an 8-byte timestamp and a variable-length queue name. The payoff is ~5 s → ~120 ms on a query that fires on every load of `/good_job/jobs`, which seems worth the write amplification. `scheduled_at` is set at enqueue and not typically updated, so the ongoing cost is just insert-time index maintenance.

## Migration

Update migration `13_add_index_good_jobs_scheduled_at_and_queue_name.rb` uses `disable_ddl_transaction!`, `algorithm: :concurrently`, and `if_not_exists: true`, same style as migrations 10–12. `GoodJob.migrated?` now points at this migration's index, following the pattern from #1631 (`concurrency_key_created_at`) and #1677 (`historic_finished_at`).

The install template picks up the new index unconditionally, and the demo schema and migration are updated so `bin/rails db:setup` stays in sync for contributors.

---

This change has been running in production at https://milkstraw.ai for several days with no issues.
