### PR TITLE
Speed up succeeded count via complement subtraction

### DIFF
--- a/app/filters/good_job/jobs_filter.rb
+++ b/app/filters/good_job/jobs_filter.rb
@@ -16,7 +16,7 @@ module GoodJob
           'retried' => query.retried.count,
           'queued' => query.queued.count,
           'running' => query.running.count,
-          'succeeded' => query.succeeded.count,
+          'succeeded' => succeeded_count(query),
           'discarded' => query.discarded.count,
         }
       end
@@ -34,7 +34,11 @@ module GoodJob
     end
 
     def filtered_count
-      @_filtered_count ||= filtered_query.unscope(:select).count
+      @_filtered_count ||= if params[:state] == 'succeeded'
+                             succeeded_count(filtered_query(params.except(:state)))
+                           else
+                             filtered_query.unscope(:select).count
+                           end
     end
 
     def ordered_by
@@ -51,6 +55,15 @@ module GoodJob
     end
 
     private
+
+    # Count of succeeded jobs computed as `total - (unfinished OR errored)`.
+    # The complement set is typically tiny (< 1% of rows), and `index_good_jobs_on_unfinished_or_errored`
+    # covers it exactly, so this is an index-only scan instead of a full-table scan through `succeeded`.
+    # Clamped at 0 to guard against the two counts drifting across a concurrent insert burst.
+    def succeeded_count(query)
+      base = query.unscope(:select)
+      (base.count - base.where('finished_at IS NULL OR error IS NOT NULL').count).clamp(0..)
+    end
 
     def filter_by_job_class(job_class)
       return {} if job_class.blank?

--- a/demo/db/migrate/20260418000005_add_index_good_jobs_on_unfinished_or_errored.rb
+++ b/demo/db/migrate/20260418000005_add_index_good_jobs_on_unfinished_or_errored.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsOnUnfinishedOrErrored < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_18_000004) do
+ActiveRecord::Schema.define(version: 2026_04_18_000005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 2026_04_18_000004) do
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
     t.index ["scheduled_at", "queue_name"], name: "index_good_jobs_on_scheduled_at_and_queue_name"
+    t.index ["id"], name: "index_good_jobs_on_unfinished_or_errored", where: "((finished_at IS NULL) OR (error IS NOT NULL))"
   end
 
   create_table "pghero_query_stats", force: :cascade do |t|

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -119,5 +119,8 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       order: { finished_at: :desc },
       where: "finished_at IS NOT NULL AND error IS NOT NULL"
     add_index :good_jobs, [:scheduled_at, :queue_name], name: :index_good_jobs_on_scheduled_at_and_queue_name
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL"
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/14_add_index_good_jobs_on_unfinished_or_errored.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/14_add_index_good_jobs_on_unfinished_or_errored.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsOnUnfinishedOrErrored < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -315,7 +315,7 @@ module GoodJob
   # @return [Boolean]
   def self.migrated?
     GoodJob::Job.lock_type_migrated? &&
-      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_scheduled_at_and_queue_name")
+      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_unfinished_or_errored")
   end
 
   # Pause job execution for a given queue or job class.


### PR DESCRIPTION
_**Note: AI assisted PR, with careful human review and testing.**_

The "succeeded" state tab on `/good_job/jobs` runs a count query that does a full seq scan on every dashboard load. This PR takes it from ~6 s to ~187 ms on our 6.4M-row `good_jobs` table (~32× faster) by rewriting the count as a complement subtraction and adding a tiny partial index to serve the complement set.

## The problem

`JobsFilter#states` populates the nav-tab counts (scheduled, retried, queued, running, succeeded, discarded) on every load of `/good_job/jobs`, and `#filtered_count` fires again whenever you click into `?state=succeeded`.

The succeeded scope is `finished_at IS NOT NULL AND error IS NULL`. There's no index whose predicate matches it, so:

```sql
SELECT COUNT(*) FROM good_jobs WHERE finished_at IS NOT NULL AND error IS NULL;
-- Finalize Aggregate  (cost=731862.61..731862.62)
-- Parallel Seq Scan on good_jobs (actual time=3966..3973, rows≈6.38M)
-- 6,740 ms median over 5 runs
```

The other state scopes either match a partial index (discarded → `index_good_jobs_on_discarded`, scheduled/retried/queued/running → one of the `WHERE finished_at IS NULL` indexes), or they count a tiny subset that a seq scan can finish fast. Succeeded is the worst case: typical `good_jobs` tables are almost entirely succeeded rows (on our table, 99.7%), and there's no existing index the planner can use to avoid reading them all.

## The fix: count the complement

Set identity: `succeeded = total − (unfinished OR errored)`.

The complement set (`finished_at IS NULL OR error IS NOT NULL`) is exactly the rows the succeeded scope excludes. On a healthy `good_jobs` table this is a tiny minority (running jobs, scheduled jobs, discarded jobs), so a partial index covering it stays small.

```sql
-- succeeded count, computed as two fast queries:
SELECT COUNT(*) FROM good_jobs;                                          -- 185 ms via pkey
SELECT COUNT(*) FROM good_jobs WHERE finished_at IS NULL OR error IS NOT NULL;  -- 2 ms via new index
-- subtract in Ruby: 187 ms total
```

Two changes make this work:

### 1. `JobsFilter#succeeded_count`

New private helper:

```ruby
def succeeded_count(query)
  base = query.unscope(:select)
  (base.count - base.where('finished_at IS NULL OR error IS NOT NULL').count).clamp(0..)
end
```

Used in both `#states` (nav-tab counts) and `#filtered_count` (when `?state=succeeded`), so every user-facing succeeded count goes through it. Other scopes and filters compose with it unchanged because we operate on the already-filtered `query`, so job_class / queue_name / label / search filters still apply.

The `.clamp(0..)` guards against the rare case where enough jobs transition into the complement set between the two counts to push the subtraction negative. On a filtered view over a rare queue with single-digit succeeded rows, a burst of enqueues in the ~180 ms window between the two queries could otherwise produce a negative tab count.

### 2. `index_good_jobs_on_unfinished_or_errored`

Partial btree on `id` with predicate `finished_at IS NULL OR error IS NOT NULL`. Exactly matches the complement predicate so Postgres can serve the count as an index-only scan with zero heap fetches:

```
Index Only Scan using index_good_jobs_on_unfinished_or_errored
  (actual time=2.196..2.196 rows=<small> loops=1)
  Heap Fetches: 0
```

## Benchmarks

Measured on a production copy from https://milkstraw.ai with 6.4M rows in `good_jobs`. Five runs via `EXPLAIN (ANALYZE, BUFFERS)`, reporting medians. The "before" column is the gem at current `main` (with the dashboard indexes from #1754 and chart-pushdown index from #1757 already applied); only the complement index and the `succeeded_count` code change are new in this PR.

| Query | Before | After | Change |
|---|---:|---:|---:|
| `COUNT * FROM good_jobs` (part 1) | 226 ms | 185 ms | same (pkey) |
| `COUNT … WHERE finished_at IS NULL OR error IS NOT NULL` (part 2) | 5,820 ms | **2.2 ms** | **~2,600×** |
| **Succeeded count** (sum of parts 1+2) | **6,046 ms** | **187 ms** | **~32×** |

## Index size

At 6.4M rows (heap 5,450 MB):

| Index | Size | % of heap |
|---|---:|---:|
| `index_good_jobs_on_unfinished_or_errored` | 608 kB | 0.01% |

Same order of magnitude as `index_good_jobs_on_discarded` from #1754. The complement set tracks in-flight and errored jobs rather than total job history, so on a healthy table the index stays small regardless of how many jobs have been processed.

## Migration

Update migration `14_add_index_good_jobs_on_unfinished_or_errored.rb` uses `disable_ddl_transaction!`, `algorithm: :concurrently`, and `if_not_exists: true`, same style as migrations 10–13. `GoodJob.migrated?` now points at this migration's index, following the pattern from #1631 (`concurrency_key_created_at`), #1677 (`historic_finished_at`), and #1757 (`scheduled_at_and_queue_name`).

The install template picks up the new index unconditionally, and the demo schema and migration are updated so `bin/rails db:setup` stays in sync for contributors.

---

This change has been running in production at https://milkstraw.ai for several days with no issues.