### PR TITLE
Fix ArgumentError when using perform_throttle without a label

### DIFF
--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -86,7 +86,7 @@ module GoodJob
           elsif @config.key?(:key) && key.present?
             GoodJob::Job.where(concurrency_key: key)
           else
-            GoodJob::Job
+            GoodJob::Job.all
           end
         end
 

--- a/spec/lib/good_job/active_job_extensions/concurrency_rule_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_rule_spec.rb
@@ -136,6 +136,23 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
     end
 
+    context 'with a perform throttle rule without a label' do
+      let(:test_rule) { { perform_throttle: [1, 1.minute] } }
+
+      before do
+        allow(GoodJob).to receive(:preserve_job_records).and_return(true)
+        stub_job_class(test_rule)
+      end
+
+      it 'does not perform if throttle period has not passed' do
+        TestJob.perform_later(name: "Alice")
+        TestJob.perform_later(name: "Alice")
+        GoodJob.perform_inline
+
+        expect(GoodJob::Job.finished.count).to eq 1
+      end
+    end
+
     context 'with a multipart rule' do
       let(:test_rule) { { label: -> { arguments.first[:name] }, enqueue_throttle: [1, 1.minute], perform_limit: 0 } }
 


### PR DESCRIPTION
Fixes #1759.

When `good_job_concurrency_rule` is used with `perform_throttle` but no `label` or `key`, the `query_scope` helper returned the `GoodJob::Job` class rather than a relation. This caused `Execution.joins(:job).merge(query_scope)` to raise `ArgumentError` because `merge` requires an `ActiveRecord::Relation`. The fix changes the fallback from `GoodJob::Job` to `GoodJob::Job.all`. A regression test is included.