### PR TITLE
Add update migration to drop redundant active_job_id index

### DIFF
--- a/lib/generators/good_job/templates/update/migrations/15_remove_duplicate_active_job_id_index.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/15_remove_duplicate_active_job_id_index.rb.erb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RemoveDuplicateActiveJobIdIndex < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        return unless connection.index_name_exists?(:good_jobs, :index_good_jobs_on_active_job_id)
+      end
+    end
+
+    remove_index :good_jobs, :active_job_id, name: :index_good_jobs_on_active_job_id, algorithm: :concurrently
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -315,7 +315,7 @@ module GoodJob
   # @return [Boolean]
   def self.migrated?
     GoodJob::Job.lock_type_migrated? &&
-      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_unfinished_or_errored")
+      !GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_active_job_id")
   end
 
   # Pause job execution for a given queue or job class.


### PR DESCRIPTION
Closes #1661

## What

Adds update migration `15_remove_duplicate_active_job_id_index` to drop `index_good_jobs_on_active_job_id` from the `good_jobs` table, and updates `GoodJob.migrated?` to reflect the latest migration.

## Why

`index_good_jobs_on_active_job_id` is fully redundant. PostgreSQL can satisfy single-column lookups on `active_job_id` using the composite `index_good_jobs_on_active_job_id_and_created_at` as a prefix scan — the single-column index adds no selectivity and is pure write overhead.

The `good_jobs` table undergoes `INSERT`, `UPDATE`, and `DELETE` at high volume, so every redundant index adds measurable write amplification and lock contention.

## History

This was originally fixed in PR #1181 (December 2023) as migration `10_remove_good_job_active_id_index`. That migration was intentionally removed during the v4 major release (July 2024), which reset the numbered update migration series. The install template has been correct since v3 (no single-column index), but existing pre-v4 installs that never ran migration #10 still carry the redundant index. This re-lands the fix as migration `#15` for the post-v4 world.

## Changes

- `lib/generators/good_job/templates/update/migrations/15_remove_duplicate_active_job_id_index.rb.erb` — new update migration; idempotent guard via `index_name_exists?`, uses `algorithm: :concurrently`, fully reversible
- `lib/good_job.rb` — `GoodJob.migrated?` updated to check absence of the redundant index (replaces the previous #14 check per the established pattern)

## Testing

- New installs (current template never creates the single-column index): migration is a no-op, `migrated?` returns `true` ✓
- Old installs that haven't run this migration yet: index still present, `migrated?` returns `false` ✓
- Old installs after running this migration: index dropped, `migrated?` returns `true` ✓
- `spec/generators/good_job/update_generator_spec.rb` "has files with unique number prefixes" passes ✓
- `spec/integration/` (62 examples) and `spec/lib/good_job_spec.rb` (18 examples) all pass ✓