### PR TITLE
Set default queue_select_limit to 1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,7 +1292,7 @@ The recommended way to monitor the queue in production is:
 
 GoodJob’s advisory locking strategy uses a materialized CTE (Common Table Expression). This strategy can be non-performant when querying a very large queue of executable jobs (100,000+) because the database query must materialize all executable jobs before acquiring an advisory lock.
 
-GoodJob offers an optional optimization to limit the number of jobs that are queried: Queue Select Limit.
+GoodJob's Queue Select Limit restricts how many jobs are materialized per advisory lock cycle. **It defaults to `1000` — no configuration needed.** Override it if your deployment requires a different value:
 
 ```none
 # CLI option
@@ -1305,7 +1305,7 @@ config.good_job.queue_select_limit = 1000
 GOOD_JOB_QUEUE_SELECT_LIMIT=1000
 ```
 
-The Queue Select Limit value should be set to a rough upper-bound that exceeds all GoodJob execution threads / database connections. `1000` is a number that likely exceeds the available database connections on most PaaS offerings, but still offers a performance boost for GoodJob when executing very large queues.
+The default of `1000` is a rough upper-bound that exceeds the available database connections on most PaaS offerings, while still offering a significant performance boost for GoodJob when executing very large queues.
 
 To explain where this value is used, here is the pseudo-query that GoodJob uses to find executable jobs:
 
@@ -1318,7 +1318,7 @@ To explain where this value is used, here is the pseudo-query that GoodJob uses 
       FROM good_jobs
       WHERE (scheduled_at <= NOW() OR scheduled_at IS NULL) AND finished_at IS NULL
       ORDER BY priority DESC NULLS LAST, created_at ASC
-      [LIMIT 1000] -- <= introduced when queue_select_limit is set
+      [LIMIT 1000] -- <= applied by default; configurable via queue_select_limit
     )
     SELECT id
     FROM rows

--- a/lib/good_job/cli.rb
+++ b/lib/good_job/cli.rb
@@ -105,7 +105,7 @@ module GoodJob
     method_option :queue_select_limit,
                   type: :numeric,
                   banner: 'COUNT',
-                  desc: "The number of queued jobs to select when polling for a job to run. (env var: GOOD_JOB_QUEUE_SELECT_LIMIT, default: nil)"
+                  desc: "The number of queued jobs to select when polling for a job to run. (env var: GOOD_JOB_QUEUE_SELECT_LIMIT, default: 1000)"
 
     def start
       set_up_application!

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -39,6 +39,8 @@ module GoodJob
     DEFAULT_ENQUEUE_AFTER_TRANSACTION_COMMIT = false
     # Default enable_pauses setting
     DEFAULT_ENABLE_PAUSES = false
+    # Default number of candidate jobs to query when polling
+    DEFAULT_QUEUE_SELECT_LIMIT = 1_000
     # Valid dequeue query sorts
     DEQUEUE_QUERY_SORTS = [:created_at, :scheduled_at].freeze
     # Valid lock strategies
@@ -242,13 +244,14 @@ module GoodJob
     # This limit is intended to avoid locking a large number of rows when selecting eligible jobs
     # from the queue. This value should be higher than the total number of threads across all good_job
     # processes to ensure a thread can retrieve an eligible and unlocked job.
-    # @return [Integer, nil]
+    # @return [Integer]
     def queue_select_limit
       (
         options[:queue_select_limit] ||
           rails_config[:queue_select_limit] ||
-          env['GOOD_JOB_QUEUE_SELECT_LIMIT']
-      )&.to_i
+          env['GOOD_JOB_QUEUE_SELECT_LIMIT'] ||
+          DEFAULT_QUEUE_SELECT_LIMIT
+      ).to_i
     end
 
     # The number of seconds that a good_job process will idle with out running a job before exiting

--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -354,4 +354,34 @@ RSpec.describe GoodJob::Configuration do
       expect(configuration.advisory_lock_heartbeat).to be true
     end
   end
+
+  describe '#queue_select_limit' do
+    it 'defaults to 1000' do
+      configuration = described_class.new({})
+      expect(configuration.queue_select_limit).to eq 1000
+    end
+
+    context 'when option is given' do
+      it 'uses option value' do
+        configuration = described_class.new({ queue_select_limit: 100 })
+        expect(configuration.queue_select_limit).to eq 100
+      end
+    end
+
+    context 'when rails config is set' do
+      it 'uses rails config value' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ queue_select_limit: 500 })
+        configuration = described_class.new({})
+        expect(configuration.queue_select_limit).to eq 500
+      end
+    end
+
+    context 'when environment variable is set' do
+      it 'uses environment variable' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_QUEUE_SELECT_LIMIT' => '2000' })
+        configuration = described_class.new({})
+        expect(configuration.queue_select_limit).to eq 2000
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #1596

## What

Sets `DEFAULT_QUEUE_SELECT_LIMIT = 1_000` as the fallback when no explicit `queue_select_limit` is configured via options, Rails initializer, or environment variable.

## Why

Without a default, `queue_select_limit` returns `nil`, which skips the `LIMIT` clause on the materialized CTE used to find candidate jobs. On large queues (100k+ eligible jobs), this forces PostgreSQL to fully materialize every row before acquiring an advisory lock — an expensive scan that grows unbounded with queue depth.

1000 is already the value recommended in the README and covers virtually all real-world deployments: it exceeds the database connection limits of most PaaS platforms, while still providing the intended performance benefit.

## Changes

- `lib/good_job/configuration.rb` — adds `DEFAULT_QUEUE_SELECT_LIMIT = 1_000` constant; updates `queue_select_limit` to use the inline-default pattern consistent with other numeric settings; fixes `@return` tag from `[Integer, nil]` to `[Integer]`
- `lib/good_job/cli.rb` — updates the `--queue-select-limit` description from `default: nil` to `default: 1000`
- `spec/lib/good_job/configuration_spec.rb` — adds `#queue_select_limit` spec covering the default and all three override sources (options, Rails config, environment variable)