### PR TITLE
Handle nil updated_at in stale? method

### DIFF
--- a/app/models/good_job/process.rb
+++ b/app/models/good_job/process.rb
@@ -151,6 +151,8 @@ module GoodJob # :nodoc:
     end
 
     def stale?
+      return true if updated_at.nil?
+
       updated_at < STALE_INTERVAL.ago
     end
 


### PR DESCRIPTION
Proposed approach to close #1649.

## What
Treat a `Process` record with a nil `updated_at` value as stale to avoid a `NoMethodError` when calling `stale?`.

## Why
It's quite edge-casey, but if the `save` call in the `rescue ActiveRecord::RecordNotFound` path for `Process#refresh` fails, `updated_at` is left as `nil` which causes `stale?` to raise an exception. See the linked issue for additional context.

We ran into this issue not-infrequently in our codebase and applied a monkey patch with this change which has resolved the problem.