### PR TITLE
Truncate long labels in dashboard badges

### DIFF
--- a/app/frontend/good_job/modules/bootstrap_init.js
+++ b/app/frontend/good_job/modules/bootstrap_init.js
@@ -15,7 +15,14 @@ function setupPopovers() {
   })
 }
 
+function setupTooltips() {
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+    new bootstrap.Tooltip(el)
+  })
+}
+
 window.document.addEventListener("turbo:load", function() {
   showToasts();
   setupPopovers();
+  setupTooltips();
 });

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -1,24 +1,3 @@
-.tooltip {
-  position: absolute;
-  z-index: 1;
-  padding: 5px;
-  background: rgba(0, 0, 0, 0.3);
-  opacity: 1;
-  border-radius: 3px;
-  text-align: center;
-  pointer-events: none;
-  color: white;
-  transition: opacity .1s ease-out;
-}
-
-.tooltip.tooltip-hidden {
-  opacity: 0;
-}
-
-.ct-label.ct-horizontal {
-  white-space: nowrap;
-}
-
 .chart-wrapper {
   position: relative;
   height: 200px;

--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -37,7 +37,8 @@
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
-                  <span class="badge rounded-pill text-bg-secondary font-monospace"><%= label %></span>
+                  <% truncated = truncate(label, length: 15) %>
+                  <%= tag.span truncated, class: "badge rounded-pill text-bg-secondary font-monospace", **(truncated != label ? { title: label, data: { bs_toggle: "tooltip" } } : {}) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -37,8 +37,8 @@
               <div class="col-4 col-lg-1 text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
-                  <% truncated = truncate(label, length: 15) %>
-                  <%= tag.span truncated, class: "badge rounded-pill text-bg-secondary font-monospace", **(truncated == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
+                  <% truncated_label = truncate(label, length: 15) %>
+                  <%= tag.span truncated_label, class: "badge rounded-pill text-bg-secondary font-monospace", **(truncated_label == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/app/views/good_job/batches/_jobs.erb
+++ b/app/views/good_job/batches/_jobs.erb
@@ -38,7 +38,7 @@
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
                   <% truncated = truncate(label, length: 15) %>
-                  <%= tag.span truncated, class: "badge rounded-pill text-bg-secondary font-monospace", **(truncated != label ? { title: label, data: { bs_toggle: "tooltip" } } : {}) %>
+                  <%= tag.span truncated, class: "badge rounded-pill text-bg-secondary font-monospace", **(truncated == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -104,7 +104,8 @@
               <div class="col-4 col-lg-1 text-wrap text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
-                  <%= link_to label, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none" %>
+                  <% truncated = truncate(label, length: 15) %>
+                  <%= link_to truncated, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none", **(truncated != label ? { title: label, data: { bs_toggle: "tooltip" } } : {}) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -104,8 +104,8 @@
               <div class="col-4 col-lg-1 text-wrap text-lg-end">
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
-                  <% truncated = truncate(label, length: 15) %>
-                  <%= link_to truncated, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none", **(truncated == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
+                  <% truncated_label = truncate(label, length: 15) %>
+                  <%= link_to truncated_label, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none", **(truncated_label == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/app/views/good_job/jobs/_table.erb
+++ b/app/views/good_job/jobs/_table.erb
@@ -105,7 +105,7 @@
                 <div class="d-lg-none small text-muted mt-1"><%= t "good_job.models.job.labels" %></div>
                 <% job.labels&.each do |label| %>
                   <% truncated = truncate(label, length: 15) %>
-                  <%= link_to truncated, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none", **(truncated != label ? { title: label, data: { bs_toggle: "tooltip" } } : {}) %>
+                  <%= link_to truncated, filter.to_params(label: label), class: "badge rounded-pill text-bg-secondary font-monospace text-decoration-none", **(truncated == label ? {} : { title: label, data: { bs_toggle: "tooltip" } }) %>
                 <% end %>
               </div>
               <div class="col-4 col-lg-1 text-lg-end">

--- a/spec/system/jobs_spec.rb
+++ b/spec/system/jobs_spec.rb
@@ -155,6 +155,17 @@ describe 'Jobs', :js, :without_executor do
         expect(table).to have_css("[role=row]", count: 1)
         expect(table).to have_content(labeled_job.job_id)
       end
+
+      it "renders long labels truncated with a tooltip showing the full label" do
+        long_label = "a_very_long_label_that_exceeds_the_badge_width"
+        ExampleJob.set(wait: 10.minutes, good_job_labels: [long_label]).perform_later
+
+        visit good_job.jobs_path
+        wait_for_turbo_load
+
+        expect(page).to have_css("a.badge[data-bs-toggle='tooltip']", text: "a_very_long_...")
+        expect(page).to have_css("a.badge[data-bs-original-title='#{long_label}']")
+      end
     end
 
     it 'can retry discarded jobs' do


### PR DESCRIPTION
Fixes #1674.

## What

Long label strings caused badge overflow that broke the table row layout — the badge would expand to full label width and spill into adjacent columns.

**Before:**

![Before: long labels break the table layout](https://github.com/user-attachments/assets/23b5a4c2-ae88-4c0b-99d5-9b1d64ec9da6)

**After:**

<img width="1710" height="706" alt="Screenshot 2026-04-28 at 23 26 47" src="https://github.com/user-attachments/assets/4715beb1-080d-4f9a-8215-51f378aa201e" />

## How

- `jobs/_table.erb` and `batches/_jobs.erb`: use Rails' `truncate` helper (length: 15) to shorten the displayed label. Only labels that are actually truncated get a `title` attribute and `data-bs-toggle="tooltip"` so the full text remains accessible on hover.
- `bootstrap_init.js`: added `setupTooltips()` (mirrors the existing `setupPopovers()`) so all `[data-bs-toggle="tooltip"]` elements are initialized on `turbo:load`.

## Tests

Added a system spec that creates a job with a long label, visits the jobs index, and asserts:
- the badge shows the truncated text (`"a_very_long_..."`)
- `data-bs-original-title` (set by Bootstrap after tooltip init) holds the full label