### PR TITLE
Fix PG::AmbiguousColumn in skiplocked/hybrid claim with ordered queues + concurrency rules

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -188,7 +188,7 @@ module GoodJob
     # @return [ActiveRecord::Relation]
     scope :queue_ordered, (lambda do |queues|
       clauses = queues.map.with_index do |queue_name, index|
-        sanitize_sql_array(["WHEN queue_name = ? THEN ?", queue_name, index])
+        sanitize_sql_array(["WHEN #{quoted_table_name}.queue_name = ? THEN ?", queue_name, index])
       end
       order(Arel.sql("(CASE #{clauses.join(' ')} ELSE #{queues.size} END)"))
     end)

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -187,8 +187,9 @@ module GoodJob
     # @param queues [Array<string] ordered names of queues
     # @return [ActiveRecord::Relation]
     scope :queue_ordered, (lambda do |queues|
+      qualified_queue_name = "#{quoted_table_name}.#{adapter_class.quote_column_name('queue_name')}"
       clauses = queues.map.with_index do |queue_name, index|
-        sanitize_sql_array(["WHEN #{quoted_table_name}.queue_name = ? THEN ?", queue_name, index])
+        sanitize_sql_array(["WHEN #{qualified_queue_name} = ? THEN ?", queue_name, index])
       end
       order(Arel.sql("(CASE #{clauses.join(' ')} ELSE #{queues.size} END)"))
     end)

--- a/app/models/good_job/job/lockable.rb
+++ b/app/models/good_job/job/lockable.rb
@@ -59,7 +59,7 @@ module GoodJob
           record = unscoped.find_by_sql([sql, locked_by_id, locked_at, lock_types[lock_type.to_s]]).first
 
           begin
-            yield(record)
+            unscoped { yield(record) }
           ensure
             record.update(locked_by_id: nil, locked_at: nil, lock_type: nil) if record && !record.destroyed? && record.locked_by_id.present?
             record&.run_callbacks(:perform_unlocked)
@@ -103,7 +103,7 @@ module GoodJob
           record_advisory_lock(lease_connection, record.lockable_column_key, cte: true) if record
 
           begin
-            yield(record)
+            unscoped { yield(record) }
           ensure
             if record
               record.advisory_unlock

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -90,25 +90,25 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "c837568c590d9608a8bb9927b31b9597aaacc72053b6482e1a54bd02aa0dd2d7",
+      "fingerprint": "c57f2525e5d0780a0bcb460502f1b3ebceb9992885466f45b4035ab670c628d9",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/models/good_job/job.rb",
-      "line": 162,
+      "line": 194,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Arel.sql(\"(CASE #{queues.map.with_index do\n sanitize_sql_array([\"WHEN queue_name = ? THEN ?\", queue_name, index])\n end.join(\" \")} ELSE #{queues.size} END)\")",
+      "code": "Arel.sql(\"(CASE #{queues.map.with_index do\n sanitize_sql_array([\"WHEN #{\"#{quoted_table_name}.#{adapter_class.quote_column_name(\"queue_name\")}\"} = ? THEN ?\", queue_name, index])\n end.join(\" \")} ELSE #{queues.size} END)\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Job",
         "method": null
       },
-      "user_input": "queues.map.with_index do\n sanitize_sql_array([\"WHEN queue_name = ? THEN ?\", queue_name, index])\n end.join(\" \")",
+      "user_input": "queues.map.with_index do\n sanitize_sql_array([\"WHEN #{\"#{quoted_table_name}.#{adapter_class.quote_column_name(\"queue_name\")}\"} = ? THEN ?\", queue_name, index])\n end.join(\" \")",
       "confidence": "Medium",
       "cwe_id": [
         89
       ],
-      "note": "Developer provided value, queue_name, is sanitized."
+      "note": "Developer provided value, queue_name, is sanitized; identifier is quoted via Rails quoted_table_name and quote_column_name."
     },
     {
       "warning_type": "Command Injection",

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -35,6 +35,7 @@ module ::THREAD_JOBS; end
 module ::TestError; end
 module ::AnotherTestJob; end
 module ::TestJob; end
+module ::ThrottledJob; end
 module ::SuccessJob; end
 module ::WAIT_EVENT; end
 module ::TestJob::Error; end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -706,7 +706,7 @@ RSpec.describe GoodJob::Job do
       it "produces SQL to order by queue order" do
         query_sql = described_class.queue_ordered(%w{one two three}).to_sql
         expect(query_sql).to include(
-          %(ORDER BY (CASE WHEN "good_jobs".queue_name = 'one' THEN 0 WHEN "good_jobs".queue_name = 'two' THEN 1 WHEN "good_jobs".queue_name = 'three' THEN 2 ELSE 3 END))
+          %(ORDER BY (CASE WHEN "good_jobs"."queue_name" = 'one' THEN 0 WHEN "good_jobs"."queue_name" = 'two' THEN 1 WHEN "good_jobs"."queue_name" = 'three' THEN 2 ELSE 3 END))
         )
       end
     end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -706,7 +706,7 @@ RSpec.describe GoodJob::Job do
       it "produces SQL to order by queue order" do
         query_sql = described_class.queue_ordered(%w{one two three}).to_sql
         expect(query_sql).to include(
-          "ORDER BY (CASE WHEN queue_name = 'one' THEN 0 WHEN queue_name = 'two' THEN 1 WHEN queue_name = 'three' THEN 2 ELSE 3 END)"
+          %(ORDER BY (CASE WHEN "good_jobs".queue_name = 'one' THEN 0 WHEN "good_jobs".queue_name = 'two' THEN 1 WHEN "good_jobs".queue_name = 'three' THEN 2 ELSE 3 END))
         )
       end
     end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -709,6 +709,12 @@ RSpec.describe GoodJob::Job do
           %(ORDER BY (CASE WHEN "good_jobs"."queue_name" = 'one' THEN 0 WHEN "good_jobs"."queue_name" = 'two' THEN 1 WHEN "good_jobs"."queue_name" = 'three' THEN 2 ELSE 3 END))
         )
       end
+
+      it "can be merged into a query that joins good_job_executions without ambiguity" do
+        expect do
+          GoodJob::Execution.joins(:job).merge(described_class.queue_ordered(%w{one two})).to_a
+        end.not_to raise_error
+      end
     end
 
     describe '.priority_ordered' do

--- a/spec/integration/lock_strategy_spec.rb
+++ b/spec/integration/lock_strategy_spec.rb
@@ -178,4 +178,41 @@ RSpec.describe 'Lock strategy integration' do
       }
     end
   end
+
+  describe 'perform_throttle with ordered queues' do
+    before do
+      stub_const 'ThrottledJob', (Class.new(ActiveJob::Base) do
+        include GoodJob::ActiveJobExtensions::Concurrency
+
+        good_job_control_concurrency_with(
+          perform_throttle: -> { [10, 1.minute] },
+          key: -> { 'shared-key' }
+        )
+
+        def perform
+          RUN_JOBS << provider_job_id
+        end
+      end)
+      ThrottledJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :external)
+    end
+
+    shared_examples 'performs throttled jobs without error' do |strategy|
+      it "#{strategy}: performs a throttled job dequeued by an ordered-queue worker" do
+        GoodJob.configuration.options[:lock_strategy] = strategy
+
+        ThrottledJob.set(queue: 'default').perform_later
+
+        expect { GoodJob.perform_inline('+default,other') }.not_to raise_error
+
+        job = GoodJob::Job.last
+        expect(job.finished_at).to be_present
+        expect(job.error).to be_nil
+        expect(RUN_JOBS.size).to eq 1
+      end
+    end
+
+    it_behaves_like 'performs throttled jobs without error', :advisory
+    it_behaves_like 'performs throttled jobs without error', :skiplocked
+    it_behaves_like 'performs throttled jobs without error', :hybrid
+  end
 end


### PR DESCRIPTION
Fixes #1767.

Under `lock_strategy: :hybrid` or `:skiplocked`, workers using `+`-prefixed ordered queues raised `PG::AmbiguousColumn: column reference "queue_name" is ambiguous` on every perform of any job using `GoodJob::ActiveJobExtensions::Concurrency`. Introduced by #1731.

The skiplocked/hybrid claim methods in `Job::Lockable` yielded the locked record while `GoodJob::Job` was still scoped to the dequeue relation, so `GoodJob::Job` queries inside the perform block (e.g. the `query_scope` built by `Concurrency#check_perform`) inherited that scope, including `queue_ordered`'s unqualified `queue_name` ORDER BY, plus `unfinished`, `where(locked_by_id: nil)`, and `limit(1)`. The advisory path already wraps its yield in `unscoped` (see `AdvisoryLockable#advisory_lock`), which is why `:advisory` was unaffected. Beyond the SQL ambiguity, the same scope leak would also silently miscount throttle limits under `:hybrid`/`:skiplocked`.

The fix wraps the yield in `unscoped { }` in `with_skip_locked_claim` and `with_hybrid_lock_claim`, matching the advisory path. It also defensively qualifies `queue_name` in the `queue_ordered` scope so it remains safe to merge into joined queries on its own. A behavioral spec parameterized over all three strategies covers the original symptom; a separate join-merge test on `queue_ordered` covers the column qualification.