### PR TITLE
Fix `PG::ProgramLimitExceeded` in jobs index search for large error payloads

### DIFF
--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -5,6 +5,11 @@ module GoodJob
   module Filterable
     extend ActiveSupport::Concern
 
+    # Bounds each to_tsvector() input so the combined tsvector stays under
+    # PG's ~1 MB limit (PG::ProgramLimitExceeded: "string is too long for
+    # tsvector").
+    MAX_SEARCH_COLUMN_CHARS = 262_144
+
     included do
       # Get records in display order with optional keyset pagination.
       # @!method display_all(ordered_by: ["created_at", "desc"], after_at: nil, after_id: nil)
@@ -65,7 +70,7 @@ module GoodJob
         next if query.blank?
 
         # TODO: turn this into proper bind parameters in Arel
-        tsvector = "(to_tsvector('english', id::text) || to_tsvector('english', COALESCE(active_job_id::text, '')) || to_tsvector('english', serialized_params) || to_tsvector('english', COALESCE(serialized_params->>'arguments', '')) || to_tsvector('english', COALESCE(error, '')) || to_tsvector('english', COALESCE(array_to_string(labels, ' '), '')))"
+        tsvector = "(to_tsvector('english', id::text) || to_tsvector('english', COALESCE(active_job_id::text, '')) || to_tsvector('english', serialized_params) || to_tsvector('english', COALESCE(LEFT(serialized_params->>'arguments', #{MAX_SEARCH_COLUMN_CHARS}), '')) || to_tsvector('english', COALESCE(LEFT(error, #{MAX_SEARCH_COLUMN_CHARS}), '')) || to_tsvector('english', COALESCE(array_to_string(labels, ' '), '')))"
         to_tsquery_function = database_supports_websearch_to_tsquery? ? 'websearch_to_tsquery' : 'plainto_tsquery'
         where("#{tsvector} @@ #{to_tsquery_function}('english', CAST(? AS text))", query)
           .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, #{to_tsquery_function}('english', CAST(? AS text)))"), query]) => 'DESC')

--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -5,9 +5,9 @@ module GoodJob
   module Filterable
     extend ActiveSupport::Concern
 
-    # Bounds each to_tsvector() input so the combined tsvector stays under
-    # PG's ~1 MB limit (PG::ProgramLimitExceeded: "string is too long for
-    # tsvector").
+    # Caps the largest free-form columns (error, serialized_params->>'arguments')
+    # fed to to_tsvector() so the combined tsvector stays under PG's ~1 MB limit
+    # (PG::ProgramLimitExceeded: "string is too long for tsvector").
     MAX_SEARCH_COLUMN_CHARS = 262_144
 
     included do

--- a/app/models/concerns/good_job/filterable.rb
+++ b/app/models/concerns/good_job/filterable.rb
@@ -70,7 +70,16 @@ module GoodJob
         next if query.blank?
 
         # TODO: turn this into proper bind parameters in Arel
-        tsvector = "(to_tsvector('english', id::text) || to_tsvector('english', COALESCE(active_job_id::text, '')) || to_tsvector('english', serialized_params) || to_tsvector('english', COALESCE(LEFT(serialized_params->>'arguments', #{MAX_SEARCH_COLUMN_CHARS}), '')) || to_tsvector('english', COALESCE(LEFT(error, #{MAX_SEARCH_COLUMN_CHARS}), '')) || to_tsvector('english', COALESCE(array_to_string(labels, ' '), '')))"
+        tsvector = <<~SQL.squish
+          (
+            to_tsvector('english', id::text) ||
+            to_tsvector('english', COALESCE(active_job_id::text, '')) ||
+            to_tsvector('english', serialized_params) ||
+            to_tsvector('english', COALESCE(LEFT(serialized_params->>'arguments', #{MAX_SEARCH_COLUMN_CHARS}), '')) ||
+            to_tsvector('english', COALESCE(LEFT(error, #{MAX_SEARCH_COLUMN_CHARS}), '')) ||
+            to_tsvector('english', COALESCE(array_to_string(labels, ' '), ''))
+          )
+        SQL
         to_tsquery_function = database_supports_websearch_to_tsquery? ? 'websearch_to_tsquery' : 'plainto_tsquery'
         where("#{tsvector} @@ #{to_tsquery_function}('english', CAST(? AS text))", query)
           .order(sanitize_sql_for_order([Arel.sql("ts_rank(#{tsvector}, #{to_tsquery_function}('english', CAST(? AS text)))"), query]) => 'DESC')

--- a/spec/app/models/concerns/good_job/filterable_spec.rb
+++ b/spec/app/models/concerns/good_job/filterable_spec.rb
@@ -53,6 +53,22 @@ RSpec.describe GoodJob::Filterable do
       expect(model_class.search_text('ghost')).to be_empty
     end
 
+    it 'does not raise when the error column exceeds the tsvector size limit' do
+      # Many distinct tokens — repeated tokens collapse via tsvector dedup.
+      oversized_error = "BoomError: #{Array.new(200_000) { |i| "w#{i}" }.join(' ')}"
+      model_class.create!(
+        active_job_id: SecureRandom.uuid,
+        queue_name: "default",
+        job_class: "ExampleJob",
+        scheduled_at: Time.current,
+        serialized_params: { arguments: [] },
+        error: oversized_error,
+        error_event: "retried"
+      )
+
+      expect { model_class.search_text('anything').to_a }.not_to raise_error
+    end
+
     it 'is chainable and reversible' do
       expect(model_class.where.not(id: nil).search_text('example_value').reverse).to include(job)
     end

--- a/spec/app/models/concerns/good_job/filterable_spec.rb
+++ b/spec/app/models/concerns/good_job/filterable_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe GoodJob::Filterable do
     it 'does not raise when the error column exceeds the tsvector size limit' do
       # Many distinct tokens — repeated tokens collapse via tsvector dedup.
       oversized_error = "BoomError: #{Array.new(200_000) { |i| "w#{i}" }.join(' ')}"
-      model_class.create!(
+      oversized_job = model_class.create!(
         active_job_id: SecureRandom.uuid,
         queue_name: "default",
         job_class: "ExampleJob",
@@ -67,6 +67,7 @@ RSpec.describe GoodJob::Filterable do
       )
 
       expect { model_class.search_text('anything').to_a }.not_to raise_error
+      expect(model_class.search_text('BoomError')).to include(oversized_job)
     end
 
     it 'is chainable and reversible' do


### PR DESCRIPTION
Filtering the jobs index with `?query=...` can raise `PG::ProgramLimitExceeded: string is too long for tsvector` whenever any row has a column whose tokenised form exceeds PostgreSQL's ~1 MB tsvector limit. `Job.format_error` stores `"#{exception.class}: #{exception.message}"` without truncation, so HTTP clients echoing response bodies, `ActiveRecord::StatementInvalid` echoing bulk-insert SQL, and similar exception messages can blow past the limit and produce 500s on the dashboard search page.

The fix wraps `error` and `serialized_params->>'arguments'` with `LEFT(...)` so individual oversized rows degrade gracefully instead of breaking the page. The full `error` column is still stored and rendered on the job detail page; only the search-side tokenisation is bounded.

`LEFT(..., 262_144)` (256 KB per bounded column) leaves comfortable headroom under PG's ~1 MB tsvector ceiling even when both bounded columns are at the cap. A regression spec covers an oversized `error` row and asserts both that the search query no longer raises and that a token in the truncated prefix is still findable.per
