### PR TITLE
Fix incorrect ENV variable guard for GOOD_JOB_ENABLE_PAUSES

### DIFF
--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -388,7 +388,7 @@ module GoodJob
     def enable_pauses
       return options[:enable_pauses] unless options[:enable_pauses].nil?
       return rails_config[:enable_pauses] unless rails_config[:enable_pauses].nil?
-      return ActiveModel::Type::Boolean.new.cast(env['GOOD_JOB_ENABLE_PAUSES']) unless env['GOOD_JOB_ENABLE_PAUSE'].nil?
+      return ActiveModel::Type::Boolean.new.cast(env['GOOD_JOB_ENABLE_PAUSES']) unless env['GOOD_JOB_ENABLE_PAUSES'].nil?
 
       DEFAULT_ENABLE_PAUSES
     end


### PR DESCRIPTION
Fixes #1771 by making the guard match the cast value.

It looks to me like the plural form was the intended one as the README and actual setting are plural.

AFTER:

```bash
GOOD_JOB_ENABLE_PAUSES=true bin/rails runner "puts GoodJob.configuration.enable_pauses.inspect" 
true
```