### PR TITLE
Use table_name instead of hardcoding :good_jobs in schema introspection

### DIFF
--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -286,14 +286,14 @@ module GoodJob
       end
 
       def historic_finished_at_index_migrated?
-        return true if connection.index_name_exists?(:good_jobs, "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished")
+        return true if connection.index_name_exists?(table_name, "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished")
 
         migration_pending_warning!
         false
       end
 
       def lock_type_migrated?
-        return true if connection.index_name_exists?(:good_jobs, :index_good_jobs_for_candidate_dequeue_unlocked)
+        return true if connection.index_name_exists?(table_name, :index_good_jobs_for_candidate_dequeue_unlocked)
 
         migration_pending_warning!
         false
@@ -305,7 +305,7 @@ module GoodJob
       def lock_type_column_exists?
         return @_lock_type_column_exists if defined?(@_lock_type_column_exists)
 
-        @_lock_type_column_exists = connection_pool.with_connection { |conn| conn.column_exists?(:good_jobs, :lock_type) }
+        @_lock_type_column_exists = connection_pool.with_connection { |conn| conn.column_exists?(table_name, :lock_type) }
       end
 
       def reset_column_information


### PR DESCRIPTION
## Summary

Replaces the hardcoded `:good_jobs` symbol in `GoodJob::Job.historic_finished_at_index_migrated?`, `lock_type_migrated?`, and `lock_type_column_exists?` with the class's `table_name`, so users who override the default table name still have schema introspection work correctly. This matches the existing `quoted_table_name` pattern used in `app/models/good_job/job/lockable.rb`.

Index names referenced in those lookups are still literal strings — they're explicitly pinned in the migration templates via `name:`, so they remain the same regardless of table name.

## Test plan

- [x] `bundle exec rspec spec/app/models/good_job/job_spec.rb` — 115 examples, 0 failures