### PR TITLE
Prune CI test matrix to boundary Ruby versions per Rails version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           # Ruby 3.4 + older PG (covers Ruby 3.4 and PG compatibility)
           - { ruby: 3.4, gemfile: rails_7.2, pg: 10 }
           # JRuby 10 targets Ruby 3.4
-          - { ruby: jruby-10, gemfile: rails_7.2, pg: 18 }
+          - { ruby: jruby-10.0, gemfile: rails_7.2, pg: 18 }
 
     env:
       PGHOST: localhost

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,38 +92,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4, "4.0"]
-        gemfile: [rails_6.1, rails_7.0, rails_7.1, rails_7.2, rails_8.0, rails_8.1, rails_head]
-        pg: [18]
         include:
-          - ruby: 3.4
-            gemfile: rails_7.2
-            pg: 10
+          # Rails 6.1: lowest (Ruby 3.0) and highest (Ruby 4.0)
+          - { ruby: "3.0", gemfile: rails_6.1, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_6.1, pg: 18 }
+          # Rails 7.0
+          - { ruby: "3.0", gemfile: rails_7.0, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_7.0, pg: 18 }
+          # Rails 7.1
+          - { ruby: "3.0", gemfile: rails_7.1, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_7.1, pg: 18 }
+          # Rails 7.2 (requires Ruby >= 3.1)
+          - { ruby: 3.1, gemfile: rails_7.2, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_7.2, pg: 18 }
+          # Rails 8.0 (requires Ruby >= 3.2)
+          - { ruby: 3.2, gemfile: rails_8.0, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_8.0, pg: 18 }
+          # Rails 8.1 (requires Ruby >= 3.2)
+          - { ruby: 3.2, gemfile: rails_8.1, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_8.1, pg: 18 }
+          # Rails head (requires Ruby >= 3.3)
+          - { ruby: 3.3, gemfile: rails_head, pg: 18 }
+          - { ruby: "4.0", gemfile: rails_head, pg: 18 }
+          # Ruby 3.4 + older PG (covers Ruby 3.4 and PG compatibility)
+          - { ruby: 3.4, gemfile: rails_7.2, pg: 10 }
           # JRuby 10 targets Ruby 3.4
-          - ruby: jruby-10
-            gemfile: rails_7.2
-            pg: 18
-        exclude:
-          # Rails 7.2 is >= 3.1
-          - ruby: "3.0"
-            gemfile: rails_7.2
-          # Rails 8.0 is >= 3.2
-          - ruby: "3.0"
-            gemfile: rails_8.0
-          - ruby: 3.1
-            gemfile: rails_8.0
-          # Rails 8.1 is >= 3.2
-          - ruby: "3.0"
-            gemfile: rails_8.1
-          - ruby: 3.1
-            gemfile: rails_8.1
-          # Rails head is >= 3.3
-          - ruby: "3.0"
-            gemfile: rails_head
-          - ruby: 3.1
-            gemfile: rails_head
-          - ruby: 3.2
-            gemfile: rails_head
+          - { ruby: jruby-10, gemfile: rails_7.2, pg: 18 }
 
     env:
       PGHOST: localhost


### PR DESCRIPTION
Replaces the full Ruby × Rails matrix (6 × 7 = 42 base combinations, minus 8 excludes) with an explicit `include` list that tests only the lowest compatible Ruby and Ruby 4.0 (highest) for each Rails version. This reduces ~36 combinations to 16 while still covering every Rails version and every Ruby version (3.0–4.0 + JRuby). The existing JRuby and PG 10 compatibility entries are preserved. The pure `include` approach also eliminates the confusing `exclude` block.

See #1390 for JRuby commentary.