### PR TITLE
Allow Continuation jobs to be paused

### DIFF
--- a/app/models/good_job/setting.rb
+++ b/app/models/good_job/setting.rb
@@ -101,10 +101,22 @@ module GoodJob
       setting.save!
     end
 
-    def self.paused?(queue: nil, job_class: nil, label: nil)
-      raise ArgumentError, "Must provide at most one of queue, job_class, or label" if [queue, job_class, label].many?(&:present?)
+    def self.paused?(active_job: nil, queue: nil, job_class: nil, label: nil)
+      raise ArgumentError, "Must provide at most one of active_job, queue, job_class, or label" if [active_job, queue, job_class, label].many?(&:present?)
 
-      if queue
+      if active_job
+        pauses = paused
+
+        return :queue_name_paused if pauses[:queues].include?(active_job.queue_name.to_s)
+        return :job_class_paused if pauses[:job_classes].include?(active_job.class.to_s)
+
+        labels = active_job.respond_to?(:good_job_labels) ? Array(active_job.good_job_labels) : []
+        labels = labels.filter_map { |label| label.to_s.presence }.uniq
+
+        return :label_paused if (labels & pauses[:labels]).any?
+
+        false
+      elsif queue
         queue.in? paused(:queues)
       elsif job_class
         job_class.in? paused(:job_classes)
@@ -116,7 +128,7 @@ module GoodJob
     end
 
     def self.paused(type = nil)
-      setting = find_by(key: PAUSES)
+      setting = uncached { find_by(key: PAUSES) }
       pauses = setting&.value&.deep_dup || { "queues" => [], "job_classes" => [], "labels" => [] }
       pauses = pauses.with_indifferent_access
 

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -341,8 +341,8 @@ module GoodJob
   # @param job_class [String, nil] Job class name to check
   # @param label [String, nil] Label to check
   # @return [Boolean]
-  def self.paused?(queue: nil, job_class: nil, label: nil)
-    GoodJob::Setting.paused?(queue: queue, job_class: job_class, label: label)
+  def self.paused?(active_job: nil, queue: nil, job_class: nil, label: nil)
+    GoodJob::Setting.paused?(active_job: active_job, queue: queue, job_class: job_class, label: label)
   end
 
   # Get a list of all paused queues and job classes

--- a/lib/good_job/adapter.rb
+++ b/lib/good_job/adapter.rb
@@ -224,13 +224,18 @@ module GoodJob
       end
     end
 
-    # Whether the current job execution thread is shutting down.
-    # This is intended to be called from within the context of a performing job.
-    # Jobs can call this while performing via `queue_adapter.stopping?` to support
-    # job continuations/iterations.
-    # @return [Boolean]
-    def stopping?
-      GoodJob.current_thread_shutting_down?
+    # Whether the current job execution thread is shutting down or the current job
+    # is paused. This is intended to be called from within the context of a
+    # performing job. Jobs can call this while performing via
+    # `queue_adapter.stopping?` to support job continuations/iterations.
+    # @param active_job [ActiveJob::Base, nil]
+    # @return [Symbol, false]
+    def stopping?(active_job = nil)
+      return :stopping if GoodJob.current_thread_shutting_down?
+      return :force_discarded if CurrentThread.job&.finished_at
+      return GoodJob::Setting.paused?(active_job: active_job) if GoodJob.configuration.enable_pauses && active_job
+
+      false
     end
 
     # Shut down the thread pool executors.

--- a/spec/app/models/good_job/setting_spec.rb
+++ b/spec/app/models/good_job/setting_spec.rb
@@ -256,10 +256,29 @@ RSpec.describe GoodJob::Setting do
     end
 
     describe '.paused?' do
+      let(:active_job_class) do
+        stub_const('PausedSettingJob', Class.new(ActiveJob::Base) do
+          include GoodJob::ActiveJobExtensions::Labels
+
+          queue_as :critical
+
+          def perform
+          end
+        end)
+      end
+      let(:active_job) do
+        active_job_class.new.tap do |job|
+          job.good_job_labels = ["important", nil, "", :urgent, "important"]
+        end
+      end
+
       it 'raises ArgumentError if multiple arguments are provided' do
-        expect { described_class.paused?(queue: "default", job_class: "MyJob") }.to raise_error(ArgumentError, "Must provide at most one of queue, job_class, or label")
-        expect { described_class.paused?(queue: "default", label: "my_label") }.to raise_error(ArgumentError, "Must provide at most one of queue, job_class, or label")
-        expect { described_class.paused?(job_class: "MyJob", label: "my_label") }.to raise_error(ArgumentError, "Must provide at most one of queue, job_class, or label")
+        error_message = "Must provide at most one of active_job, queue, job_class, or label"
+
+        expect { described_class.paused?(queue: "default", job_class: "MyJob") }.to raise_error(ArgumentError, error_message)
+        expect { described_class.paused?(queue: "default", label: "my_label") }.to raise_error(ArgumentError, error_message)
+        expect { described_class.paused?(job_class: "MyJob", label: "my_label") }.to raise_error(ArgumentError, error_message)
+        expect { described_class.paused?(active_job: active_job, queue: "default") }.to raise_error(ArgumentError, error_message)
       end
 
       it 'returns true when queue is paused' do
@@ -288,11 +307,73 @@ RSpec.describe GoodJob::Setting do
       it 'returns false when label is not paused' do
         expect(described_class.paused?(label: "important")).to be false
       end
+
+      it 'returns true when any queue, job class, or label is paused and no filter is provided' do
+        described_class.pause(queue: "default")
+
+        expect(described_class.paused?).to be true
+      end
+
+      it 'returns false when nothing is paused and no filter is provided' do
+        expect(described_class.paused?).to be false
+      end
+
+      it 'returns :queue_name_paused when an Active Job queue name is paused' do
+        described_class.pause(queue: "critical")
+
+        expect(described_class.paused?(active_job: active_job)).to eq(:queue_name_paused)
+      end
+
+      it 'returns :job_class_paused when an Active Job class is paused' do
+        described_class.pause(job_class: "PausedSettingJob")
+
+        expect(described_class.paused?(active_job: active_job)).to eq(:job_class_paused)
+      end
+
+      it 'returns :label_paused when an Active Job label is paused' do
+        described_class.pause(label: "urgent")
+
+        expect(described_class.paused?(active_job: active_job)).to eq(:label_paused)
+      end
+
+      it 'returns false when pauses do not match an Active Job' do
+        described_class.pause(queue: "default")
+        described_class.pause(job_class: "OtherJob")
+        described_class.pause(label: "low_priority")
+
+        expect(described_class.paused?(active_job: active_job)).to be false
+      end
+
+      it 'returns false when an Active Job has no GoodJob labels and only labels are paused' do
+        active_job_without_labels = stub_const('UnlabeledSettingJob', Class.new(ActiveJob::Base) do
+          queue_as :critical
+
+          def perform
+          end
+        end).new
+        described_class.pause(label: "urgent")
+
+        expect(described_class.paused?(active_job: active_job_without_labels)).to be false
+      end
     end
 
     describe '.paused' do
       it 'returns empty arrays when nothing is paused' do
         expect(described_class.paused).to eq({ queues: [], job_classes: [], labels: [] })
+      end
+
+      it 'bypasses the Active Record query cache' do
+        described_class.pause(queue: "default")
+
+        described_class.cache do
+          expect(described_class.paused(:queues)).to contain_exactly "default"
+
+          # Simulate a pause update from another execution context without clearing this
+          # thread's query cache; Rails 7.1 does not support uncached(dirties: false).
+          rails_promise { described_class.unpause(queue: "default") }.value!
+
+          expect(described_class.paused(:queues)).to eq []
+        end
       end
 
       it 'returns only queues when type is :queues' do

--- a/spec/lib/good_job/adapter_spec.rb
+++ b/spec/lib/good_job/adapter_spec.rb
@@ -278,8 +278,51 @@ RSpec.describe GoodJob::Adapter do
   end
 
   describe '#stopping?' do
-    it 'is callable' do
+    it 'is callable without a job argument for Rails <= 8.1 compatibility' do
       expect { adapter.stopping? }.not_to raise_error
+    end
+
+    it 'returns :stopping when the current thread is shutting down' do
+      allow(GoodJob).to receive(:current_thread_shutting_down?).and_return(true)
+
+      expect(adapter.stopping?).to eq(:stopping)
+    end
+
+    it 'returns :force_discarded when the current GoodJob job is finished' do
+      GoodJob::CurrentThread.within do |current_thread|
+        current_thread.job = GoodJob::Job.new(finished_at: Time.current)
+
+        expect(adapter.stopping?).to eq(:force_discarded)
+      end
+    end
+
+    context 'with pauses enabled' do
+      before do
+        allow(GoodJob.configuration).to receive(:enable_pauses).and_return(true)
+      end
+
+      it 'delegates pause evaluation to the settings store when a job argument is provided' do
+        allow(GoodJob::Setting).to receive(:paused?).with(active_job: active_job).and_return(:queue_name_paused)
+
+        expect(adapter.stopping?(active_job)).to eq(:queue_name_paused)
+      end
+
+      it 'returns false when Rails does not provide an Active Job argument' do
+        GoodJob::Setting.pause(queue: "critical")
+        allow(GoodJob::Setting).to receive(:paused?).and_call_original
+
+        expect(adapter.stopping?).to be false
+        expect(GoodJob::Setting).not_to have_received(:paused?)
+      end
+    end
+
+    it 'ignores pauses when pauses are disabled' do
+      allow(GoodJob.configuration).to receive(:enable_pauses).and_return(false)
+      GoodJob::Setting.pause(queue: "default")
+      allow(GoodJob::Setting).to receive(:paused?).and_call_original
+
+      expect(adapter.stopping?(active_job)).to be false
+      expect(GoodJob::Setting).not_to have_received(:paused?)
     end
   end
 

--- a/spec/lib/good_job_spec.rb
+++ b/spec/lib/good_job_spec.rb
@@ -185,6 +185,62 @@ describe GoodJob do
 
       expect(PERFORMED.size).to eq 1
     end
+
+    it 'interrupts continuable jobs when their queue is paused at a checkpoint' do
+      skip "ActiveJob::Continuable is not available in this Rails version" unless defined?(ActiveJob::Continuable)
+      skip "ActiveJob::Continuable does not pass the job to queue_adapter.stopping? in Rails 8.1 or below" if Rails.gem_version.release < Gem::Version.new("8.2.0")
+
+      allow(described_class.configuration).to receive(:enable_pauses).and_return(true)
+      continuable_events = []
+      job_adapter = GoodJob::Adapter.new(execution_mode: :external)
+      continuable_pause_job = stub_const('ContinuablePauseJob', Class.new(ActiveJob::Base) do
+        include ActiveJob::Continuable
+
+        self.queue_adapter = job_adapter
+        self.resume_options = { wait: 0 }
+        queue_as :pausable
+
+        class << self
+          attr_accessor :pause_once
+        end
+        self.pause_once = true
+
+        define_method(:perform) do
+          step :process do |step|
+            continuable_events << :started
+            if self.class.pause_once
+              self.class.pause_once = false
+              GoodJob::Setting.pause(queue: "pausable")
+            end
+            step.checkpoint!
+            continuable_events << :completed
+          end
+        end
+      end)
+
+      continuable_pause_job.perform_later
+
+      described_class.perform_inline
+
+      job = GoodJob::Job.find_by(job_class: "ContinuablePauseJob")
+      expect(continuable_events).to eq([:started])
+      expect(job).to have_attributes(
+        performed_at: be_blank,
+        finished_at: be_blank
+      )
+      expect(job.serialized_params.dig("continuation", "current")).to eq(["process", nil])
+      expect(GoodJob::Job.exclude_paused).not_to include(job)
+
+      GoodJob::Setting.unpause(queue: "pausable")
+      described_class.perform_inline
+
+      expect(continuable_events).to eq([:started, :started, :completed])
+      expect(job.reload).to have_attributes(
+        finished_at: be_present,
+        error: be_nil,
+        error_event: nil
+      )
+    end
   end
 
   describe '#v4_ready?' do
@@ -211,6 +267,15 @@ describe GoodJob do
 
       described_class.unpause(job_class: 'MyJob')
       expect(described_class.paused).to eq({ queues: [], job_classes: [], labels: [] })
+    end
+
+    it 'can check an Active Job pause reason' do
+      active_job = instance_double(ActiveJob::Base)
+      allow(GoodJob::Setting).to receive(:paused?)
+        .with(active_job: active_job, queue: nil, job_class: nil, label: nil)
+        .and_return(:queue_name_paused)
+
+      expect(described_class.paused?(active_job: active_job)).to eq(:queue_name_paused)
     end
   end
 


### PR DESCRIPTION
Implements the Good Job portion of https://github.com/rails/rails/pull/57472

Related to (but doesn't exactly fix) https://github.com/bensheldon/good_job/issues/1775

Couple notes:
- I wasn't expecting `CurrentThread.job` 😅 LMK if you prefer the current conditional or want to rely on it solely
- I didn't want this to hammer the database constantly for so figured the cache was a good idea