### PR TITLE
Emit ActiveSupport::Notifications for concurrency-aborted enqueues

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -66,13 +66,13 @@
     {
       "warning_type": "Dangerous Eval",
       "warning_code": 13,
-      "fingerprint": "c4c3e1b8b28ebbfd4672cf3e8f0022a27aff3c12dc4fea750b412de1387f91e6",
+      "fingerprint": "c01ff32ee40cc694540aaa76e3fdab8f330babd9d6dbf2564c32aef1cfd877fa",
       "check_name": "Evaluation",
       "message": "Dynamic string evaluated as code",
       "file": "lib/good_job/log_subscriber.rb",
-      "line": 256,
+      "line": 278,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
-      "code": "class_eval(\"        def #{level}(progname = nil, tags: [], &block)   # def info(progname = nil, tags: [], &block)\\n          return unless logger                           #   return unless logger\\n                                                         #\\n          tag_logger(*tags) do                           #   tag_logger(*tags) do\\n            logger.#{level}(progname, &block)            #     logger.info(progname, &block)\\n          end                                            #   end\\n        end                                              #\\n\", \"lib/good_job/log_subscriber.rb\", (256 + 1))",
+      "code": "class_eval(\"        def #{level}(progname = nil, tags: [], &block)   # def info(progname = nil, tags: [], &block)\\n          return unless logger                           #   return unless logger\\n                                                         #\\n          tag_logger(*tags) do                           #   tag_logger(*tags) do\\n            logger.#{level}(progname, &block)            #     logger.info(progname, &block)\\n          end                                            #   end\\n        end                                              #\\n\", \"lib/good_job/log_subscriber.rb\", (278 + 1))",
       "render_path": null,
       "location": {
         "type": "method",

--- a/lib/good_job/active_job_extensions/concurrency.rb
+++ b/lib/good_job/active_job_extensions/concurrency.rb
@@ -120,7 +120,10 @@ module GoodJob
                                       end
 
                 if (enqueue_concurrency + 1) > limit
-                  job.logger.info "Aborted enqueue of #{job.class.name} (Job ID: #{job.job_id}) because the concurrency key '#{key}' has reached its enqueue limit of #{limit} #{'job'.pluralize(limit)}"
+                  ActiveSupport::Notifications.instrument(
+                    "enqueue_concurrency_limit_exceeded.good_job",
+                    { job: job, key: key, limit: limit }
+                  )
                   exceeded = :limit
                   next
                 end
@@ -134,7 +137,10 @@ module GoodJob
                                          .count
 
                 if (enqueued_within_period + 1) > throttle_limit
-                  job.logger.info "Aborted enqueue of #{job.class.name} (Job ID: #{job.job_id}) because the concurrency key '#{key}' has reached its throttle limit of #{throttle_limit} #{'job'.pluralize(throttle_limit)}"
+                  ActiveSupport::Notifications.instrument(
+                    "enqueue_concurrency_throttle_exceeded.good_job",
+                    { job: job, key: key, limit: throttle_limit }
+                  )
                   exceeded = :throttle
                   next
                 end

--- a/lib/good_job/log_subscriber.rb
+++ b/lib/good_job/log_subscriber.rb
@@ -154,6 +154,28 @@ module GoodJob
     end
 
     # @!macro notification_responder
+    def enqueue_concurrency_limit_exceeded(event)
+      job = event.payload[:job]
+      key = event.payload[:key]
+      limit = event.payload[:limit]
+
+      info do
+        "Aborted enqueue of #{job.class.name} (Job ID: #{job.job_id}) because the concurrency key '#{key}' has reached its enqueue limit of #{limit} #{'job'.pluralize(limit)}"
+      end
+    end
+
+    # @!macro notification_responder
+    def enqueue_concurrency_throttle_exceeded(event)
+      job = event.payload[:job]
+      key = event.payload[:key]
+      limit = event.payload[:limit]
+
+      info do
+        "Aborted enqueue of #{job.class.name} (Job ID: #{job.job_id}) because the concurrency key '#{key}' has reached its throttle limit of #{limit} #{'job'.pluralize(limit)}"
+      end
+    end
+
+    # @!macro notification_responder
     def systemd_watchdog_start(event)
       interval = event.payload[:interval]
 

--- a/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
+++ b/spec/lib/good_job/active_job_extensions/concurrency_spec.rb
@@ -60,28 +60,35 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
       end
 
       it "does not enqueue if enqueue concurrency limit is exceeded for a particular key" do
-        allow(TestJob.logger.formatter).to receive(:call).and_call_original
+        abort_events = []
+        enqueue_events = []
+        enqueue_callback = ->(*args) { enqueue_events << ActiveSupport::Notifications::Event.new(*args) }
+        abort_callback = ->(*args) { abort_events << ActiveSupport::Notifications::Event.new(*args) }
 
-        expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be_present
-        expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be_present
+        ActiveSupport::Notifications.subscribed(enqueue_callback, "enqueue.active_job") do
+          ActiveSupport::Notifications.subscribed(abort_callback, "enqueue_concurrency_limit_exceeded.good_job") do
+            expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be_present
+            expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be_present
 
-        # Third usage of key does not enqueue
-        expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be false
+            # Third usage of key does not enqueue
+            expect(TestJob.set(good_job_labels: "testlabel").perform_later(name: "Alice")).to be false
 
-        # Usage of different key does enqueue
-        expect(TestJob.set(good_job_labels: "otherlabel").perform_later(name: "Bob")).to be_present
+            # Usage of different key does enqueue
+            expect(TestJob.set(good_job_labels: "otherlabel").perform_later(name: "Bob")).to be_present
+          end
+        end
 
         expect(GoodJob::Job.labeled("testlabel").count).to eq 2
         expect(GoodJob::Job.labeled("otherlabel").count).to eq 1
 
-        expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Aborted enqueue of TestJob \(Job ID: .*\) because the concurrency key 'label:testlabel' has reached its enqueue limit of 2 jobs/)).exactly(:once)
-        if RUBY_VERSION >= "3.4"
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {name: "Alice"}/)).exactly(:twice)
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {name: "Bob"}/)).exactly(:once)
-        else
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
-        end
+        expect(abort_events.size).to eq 1
+        expect(abort_events.first.payload).to include(key: 'label:testlabel', limit: 2)
+        expect(abort_events.first.payload[:job]).to be_a(TestJob)
+
+        # Aborted enqueues must not be logged as successfully enqueued (regression: PR #820).
+        successful = enqueue_events.reject { |e| e.payload[:aborted] }
+        expect(successful.count { |e| e.payload[:job].arguments == [{ name: "Alice" }] }).to eq 2
+        expect(successful.count { |e| e.payload[:job].arguments == [{ name: "Bob" }] }).to eq 1
       end
 
       it 'excludes jobs that are already executing/locked' do
@@ -286,28 +293,35 @@ RSpec.describe GoodJob::ActiveJobExtensions::Concurrency do
         end
 
         it "does not enqueue if enqueue concurrency limit is exceeded for a particular key" do
-          allow(TestJob.logger.formatter).to receive(:call).and_call_original
+          abort_events = []
+          enqueue_events = []
+          enqueue_callback = ->(*args) { enqueue_events << ActiveSupport::Notifications::Event.new(*args) }
+          abort_callback = ->(*args) { abort_events << ActiveSupport::Notifications::Event.new(*args) }
 
-          expect(TestJob.perform_later(name: "Alice")).to be_present
-          expect(TestJob.perform_later(name: "Alice")).to be_present
+          ActiveSupport::Notifications.subscribed(enqueue_callback, "enqueue.active_job") do
+            ActiveSupport::Notifications.subscribed(abort_callback, "enqueue_concurrency_limit_exceeded.good_job") do
+              expect(TestJob.perform_later(name: "Alice")).to be_present
+              expect(TestJob.perform_later(name: "Alice")).to be_present
 
-          # Third usage of key does not enqueue
-          expect(TestJob.perform_later(name: "Alice")).to be false
+              # Third usage of key does not enqueue
+              expect(TestJob.perform_later(name: "Alice")).to be false
 
-          # Usage of different key does enqueue
-          expect(TestJob.perform_later(name: "Bob")).to be_present
+              # Usage of different key does enqueue
+              expect(TestJob.perform_later(name: "Bob")).to be_present
+            end
+          end
 
           expect(GoodJob::Job.where(concurrency_key: "Alice").count).to eq 2
           expect(GoodJob::Job.where(concurrency_key: "Bob").count).to eq 1
 
-          expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Aborted enqueue of TestJob \(Job ID: .*\) because the concurrency key 'Alice' has reached its enqueue limit of 2 jobs/)).exactly(:once)
-          if RUBY_VERSION >= "3.4"
-            expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {name: "Alice"}/)).exactly(:twice)
-            expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {name: "Bob"}/)).exactly(:once)
-          else
-            expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Alice"}/)).exactly(:twice)
-            expect(TestJob.logger.formatter).to have_received(:call).with("INFO", anything, anything, a_string_matching(/Enqueued TestJob \(Job ID: .*\) to \(default\) with arguments: {:name=>"Bob"}/)).exactly(:once)
-          end
+          expect(abort_events.size).to eq 1
+          expect(abort_events.first.payload).to include(key: 'Alice', limit: 2)
+          expect(abort_events.first.payload[:job]).to be_a(TestJob)
+
+          # Aborted enqueues must not be logged as successfully enqueued (regression: PR #820).
+          successful = enqueue_events.reject { |e| e.payload[:aborted] }
+          expect(successful.count { |e| e.payload[:job].arguments == [{ name: "Alice" }] }).to eq 2
+          expect(successful.count { |e| e.payload[:job].arguments == [{ name: "Bob" }] }).to eq 1
         end
 
         it 'excludes jobs that are already executing/locked' do

--- a/spec/lib/good_job/log_subscriber_spec.rb
+++ b/spec/lib/good_job/log_subscriber_spec.rb
@@ -38,4 +38,40 @@ RSpec.describe GoodJob::LogSubscriber do
       expect(logs.string).to include("GoodJob #{GoodJob::VERSION} started scheduler with queues= max_threads=")
     end
   end
+
+  describe "#enqueue_concurrency_limit_exceeded" do
+    let(:logs) { StringIO.new }
+    let(:job_class) { Class.new(ActiveJob::Base) { def self.name = "MyJob" } }
+    let(:job) { job_class.new.tap { |j| j.job_id = "abc-123" } }
+
+    it 'logs the aborted enqueue message' do
+      described_class.loggers << Logger.new(logs)
+      event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", { job: job, key: "mykey", limit: 5 })
+
+      subscriber.enqueue_concurrency_limit_exceeded(event)
+      expect(logs.string).to include("Aborted enqueue of MyJob (Job ID: abc-123) because the concurrency key 'mykey' has reached its enqueue limit of 5 jobs")
+    end
+
+    it 'pluralizes the message for a single job' do
+      described_class.loggers << Logger.new(logs)
+      event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", { job: job, key: "mykey", limit: 1 })
+
+      subscriber.enqueue_concurrency_limit_exceeded(event)
+      expect(logs.string).to include("has reached its enqueue limit of 1 job")
+    end
+  end
+
+  describe "#enqueue_concurrency_throttle_exceeded" do
+    let(:logs) { StringIO.new }
+    let(:job_class) { Class.new(ActiveJob::Base) { def self.name = "MyJob" } }
+    let(:job) { job_class.new.tap { |j| j.job_id = "abc-123" } }
+
+    it 'logs the aborted enqueue message' do
+      described_class.loggers << Logger.new(logs)
+      event = ActiveSupport::Notifications::Event.new("", nil, nil, "id", { job: job, key: "mykey", limit: 5 })
+
+      subscriber.enqueue_concurrency_throttle_exceeded(event)
+      expect(logs.string).to include("Aborted enqueue of MyJob (Job ID: abc-123) because the concurrency key 'mykey' has reached its throttle limit of 5 jobs")
+    end
+  end
 end


### PR DESCRIPTION
I came across a few hardcoded logger calls and the readme promises "GoodJob is fully instrumented with ActiveSupport::Notifications", this makes sure we do :)