### PR TITLE
Support Rails Edge version of Arel::Table

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -357,7 +357,7 @@ module GoodJob
           primary_key_for_select = primary_key.to_sym
           column_for_select = column.to_sym
 
-          cte_table = Arel::Table.new(:rows)
+          cte_table = arel_table_for(:rows)
           cte_query = original_query.except(:limit)
           cte_query = if primary_key_for_select == column_for_select
                         cte_query.select(primary_key_for_select)
@@ -484,6 +484,16 @@ module GoodJob
       end
 
       private
+
+      # Arel::Table.new has different parameters depending on Rails version.
+      # This method creates a new Arel::Table instance with the correct parameters.
+      # New version expects keyword arguments for the name while the old version expects a positional argument.
+      def arel_table_for(name)
+        arel_table = Arel::Table
+        parameters = arel_table.instance_method(:initialize).parameters
+
+        parameters.first.any?(:req) ? arel_table.new(name) : arel_table.new(name: name)
+      end
 
       # Executes a single pg_advisory_unlock call and updates bookkeeping.
       # Used by {.advisory_unlock_key} and {.advisory_unlock_key!} to avoid

--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -490,7 +490,7 @@ module GoodJob
       # New version expects keyword arguments for the name while the old version expects a positional argument.
       # This method creates a new Arel::Table instance with the correct parameters.
       def arel_table_for(name)
-        AREL_TABLE_NEW_KWARGS ? arel_table.new(name: name) : arel_table.new(name)
+        AREL_TABLE_NEW_KWARGS ? Arel::Table.new(name: name) : Arel::Table.new(name)
       end
 
       # Executes a single pg_advisory_unlock call and updates bookkeeping.

--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -207,6 +207,7 @@ module GoodJob
     end
 
     ADVISORY_LOCK_COUNTS = AdvisoryLockCounter.new
+    AREL_TABLE_NEW_KWARGS = Arel::Table.instance_method(:initialize).parameters.any? { |type, name| type == :key && name == :name }
 
     included do
       # Default column to be used when creating Advisory Locks
@@ -486,13 +487,10 @@ module GoodJob
       private
 
       # Arel::Table.new has different parameters depending on Rails version.
-      # This method creates a new Arel::Table instance with the correct parameters.
       # New version expects keyword arguments for the name while the old version expects a positional argument.
+      # This method creates a new Arel::Table instance with the correct parameters.
       def arel_table_for(name)
-        arel_table = Arel::Table
-        parameters = arel_table.instance_method(:initialize).parameters
-
-        parameters.first.any?(:req) ? arel_table.new(name) : arel_table.new(name: name)
+        AREL_TABLE_NEW_KWARGS ? arel_table.new(name: name) : arel_table.new(name)
       end
 
       # Executes a single pg_advisory_unlock call and updates bookkeeping.


### PR DESCRIPTION
I use Rails from the main branch on my app and I noticed that [this commit](https://github.com/rails/rails/commit/191069ea89a53c9b4d9c498c940bf146efbd967d) has introduced a breaking change to the `Arel::Table` signature. 

I added a wrapper to handle both versions here. I tried to add a test, but could only think of mocking the `Arel::Table` method signature, which I think is kinda pointless: you create a mock, then test the mock. I guess a better test is to make sure that when running the tests with  `rails_head` gemfile, it passes

I tested locally on my project and it worked (where's my "Works On My Machine™ pin 😄)

