### PR TITLE
Preserve created_at when a job is retried

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,9 @@ Available configuration options are:
     ```
 
 - `enable_pauses` (boolean) whether job processing can be paused. Defaults to `false`. You can also set this with the environment variable `GOOD_JOB_ENABLE_PAUSES`.
+- `dequeue_query_sort` (symbol) sets the sort order used when querying for the next job(s) to execute. Defaults to `:created_at`. It can be any one of:
+    - `:created_at` sorts by priority, then job creation order. This is the default, but no longer best matches GoodJob's contemporary data model.
+    - `:scheduled_at` sorts by priority, then `scheduled_at`, then `id`, which better matches GoodJob's contemporary data model. This will become the default/only behavior in a future major release.
 
 By default, GoodJob configures the following execution modes per environment:
 

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -360,6 +360,7 @@ module GoodJob
       current_job = CurrentThread.job
 
       if reenqueued_current_job
+        execution_args[:created_at] = current_job.created_at
         execution_args[:batch_id] = current_job.batch_id
         execution_args[:batch_callback_id] = current_job.batch_callback_id
         execution_args[:cron_key] = current_job.cron_key

--- a/app/models/good_job/job.rb
+++ b/app/models/good_job/job.rb
@@ -327,8 +327,11 @@ module GoodJob
       new(**enqueue_args(active_job, scheduled_at: scheduled_at))
     end
 
-    # Construct arguments for GoodJob::Execution from an ActiveJob instance.
+    # Construct arguments for GoodJob::Job from an ActiveJob instance.
     def self.enqueue_args(active_job, scheduled_at: nil)
+      reenqueued_current_job = CurrentThread.active_job_id && CurrentThread.active_job_id == active_job.job_id
+      current_job = CurrentThread.job
+
       execution_args = {
         id: active_job.job_id,
         active_job_id: active_job.job_id,
@@ -336,15 +339,16 @@ module GoodJob
         queue_name: active_job.queue_name.presence || DEFAULT_QUEUE_NAME,
         priority: active_job.priority || DEFAULT_PRIORITY,
         serialized_params: active_job.serialize,
-        created_at: Time.current,
       }
 
+      now = Time.current
+      execution_args[:created_at] = now if !reenqueued_current_job || GoodJob.configuration.dequeue_query_sort == :created_at
       execution_args[:scheduled_at] = if scheduled_at
                                         scheduled_at
                                       elsif active_job.scheduled_at
                                         Time.zone.at(active_job.scheduled_at)
                                       else
-                                        execution_args[:created_at]
+                                        now
                                       end
 
       execution_args[:concurrency_key] = active_job.good_job_concurrency_key if active_job.respond_to?(:good_job_concurrency_key)
@@ -356,11 +360,7 @@ module GoodJob
         execution_args[:labels] = labels
       end
 
-      reenqueued_current_job = CurrentThread.active_job_id && CurrentThread.active_job_id == active_job.job_id
-      current_job = CurrentThread.job
-
       if reenqueued_current_job
-        execution_args[:created_at] = current_job.created_at
         execution_args[:batch_id] = current_job.batch_id
         execution_args[:batch_callback_id] = current_job.batch_callback_id
         execution_args[:cron_key] = current_job.cron_key

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -439,6 +439,7 @@ module GoodJob
       Rails.env.development?
     end
 
+    # TODO: Remove :created_at and this option entirely in the next major version; :scheduled_at will become the only behavior.
     def dequeue_query_sort
       (options[:dequeue_query_sort] || rails_config[:dequeue_query_sort] || :created_at).to_sym
     end

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -181,6 +181,13 @@ RSpec.describe GoodJob::Job do
           expect(executions[0].finished_at).to be < executions[1].finished_at
           expect(executions[1].finished_at).to be < executions[2].finished_at
         end
+
+        it 'preserves the original created_at across retries' do
+          TestJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+          job.update!(created_at: 1.hour.ago)
+
+          expect { job.retry_job }.not_to change { job.reload.created_at }
+        end
       end
     end
 

--- a/spec/app/models/good_job/job_spec.rb
+++ b/spec/app/models/good_job/job_spec.rb
@@ -182,11 +182,22 @@ RSpec.describe GoodJob::Job do
           expect(executions[1].finished_at).to be < executions[2].finished_at
         end
 
-        it 'preserves the original created_at across retries' do
-          TestJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
-          job.update!(created_at: 1.hour.ago)
+        describe "created_at behavior" do
+          it "dequeue_query_sort = :created_at resets created_at" do
+            allow(GoodJob.configuration).to receive(:dequeue_query_sort).and_return(:created_at)
+            TestJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+            job.update!(created_at: 1.hour.ago)
 
-          expect { job.retry_job }.not_to change { job.reload.created_at }
+            expect { job.retry_job }.to change { job.reload.created_at }
+          end
+
+          it "dequeue_query_sort = :scheduled_at preserves created_at" do
+            allow(GoodJob.configuration).to receive(:dequeue_query_sort).and_return(:scheduled_at)
+            TestJob.queue_adapter = GoodJob::Adapter.new(execution_mode: :inline)
+            job.update!(created_at: 1.hour.ago)
+
+            expect { job.retry_job }.not_to change { job.reload.created_at }
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #1788.

`GoodJob::Job.enqueue_args` always sets `created_at: Time.current`, and the retry path in `.enqueue` assigns those attributes onto the existing job record, so `created_at` moved forward to the latest attempt on every retry.

When reenqueuing the current job, keep the record's existing `created_at` so it continues to reflect when the job was first enqueued. `scheduled_at` and the per-attempt `good_job_executions` rows still track retry timing, so nothing that depends on retry times is affected.
