### PR TITLE
Add GoodJob::Batch.where(id:) for GlobalID::Locator.fetch

### DIFF
--- a/app/models/good_job/batch.rb
+++ b/app/models/good_job/batch.rb
@@ -197,6 +197,12 @@ module GoodJob
       new _record: BatchRecord.find(id)
     end
 
+    # Required by GlobalID::Locator.fetch/locate_many, which query with
+    # `ignore_missing: true` and thus call `.where(id: ids)` instead of `.find(id)`.
+    def self.where(id:)
+      BatchRecord.where(id: id).map { |record| new(_record: record) }
+    end
+
     # Helper method to enqueue jobs and assign them to a batch
     def self.within_thread(batch_id: nil, batch_callback_id: nil)
       original_batch_id = current_batch_id

--- a/spec/app/models/good_job/batch_record_spec.rb
+++ b/spec/app/models/good_job/batch_record_spec.rb
@@ -48,6 +48,13 @@ describe GoodJob::BatchRecord do
           def self.find(_id)
             new
           end
+
+          # GlobalID::Locator.fetch (used by Rails' ActiveJob::Arguments#deserialize_global_id
+          # on Rails main) queries with `ignore_missing: true`, which calls `.where(id: ids)`
+          # instead of `.find(id)`.
+          def self.where(id:)
+            Array(id).map { new }
+          end
         end)
       end
 
@@ -56,6 +63,7 @@ describe GoodJob::BatchRecord do
         record = described_class.create(serialized_properties: { 'record' => instance })
 
         allow(SomeClass).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+        allow(SomeClass).to receive(:where).and_raise(ActiveRecord::RecordNotFound)
 
         expect(record.display_attributes["properties"]).to eq(
           "_aj_symbol_keys" => [],


### PR DESCRIPTION
- Rails main now deserializes Global IDs via `GlobalID::Locator.fetch`, which internally queries with `ignore_missing: true` and calls `.where(id: ids)` instead of `.find(id)`.
- Adds `GoodJob::Batch.where(id:)`, delegating to `BatchRecord.where(id:)`, mirroring the existing `self.find` delegation.

I upstreamed some doc improvements too: https://github.com/rails/globalid/pull/209
