### PR TITLE
Fix JRuby CI failure installing `rbs` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,11 @@ gemspec
 gem 'activerecord-jdbcpostgresql-adapter', platforms: [:jruby]
 gem 'pg', platforms: [:mri, :windows]
 
-# rbs 4.0.3 added a native extension with no jruby-compatible (java platform) build,
-# breaking installs on JRuby. Remove once rbs ships a stable release with a java build.
-gem 'rbs', '< 4.0.3', platforms: [:jruby]
+# rdoc >= 8.0 hard-depends on rbs, whose native extension doesn't build on JRuby
+# (github.com/ruby/rdoc/issues/1746). rbs only ships a working (precompiled java
+# platform) build starting with this prerelease. Remove once rbs ships a stable
+# release with JRuby support.
+gem 'rbs', '4.1.0.pre.2', platforms: [:jruby]
 
 rails_versions = {
   "6.1" => { github: "rails/rails", branch: "6-1-stable" }, # https://github.com/bensheldon/good_job/issues/1280

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ gemspec
 gem 'activerecord-jdbcpostgresql-adapter', platforms: [:jruby]
 gem 'pg', platforms: [:mri, :windows]
 
+# rbs 4.0.3 added a native extension with no jruby-compatible (java platform) build,
+# breaking installs on JRuby. Remove once rbs ships a stable release with a java build.
+gem 'rbs', '< 4.0.3', platforms: [:jruby]
+
 rails_versions = {
   "6.1" => { github: "rails/rails", branch: "6-1-stable" }, # https://github.com/bensheldon/good_job/issues/1280
   "7.0" => { github: "rails/rails", branch: "7-0-stable" }, # Ruby 3.4 requires bigdecimal which rails doesn't declare

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,6 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.4)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm-linux-gnu)
     ffi (1.17.4-arm64-darwin)
@@ -602,7 +601,7 @@ DEPENDENCIES
   puma
   rack-mini-profiler
   rails (~> 8.1.0)
-  rbs (< 4.0.3)
+  rbs (= 4.1.0.pre.2)
   rbtrace
   rdoc
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -602,6 +602,7 @@ DEPENDENCIES
   puma
   rack-mini-profiler
   rails (~> 8.1.0)
+  rbs (< 4.0.3)
   rbtrace
   rdoc
   rspec-rails


### PR DESCRIPTION
JRuby CI has been failing since ~2026-06-25 because `rdoc` >= 8.0 (pulled in via `railties` -> `irb` -> `rdoc`) gained a hard dependency on `rbs`, and `rbs`'s native C extension doesn't build on JRuby (no C toolchain support for it there). This is a known upstream issue: [ruby/rdoc#1746](https://github.com/ruby/rdoc/issues/1746).

Pins `rbs` to `4.1.0.pre.2`, scoped to the `:jruby` platform only, since that's the first `rbs` release to ship a precompiled `java`-platform gem (no native build required) per the upstream issue thread. Other platforms are unaffected and continue resolving `rbs` normally.