### PR TITLE
Add index for discarded jobs with job_class

### DIFF
--- a/app/controllers/good_job/cleaner_controller.rb
+++ b/app/controllers/good_job/cleaner_controller.rb
@@ -23,7 +23,7 @@ module GoodJob
         GoodJob::Job.discarded
                     .select(<<~SQL.squish)
                       job_class,
-                      count(id) AS failed,
+                      COUNT(*) AS failed,
                       COUNT(*) FILTER (WHERE "finished_at" > NOW() - INTERVAL '1 HOUR') AS last_1_hour,
                       COUNT(*) FILTER (WHERE "finished_at" > NOW() - INTERVAL '3 HOURS') AS last_3_hours,
                       COUNT(*) FILTER (WHERE "finished_at" > NOW() - INTERVAL '24 HOURS') AS last_24_hours,

--- a/demo/db/migrate/20260717000000_add_index_good_jobs_discarded_job_class.rb
+++ b/demo/db/migrate/20260717000000_add_index_good_jobs_discarded_job_class.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDiscardedJobClass < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:job_class, :finished_at],
+      name: :index_good_jobs_on_discarded_job_class,
+      where: "finished_at IS NOT NULL AND error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_18_000005) do
+ActiveRecord::Schema.define(version: 2026_07_17_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
@@ -101,6 +101,7 @@ ActiveRecord::Schema.define(version: 2026_04_18_000005) do
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
     t.index ["finished_at"], name: "index_good_jobs_on_discarded", order: { finished_at: :desc }, where: "(finished_at IS NOT NULL AND error IS NOT NULL)"
+    t.index ["job_class", "finished_at"], name: "index_good_jobs_on_discarded_job_class", where: "(finished_at IS NOT NULL AND error IS NOT NULL)"
     t.index ["job_class"], name: "index_good_jobs_on_job_class"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
     t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -118,6 +118,9 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
       name: :index_good_jobs_on_discarded,
       order: { finished_at: :desc },
       where: "finished_at IS NOT NULL AND error IS NOT NULL"
+    add_index :good_jobs, [:job_class, :finished_at],
+      name: :index_good_jobs_on_discarded_job_class,
+      where: "finished_at IS NOT NULL AND error IS NOT NULL"
     add_index :good_jobs, [:scheduled_at, :queue_name], name: :index_good_jobs_on_scheduled_at_and_queue_name
     add_index :good_jobs, :id,
       name: :index_good_jobs_on_unfinished_or_errored,

--- a/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
+++ b/lib/generators/good_job/templates/install/migrations/create_good_jobs.rb.erb
@@ -122,5 +122,8 @@ class CreateGoodJobs < ActiveRecord::Migration<%= migration_version %>
     add_index :good_jobs, :id,
       name: :index_good_jobs_on_unfinished_or_errored,
       where: "finished_at IS NULL OR error IS NOT NULL"
+    add_index :good_jobs, [:job_class, :finished_at],
+      name: :index_good_jobs_on_discarded_job_class,
+      where: "finished_at IS NOT NULL AND error IS NOT NULL"
   end
 end

--- a/lib/generators/good_job/templates/update/migrations/15_add_index_good_jobs_discarded_job_class.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/15_add_index_good_jobs_discarded_job_class.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDiscardedJobClass < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:job_class, :finished_at],
+      name: :index_good_jobs_on_discarded_job_class,
+      where: "finished_at IS NOT NULL AND error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/lib/good_job.rb
+++ b/lib/good_job.rb
@@ -316,7 +316,7 @@ module GoodJob
   # @return [Boolean]
   def self.migrated?
     GoodJob::Job.lock_type_migrated? &&
-      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_unfinished_or_errored")
+      GoodJob::Job.connection.index_name_exists?(:good_jobs, "index_good_jobs_on_discarded_job_class")
   end
 
   # Pause job execution for a given queue or job class.


### PR DESCRIPTION
We were running into postgres timeouts on the Cleaner Controller, and noticed the existing `index_good_jobs_on_discarded index` contains only `finished_at`, but not the `job_class` which it still uses to group and order by:
https://github.com/bensheldon/good_job/blob/1dc2c38fddcd5a9b79cbb66a9c9f8a881280e703/app/controllers/good_job/cleaner_controller.rb#L22-L34

This PR:
- Adds a partial index on `(job_class, finished_at)` for discarded jobs:
  - `WHERE finished_at IS NOT NULL AND error IS NOT NULL`
- Changes `count(id)` to `COUNT(*)`
  - Since id is non-null, this is equivalent and allows the query to be covered without PostgreSQL 11’s `INCLUDE` feature, preserving PostgreSQL 10 compatibility
- Adds the index to both the install and update migration templates
- Updates the demo migration/schema and `GoodJob.migrated?`

