### PR TITLE
Add GoodJob::Configuration#valid? to validate Cron configuration

### DIFF
--- a/app/models/good_job/cron_entry.rb
+++ b/app/models/good_job/cron_entry.rb
@@ -13,6 +13,15 @@ module GoodJob # :nodoc:
 
     attr_reader :params
 
+    VALUE_TYPES = {
+      args: Array,
+      kwargs: Hash,
+      set: Hash,
+    }.freeze
+
+    validate :validate_job_class
+    validate :validate_value_types
+
     def self.all(configuration: nil)
       configuration ||= GoodJob.configuration
       configuration.cron_entries
@@ -126,8 +135,7 @@ module GoodJob # :nodoc:
         current_thread.cron_at = cron_at
 
         I18n.with_locale(I18n.default_locale) do
-          job_klass = job_class_value
-          job_klass = job_klass.constantize if job_klass.is_a?(String)
+          job_klass = resolve_job_class
           next unless job_klass.is_a?(Class)
 
           configured_job = job_klass.set(set_value)
@@ -174,6 +182,28 @@ module GoodJob # :nodoc:
     end
 
     private
+
+    def validate_job_class
+      return if job_class.blank? || job_class.is_a?(Class) || job_class.respond_to?(:call)
+
+      resolve_job_class
+    rescue NameError
+      errors.add(:class, "'#{job_class}' does not exist")
+    end
+
+    def validate_value_types
+      VALUE_TYPES.each do |attribute, type|
+        value = public_send(attribute)
+        next if value.blank? || value.respond_to?(:call) || value.is_a?(type)
+
+        errors.add(attribute, "must be a #{type}")
+      end
+    end
+
+    def resolve_job_class
+      value = job_class_value
+      value.is_a?(String) ? value.constantize : value
+    end
 
     def cron
       params.fetch(:cron)

--- a/lib/good_job/configuration.rb
+++ b/lib/good_job/configuration.rb
@@ -2,6 +2,8 @@
 
 require "active_support/core_ext/numeric/time"
 
+require_relative "configuration/validator"
+
 module GoodJob
   #
   # +GoodJob::Configuration+ provides normalized configuration information to
@@ -105,6 +107,12 @@ module GoodJob
       self.class.validate_execution_mode(execution_mode)
       self.class.validate_dequeue_query_sort(dequeue_query_sort)
     end
+
+    # +valid?+ checks whether the configuration is valid, e.g. whether Cron
+    # entries reference Job classes that exist. Intended to be used in a
+    # test, for example: +expect(GoodJob.configuration).to be_valid+
+    # +errors+ contains any errors from the most recent call to +valid?+.
+    delegate :valid?, :errors, to: :validator
 
     # Specifies how and where jobs should be executed. See {Adapter#initialize}
     # for more details on possible values.
@@ -441,6 +449,10 @@ module GoodJob
     end
 
     private
+
+    def validator
+      @_validator ||= Validator.new(self)
+    end
 
     def rails_config
       Rails.application.config.good_job

--- a/lib/good_job/configuration/validator.rb
+++ b/lib/good_job/configuration/validator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module GoodJob
+  class Configuration
+    # Validates a {Configuration} instance so that misconfigurations can be
+    # caught in a test (e.g. `expect(GoodJob.configuration).to be_valid`)
+    # rather than at runtime.
+    class Validator
+      include ActiveModel::Model
+
+      # @return [Configuration]
+      attr_accessor :configuration
+
+      validate :validate_cron_entries
+
+      def initialize(configuration)
+        super()
+        @configuration = configuration
+      end
+
+      private
+
+      def validate_cron_entries
+        cron_entries = begin
+          configuration.cron_entries
+        rescue StandardError => e
+          errors.add(:cron, "is invalid: #{e.message}")
+          nil
+        end
+        return if cron_entries.nil?
+
+        cron_entries.each do |cron_entry|
+          next if cron_entry.valid?
+
+          cron_entry.errors.full_messages.each do |message|
+            errors.add(:cron, "entry '#{cron_entry.key}' #{message}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/app/models/good_job/cron_entry_spec.rb
+++ b/spec/app/models/good_job/cron_entry_spec.rb
@@ -31,6 +31,55 @@ describe GoodJob::CronEntry do
     end
   end
 
+  describe '#valid?' do
+    it 'is valid when the class exists' do
+      expect(entry).to be_valid
+    end
+
+    it 'is valid when the class is a Class' do
+      entry = described_class.new(params.merge(class: TestJob))
+      expect(entry).to be_valid
+    end
+
+    it 'is valid when the class is a callable' do
+      entry = described_class.new(params.merge(class: -> { "TestJob" }))
+      expect(entry).to be_valid
+    end
+
+    it 'is invalid when the class does not exist' do
+      entry = described_class.new(params.merge(class: "NonexistentJob"))
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:class]).to include(/NonexistentJob/)
+    end
+
+    it 'is valid when args, kwargs, and set are callables' do
+      entry = described_class.new(params.merge(args: -> { [42] }, kwargs: -> { {} }, set: -> { {} }))
+      expect(entry).to be_valid
+    end
+
+    it 'is invalid when args is not an Array' do
+      entry = described_class.new(params.merge(args: { name: "Alice" }))
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:args]).to include(/must be a/)
+    end
+
+    it 'is invalid when kwargs is not a Hash' do
+      entry = described_class.new(params.merge(kwargs: [42]))
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:kwargs]).to include(/must be a/)
+    end
+
+    it 'is invalid when set is not a Hash' do
+      entry = described_class.new(params.merge(set: [42]))
+
+      expect(entry).not_to be_valid
+      expect(entry.errors[:set]).to include(/must be a/)
+    end
+  end
+
   describe '#all' do
     it 'returns all entries' do
       expect(described_class.all).to be_a(Array)

--- a/spec/lib/good_job/configuration/validator_spec.rb
+++ b/spec/lib/good_job/configuration/validator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoodJob::Configuration::Validator do
+  before do
+    stub_const 'TestJob', Class.new(ActiveJob::Base)
+  end
+
+  describe '#valid?' do
+    it 'is valid when there is no cron configuration' do
+      configuration = GoodJob::Configuration.new({})
+      expect(configuration).to be_valid
+    end
+
+    it 'is valid when cron job classes exist' do
+      cron = { test: { cron: "* * * * *", class: "TestJob" } }
+      configuration = GoodJob::Configuration.new({ cron: cron })
+      expect(configuration).to be_valid
+    end
+
+    it 'is valid when the cron job class is a Class' do
+      cron = { test: { cron: "* * * * *", class: TestJob } }
+      configuration = GoodJob::Configuration.new({ cron: cron })
+      expect(configuration).to be_valid
+    end
+
+    it 'is valid when the cron job class is a callable' do
+      cron = { test: { cron: "* * * * *", class: -> { "TestJob" } } }
+      configuration = GoodJob::Configuration.new({ cron: cron })
+      expect(configuration).to be_valid
+    end
+
+    it 'is invalid when a cron job class does not exist' do
+      cron = { test: { cron: "* * * * *", class: "NonexistentJob" } }
+      configuration = GoodJob::Configuration.new({ cron: cron })
+
+      expect(configuration).not_to be_valid
+      expect(configuration.errors[:cron]).to include(/NonexistentJob/)
+    end
+
+    it 'is invalid when a cron expression does not parse' do
+      cron = { test: { cron: "2017-12-12", class: "TestJob" } }
+      configuration = GoodJob::Configuration.new({ cron: cron })
+
+      expect(configuration).not_to be_valid
+      expect(configuration.errors[:cron]).to include(/invalid/)
+    end
+  end
+end


### PR DESCRIPTION
Exposes GoodJob.configuration.valid? so a test can assert Cron entries reference existing Job classes and have correctly-typed args/kwargs/set, catching misconfigurations before they fail at runtime (#1261).