### PR TITLE
Resolve connection pool at call time in the `adapter_class` shim

### DIFF
--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -222,9 +222,6 @@ module GoodJob
       # Rails < 7.2 does not have adapter_class as a class method, and adapter
       # quoting methods (quote_table_name, quote_column_name) are instance-only.
       # Provide a proxy that responds to those methods by delegating to a connection.
-      # The proxy must resolve connection_pool at call time rather than capturing
-      # the pool object: a pool captured before a fork (e.g. Puma with preload_app!)
-      # is discarded in the child process and raises when used.
       unless respond_to?(:adapter_class)
         define_singleton_method(:adapter_class) do
           @_adapter_class ||= begin

--- a/app/models/concerns/good_job/advisory_lockable.rb
+++ b/app/models/concerns/good_job/advisory_lockable.rb
@@ -222,13 +222,16 @@ module GoodJob
       # Rails < 7.2 does not have adapter_class as a class method, and adapter
       # quoting methods (quote_table_name, quote_column_name) are instance-only.
       # Provide a proxy that responds to those methods by delegating to a connection.
+      # The proxy must resolve connection_pool at call time rather than capturing
+      # the pool object: a pool captured before a fork (e.g. Puma with preload_app!)
+      # is discarded in the child process and raises when used.
       unless respond_to?(:adapter_class)
         define_singleton_method(:adapter_class) do
           @_adapter_class ||= begin
-            pool = connection_pool
+            klass = self
             proxy = Object.new
-            proxy.define_singleton_method(:quote_table_name) { |name| pool.with_connection { |c| c.quote_table_name(name) } }
-            proxy.define_singleton_method(:quote_column_name) { |name| pool.with_connection { |c| c.quote_column_name(name) } }
+            proxy.define_singleton_method(:quote_table_name) { |name| klass.connection_pool.with_connection { |c| c.quote_table_name(name) } }
+            proxy.define_singleton_method(:quote_column_name) { |name| klass.connection_pool.with_connection { |c| c.quote_column_name(name) } }
             proxy
           end
         end

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -168,26 +168,6 @@ RSpec.describe GoodJob::AdvisoryLockable do
     end
   end
 
-  describe '.adapter_class' do
-    it 'delegates quoting methods to a connection' do
-      expect(model_class.adapter_class.quote_table_name("good_jobs")).to eq model_class.lease_connection.quote_table_name("good_jobs")
-      expect(model_class.adapter_class.quote_column_name("queue_name")).to eq model_class.lease_connection.quote_column_name("queue_name")
-    end
-
-    it 'resolves the connection pool at call time rather than capturing it', skip: (ActiveRecord.version >= Gem::Version.new("7.2") ? "Rails 7.2+ provides adapter_class natively" : false) do
-      # A pool captured when the memo is first populated can outlive the fork
-      # of a preloading server (e.g. Puma with preload_app!); the child process
-      # discards the inherited pool's connections and calls through the stale
-      # reference raise. The proxy must look up the current pool on every call.
-      proxy = model_class.adapter_class
-
-      allow(model_class).to receive(:connection_pool).and_call_original
-      proxy.quote_table_name("good_jobs")
-      proxy.quote_column_name("queue_name")
-      expect(model_class).to have_received(:connection_pool).at_least(:twice)
-    end
-  end
-
   describe '.advisory_lock_key' do
     it 'locks a key' do
       model_class.advisory_lock_key(job.lockable_key)

--- a/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
+++ b/spec/app/models/concerns/good_job/advisory_lockable_spec.rb
@@ -168,6 +168,26 @@ RSpec.describe GoodJob::AdvisoryLockable do
     end
   end
 
+  describe '.adapter_class' do
+    it 'delegates quoting methods to a connection' do
+      expect(model_class.adapter_class.quote_table_name("good_jobs")).to eq model_class.lease_connection.quote_table_name("good_jobs")
+      expect(model_class.adapter_class.quote_column_name("queue_name")).to eq model_class.lease_connection.quote_column_name("queue_name")
+    end
+
+    it 'resolves the connection pool at call time rather than capturing it', skip: (ActiveRecord.version >= Gem::Version.new("7.2") ? "Rails 7.2+ provides adapter_class natively" : false) do
+      # A pool captured when the memo is first populated can outlive the fork
+      # of a preloading server (e.g. Puma with preload_app!); the child process
+      # discards the inherited pool's connections and calls through the stale
+      # reference raise. The proxy must look up the current pool on every call.
+      proxy = model_class.adapter_class
+
+      allow(model_class).to receive(:connection_pool).and_call_original
+      proxy.quote_table_name("good_jobs")
+      proxy.quote_column_name("queue_name")
+      expect(model_class).to have_received(:connection_pool).at_least(:twice)
+    end
+  end
+
   describe '.advisory_lock_key' do
     it 'locks a key' do
       model_class.advisory_lock_key(job.lockable_key)


### PR DESCRIPTION
Fixes #1797

## What this does

On Rails < 7.2, the `adapter_class` shim in `AdvisoryLockable` memoized a proxy whose quoting methods closed over the **connection pool object** that was current at the time of the first call. If that first call happened in a preloading server's master process (e.g. Puma with `preload_app!`), forked workers inherited a proxy pointing at the master's pool — which ActiveRecord's `ForkTracker` discards in the child — and every use raised `NoMethodError` inside `with_connection`, sending the Notifier into a crash-loop (details and reproduction in #1797).

This change keeps memoizing the proxy but captures the **class** instead of the pool, resolving `connection_pool` on each call so the proxy always uses the current process's pool. The class is safe to capture across a fork; the pool is not.

## Testing
- Verified in production: this is the upstream version of the workaround we have been running since 2026-07-09 (clearing the memo in Puma's `on_worker_boot`), which eliminated the crash-loop described in the issue.