### PR TITLE
Add spec coverage for Configuration#max_threads

### DIFF
--- a/spec/lib/good_job/configuration_spec.rb
+++ b/spec/lib/good_job/configuration_spec.rb
@@ -57,6 +57,53 @@ RSpec.describe GoodJob::Configuration do
     end
   end
 
+  describe '#max_threads' do
+    it 'defaults to 5' do
+      stub_const 'ENV', ENV.to_hash.except('GOOD_JOB_MAX_THREADS', 'RAILS_MAX_THREADS')
+      configuration = described_class.new({})
+      expect(configuration.max_threads).to eq 5
+    end
+
+    context 'when option is given' do
+      it 'uses option value' do
+        configuration = described_class.new({ max_threads: 4 })
+        expect(configuration.max_threads).to eq 4
+      end
+    end
+
+    context 'when rails config is set' do
+      it 'uses rails config value' do
+        allow(Rails.application.config).to receive(:good_job).and_return({ max_threads: 6 })
+        configuration = described_class.new({})
+        expect(configuration.max_threads).to eq 6
+      end
+    end
+
+    context 'when GOOD_JOB_MAX_THREADS is set' do
+      it 'uses the environment variable' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_MAX_THREADS' => '7' })
+        configuration = described_class.new({})
+        expect(configuration.max_threads).to eq 7
+      end
+    end
+
+    context 'when only RAILS_MAX_THREADS is set' do
+      it 'falls back to RAILS_MAX_THREADS' do
+        stub_const 'ENV', ENV.to_hash.except('GOOD_JOB_MAX_THREADS').merge({ 'RAILS_MAX_THREADS' => '8' })
+        configuration = described_class.new({})
+        expect(configuration.max_threads).to eq 8
+      end
+    end
+
+    context 'when both GOOD_JOB_MAX_THREADS and RAILS_MAX_THREADS are set' do
+      it 'prefers GOOD_JOB_MAX_THREADS' do
+        stub_const 'ENV', ENV.to_hash.merge({ 'GOOD_JOB_MAX_THREADS' => '9', 'RAILS_MAX_THREADS' => '2' })
+        configuration = described_class.new({})
+        expect(configuration.max_threads).to eq 9
+      end
+    end
+  end
+
   describe '#cleanup_discarded_jobs?' do
     it 'defaults to true' do
       configuration = described_class.new({})


### PR DESCRIPTION
## What changed

Add a `#max_threads` describe block to `spec/lib/good_job/configuration_spec.rb`.

Tests only.

No source change.

## Why

`GoodJob::Configuration#max_threads` had no direct spec.

Its precedence chain is: option, then Rails config, then `GOOD_JOB_MAX_THREADS`, then `RAILS_MAX_THREADS`, then the default of 5.

The `RAILS_MAX_THREADS` fallback had no coverage anywhere in the suite (`grep -rn RAILS_MAX_THREADS spec/` returned nothing).

That fallback is a documented Rails integration point, so a refactor could silently drop it.

The gap was verified by mutation: deleting the `env['RAILS_MAX_THREADS']` line from `max_threads` makes the new "falls back to RAILS_MAX_THREADS" example fail (expected 8, got the default 5).

So the test has teeth.

## How to verify

```
git fetch https://github.com/olitreadwell/good_job.git test-configuration-max-threads
git checkout FETCH_HEAD
bundle exec rspec spec/lib/good_job/configuration_spec.rb
bundle exec rubocop spec/lib/good_job/configuration_spec.rb
```

## Coverage

Before: `#max_threads` had 0 examples / After: 6 examples.

File suite: 48 -> 54 examples, 0 failures.

## Checks run locally

- [x] Tests: PASS (54 passed, 0 failed in configuration_spec.rb)
- [x] Lint: PASS (rubocop, no offenses)
- [ ] Typecheck: N/A (Ruby; no separate typecheck for this file)
- [ ] Build: N/A (library gem, no build step)

Env: Ruby 3.4.9, Postgres on 5432, run against the file's own suite.

The full Appraisal matrix (multiple Rails versions) was not run locally, but the fork CI runs it on this PR.

This change is spec-only, one file.