### PR TITLE
Deprecate the fallback when `probe_handler` can't be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1716,7 +1716,7 @@ Note that GoodJob doesn't include WEBrick as a dependency, so you'll need to add
 gem 'webrick'
 ```
 
-If WEBrick is configured to be used, but the dependency is not found, GoodJob will log a warning and fallback to the default probe server.
+If WEBrick is configured to be used, but the dependency is not found, GoodJob will log a warning and fallback to the default probe server. This behavior is deprecated and will raise in the next release. An unsupported `probe_handler` value behaves the same way.
 
 ### Pausing Jobs
 

--- a/lib/good_job/probe_server.rb
+++ b/lib/good_job/probe_server.rb
@@ -36,15 +36,25 @@ module GoodJob
     end
 
     def build_handler(port:, handler:, app:)
-      if handler == :webrick
+      case handler
+      when :webrick
         begin
           require 'webrick'
           WebrickHandler.new(app, port: port, logger: GoodJob.logger)
         rescue LoadError
-          GoodJob.logger.warn("WEBrick was requested as the probe server handler, but it's not in the load path. GoodJob doesn't keep WEBrick as a dependency, so you'll have to make sure its added to your Gemfile to make use of it. GoodJob will fallback to its own webserver in the meantime.")
+          GoodJob.deprecator.warn(<<~MSG)
+            `probe_handler: :webrick` is specified but WEBrick is not in the load path, so GoodJob's own webserver is used instead.
+            Add `gem "webrick"` to your Gemfile. This fallback is deprecated and will raise in the next release.
+          MSG
           SimpleHandler.new(app, port: port, logger: GoodJob.logger)
         end
+      when nil
+        SimpleHandler.new(app, port: port, logger: GoodJob.logger)
       else
+        GoodJob.deprecator.warn(<<~MSG)
+          `probe_handler: #{handler.inspect}` is not supported, so GoodJob's own webserver is used instead.
+          Specify `:webrick` or `nil`. This fallback is deprecated and will raise in the next release.
+        MSG
         SimpleHandler.new(app, port: port, logger: GoodJob.logger)
       end
     end

--- a/spec/lib/good_job/probe_server_spec.rb
+++ b/spec/lib/good_job/probe_server_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe GoodJob::ProbeServer do
         context "when WEBrick isn't in the load path" do
           it 'sends out a warning and falls back to the built in server' do
             allow_any_instance_of(described_class).to receive(:require).with("webrick").and_raise(LoadError)
-            allow(GoodJob.logger).to receive(:warn)
+            allow(GoodJob.deprecator).to receive(:warn)
 
             probe_server = described_class.new(port: port, handler: :webrick)
             probe_server.start
@@ -147,7 +147,7 @@ RSpec.describe GoodJob::ProbeServer do
             ip_address = Socket.ip_address_list.select(&:ipv4?).map(&:ip_address).first
             response = Net::HTTP.get(ip_address, "/", port)
 
-            expect(GoodJob.logger).to have_received(:warn).with(/WEBrick was requested/)
+            expect(GoodJob.deprecator).to have_received(:warn)
             expect(response).to eq("OK")
 
             probe_server.stop
@@ -175,6 +175,24 @@ RSpec.describe GoodJob::ProbeServer do
 
           probe_server.stop
         end
+      end
+    end
+
+    context "with an unsupported handler" do
+      it 'sends out a warning and falls back to the built in server' do
+        allow(GoodJob.deprecator).to receive(:warn)
+
+        probe_server = described_class.new(port: port, handler: :puma)
+        probe_server.start
+        wait_until(max: 1) { expect(probe_server).to be_running }
+
+        ip_address = Socket.ip_address_list.select(&:ipv4?).map(&:ip_address).first
+        response = Net::HTTP.get(ip_address, "/", port)
+
+        expect(GoodJob.deprecator).to have_received(:warn)
+        expect(response).to eq("OK")
+
+        probe_server.stop
       end
     end
   end


### PR DESCRIPTION
Problem:

In ruby 3.0, webrick was removed from the standard libraries. After we upgraded, `probe_handler: :webrick` stopped working. GoodJob logged a warning and used its own server instead, and we didn't notice it for months.

There is one more case. If the value is not `:webrick` or `nil`, GoodJob uses its own server without any warnings.

Solution:

Use `GoodJob.deprecator` for both cases. The behavior doesn't change, but the warning now says the fallback will raise in the next release, and an application can set `GoodJob.deprecator.behavior = :raise` to find the problem early.
