### PR TITLE
Add a queue-scoped index for the dequeue candidate query

### DIFF
--- a/demo/db/migrate/20260902000000_add_index_good_jobs_dequeue_by_queue.rb
+++ b/demo/db/migrate/20260902000000_add_index_good_jobs_dequeue_by_queue.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDequeueByQueue < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:queue_name, :priority, :created_at],
+      name: :index_good_jobs_dequeue_by_queue,
+      order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/demo/db/schema.rb
+++ b/demo/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_07_17_000000) do
+ActiveRecord::Schema.define(version: 2026_09_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2026_07_17_000000) do
     t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_for_candidate_dequeue_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_on_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "priority", "created_at"], name: "index_good_jobs_dequeue_by_queue", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
     t.index ["queue_name"], name: "index_good_jobs_on_queue_name"
     t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"

--- a/lib/generators/good_job/templates/update/migrations/16_add_index_good_jobs_dequeue_by_queue.rb.erb
+++ b/lib/generators/good_job/templates/update/migrations/16_add_index_good_jobs_dequeue_by_queue.rb.erb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDequeueByQueue < ActiveRecord::Migration<%= migration_version %>
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:queue_name, :priority, :created_at],
+      name: :index_good_jobs_dequeue_by_queue,
+      order: { priority: "ASC NULLS LAST", created_at: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end


### PR DESCRIPTION
Fixes #1790.

Workers pinned to a queue via `GOOD_JOB_QUEUES` run a claim query filtered by `queue_name` and ordered by `priority` and `created_at`. No index leads with `queue_name`, so the planner has two bad choices: walk a priority-ordered index and filter out every other queue's rows, or use `index_good_jobs_on_queue_name` and sort the result. Which one it picks depends on table statistics, so a backlog building up on one queue degrades the claim query for every *other* queue.

### Measured

200k jobs backed up on one queue, 50 on another, claiming from the small one:

**Before**
```
Limit (actual time=19.598..19.599 rows=1)
  Buffers: shared hit=3244
  ->  Index Scan using index_good_job_jobs_for_candidate_lookup on good_jobs
        Filter: ((finished_at IS NULL) AND (locked_by_id IS NULL) AND (queue_name = 'urgent') AND (scheduled_at <= now()))
        Rows Removed by Filter: 199953
```

**After**
```
Limit (actual time=0.050..0.050 rows=1)
  Buffers: shared hit=3 read=3
  ->  Index Scan using index_good_jobs_dequeue_by_queue on good_jobs
        Index Cond: (queue_name = 'urgent')
        Filter: ((finished_at IS NULL) AND (locked_by_id IS NULL) AND (scheduled_at <= now()))
```

19.6ms to 0.05ms, 3,244 buffers to 6, and `Rows Removed by Filter` goes away. This matches what @eidam measured in the issue, where the same scan was discarding 5,982 rows.

### Two choices worth a look

**`created_at` rather than `scheduled_at`.** You noted in the issue that `(queue_name, priority, scheduled_at, id)` is what you would expect to be ideal, but that scheduled_at-ordering is not the default. `Job.dequeueing_ordered` sorts by `priority, created_at` unless `dequeue_query_sort` is `:scheduled_at`, and the default in `Configuration#dequeue_query_sort` is `:created_at`, so this index matches what most installs actually run. If `:scheduled_at` becomes the default, this index wants to change with it, and @ollym's question in the issue about whether that is planned is still open.

**Partial predicate matches index 08.** @eidam's version used `where: "finished_at IS NULL"`. I used `finished_at IS NULL AND locked_by_id IS NULL` to match `index_good_jobs_for_candidate_dequeue_unlocked`, since the claim query always includes both and the narrower predicate keeps the index smaller. Happy to widen it if you would rather it also serve queries that do not filter on `locked_by_id`.

### Changes

- New update migration template, `16_add_index_good_jobs_dequeue_by_queue.rb.erb`, following the `if_not_exists` and `algorithm: :concurrently` pattern of the existing index migrations. `UpdateGenerator` picks it up automatically from `Dir.children`.
- Matching demo migration and `demo/db/schema.rb`.

The schema line carries no `order:` key on purpose: I created the index on a real database and ran `SchemaDumper` against it, and Rails does not round-trip `ASC NULLS LAST`, exactly as with `index_good_jobs_for_candidate_dequeue_unlocked` today.

I have not touched `GoodJob.migrated?`, since that would make the new index mandatory for existing installs rather than optional.
