### PR TITLE
Add queue and total latency to the Performance dashboard

### DIFF
--- a/app/charts/good_job/latency_metric.rb
+++ b/app/charts/good_job/latency_metric.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module GoodJob
+  # The measurements the Performance charts plot and the index tables aggregate.
+  module LatencyMetric
+    PARAMETER_KEY = :chart
+
+    def self.options
+      [
+        GoodJob::LatencyMetric::Execution.new,
+        GoodJob::LatencyMetric::Queue.new,
+        GoodJob::LatencyMetric::Total.new,
+      ]
+    end
+
+    def self.default = options.first
+
+    def self.table_aggregates_sql
+      <<~SQL.squish
+        COUNT(DISTINCT active_job_id) AS jobs_count,
+        COUNT(*) AS executions_count,
+        AVG(#{GoodJob::LatencyMetric::Queue::EXPRESSION}) AS avg_queue,
+        MIN(#{GoodJob::LatencyMetric::Queue::EXPRESSION}) AS min_queue,
+        MAX(#{GoodJob::LatencyMetric::Queue::EXPRESSION}) AS max_queue,
+        AVG(#{GoodJob::LatencyMetric::Execution::EXPRESSION}) AS avg_execution,
+        MIN(#{GoodJob::LatencyMetric::Execution::EXPRESSION}) AS min_execution,
+        MAX(#{GoodJob::LatencyMetric::Execution::EXPRESSION}) AS max_execution,
+        AVG(#{GoodJob::LatencyMetric::Total::EXPRESSION}) AS avg_total,
+        MIN(#{GoodJob::LatencyMetric::Total::EXPRESSION}) AS min_total,
+        MAX(#{GoodJob::LatencyMetric::Total::EXPRESSION}) AS max_total
+      SQL
+    end
+
+    # Compare as strings: the value is whatever the query string held, so array- and
+    # hash-valued input has to fall through to the default rather than be coerced.
+    def self.from_params(params)
+      key = params[PARAMETER_KEY]
+
+      options.find { |metric| metric.key.to_s == key } || default
+    end
+  end
+end

--- a/app/charts/good_job/latency_metric/base.rb
+++ b/app/charts/good_job/latency_metric/base.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module GoodJob
+  module LatencyMetric
+    # A measurement the Performance charts can plot. Subclasses supply a SQL
+    # expression over +good_job_executions+, the aggregate that summarizes it per
+    # time bucket, and their titles.
+    class Base
+      def expression = self.class::EXPRESSION
+
+      def to_arel = Arel.sql(expression)
+
+      # nil plots an empty bucket as a gap; a summed metric overrides this with a true zero.
+      def empty_value = nil
+
+      def to_params = { PARAMETER_KEY => key.to_s }
+
+      def span_gaps? = empty_value.nil?
+    end
+  end
+end

--- a/app/charts/good_job/latency_metric/execution.rb
+++ b/app/charts/good_job/latency_metric/execution.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GoodJob
+  module LatencyMetric
+    # How long jobs took to run. Summed across a bucket because total execution time
+    # is a measure of load.
+    class Execution < Base
+      EXPRESSION = "duration"
+
+      def key = :execution
+
+      def aggregate = "SUM"
+
+      def presence_sql = "duration IS NOT NULL"
+
+      def empty_value = 0
+
+      # The default metric stays out of navigation URLs.
+      def to_params = {}
+
+      def chart_title = I18n.t("good_job.performance.index.chart_title")
+
+      def histogram_title = I18n.t("good_job.performance.show.execution_chart_title")
+    end
+  end
+end

--- a/app/charts/good_job/latency_metric/queue.rb
+++ b/app/charts/good_job/latency_metric/queue.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GoodJob
+  module LatencyMetric
+    # How long jobs waited between becoming eligible and actually starting, the same
+    # quantity as GoodJob::Execution#queue_latency. Averaged across a bucket because a
+    # summed wait would grow with volume alone.
+    class Queue < Base
+      EXPRESSION = "(created_at - scheduled_at)"
+
+      def key = :queue
+
+      def aggregate = "AVG"
+
+      def presence_sql = "scheduled_at IS NOT NULL"
+
+      def chart_title = I18n.t("good_job.performance.index.chart_title_queue")
+
+      def histogram_title = I18n.t("good_job.performance.show.queue_chart_title")
+    end
+  end
+end

--- a/app/charts/good_job/latency_metric/total.rb
+++ b/app/charts/good_job/latency_metric/total.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module GoodJob
+  module LatencyMetric
+    # How long jobs took end to end: the wait before starting plus the run itself.
+    # Averaged across a bucket for the same reason as Queue.
+    class Total < Base
+      # NULL while an execution is still running, so the aggregates skip it rather than count zero.
+      EXPRESSION = "(#{GoodJob::LatencyMetric::Queue::EXPRESSION} + #{GoodJob::LatencyMetric::Execution::EXPRESSION})".freeze
+
+      def key = :total
+
+      def aggregate = "AVG"
+
+      def presence_sql = "scheduled_at IS NOT NULL AND duration IS NOT NULL"
+
+      def chart_title = I18n.t("good_job.performance.index.chart_title_total")
+
+      def histogram_title = I18n.t("good_job.performance.show.total_chart_title")
+    end
+  end
+end

--- a/app/charts/good_job/performance_index_chart.rb
+++ b/app/charts/good_job/performance_index_chart.rb
@@ -2,9 +2,10 @@
 
 module GoodJob
   class PerformanceIndexChart < BaseChart
-    def initialize(range = GoodJob::PerformanceRange.new)
+    def initialize(range = GoodJob::PerformanceRange.new, metric = GoodJob::LatencyMetric.default)
       super()
       @range = range
+      @metric = metric
     end
 
     def data
@@ -14,7 +15,7 @@ module GoodJob
         start_expression: "range_parameters.series_start_time",
         interval_expression: "range_parameters.interval_seconds"
       )
-      inner_sql = @range.apply(GoodJob::Execution).select(:job_class, :scheduled_at, :duration).to_sql
+      inner_sql = @range.apply(GoodJob::Execution).select(:job_class, :scheduled_at, @metric.to_arel.as("metric_value")).to_sql
 
       # Keep each bind placeholder single-use because JDBC binds every converted occurrence.
       sum_query = <<~SQL.squish
@@ -34,7 +35,7 @@ module GoodJob
           SELECT
             #{bucket_sql} AS scheduled_at,
             job_class,
-            SUM(duration) AS sum
+            #{@metric.aggregate}(metric_value) AS value
           FROM (#{inner_sql}) executions
           CROSS JOIN range_parameters
           GROUP BY #{bucket_sql}, job_class
@@ -47,16 +48,16 @@ module GoodJob
 
       executions_data = GoodJob::Job.connection_pool.with_connection { |conn| conn.exec_query(GoodJob::Job.pg_or_jdbc_query(sum_query), "GoodJob Performance Chart", binds) }
 
-      job_names = executions_data.reject { |d| d['sum'].nil? }.map { |d| d['job_class'] || BaseFilter::EMPTY }.uniq
+      job_names = executions_data.reject { |d| d['value'].nil? }.map { |d| d['job_class'] || BaseFilter::EMPTY }.uniq
       timestamp_values = []
       timestamps = []
       jobs_data = executions_data.to_a.group_by { |d| d['timestamp'] }.each_with_object({}) do |(timestamp, values), hash|
         timestamp_values << timestamp
         timestamps << @range.canonical_timestamp(timestamp)
         job_names.each do |job_class|
-          sum = values.find { |d| d['job_class'] == job_class }&.[]('sum')
-          duration = sum ? ActiveSupport::Duration.parse(sum).to_f : 0
-          (hash[job_class] ||= []) << duration
+          value = values.find { |d| d['job_class'] == job_class }&.[]('value')
+          seconds = value ? ActiveSupport::Duration.parse(value).to_f : @metric.empty_value
+          (hash[job_class] ||= []) << seconds
         end
       end
       labels = @range.chart_timestamp_labels(timestamp_values)
@@ -72,6 +73,7 @@ module GoodJob
               data: data,
               backgroundColor: string_to_hsl(label),
               borderColor: string_to_hsl(label),
+              spanGaps: @metric.span_gaps?,
             }
           end,
         },
@@ -79,7 +81,7 @@ module GoodJob
           plugins: {
             title: {
               display: true,
-              text: I18n.t("good_job.performance.index.chart_title"),
+              text: @metric.chart_title,
             },
             legend: {
               vertical: true,

--- a/app/charts/good_job/performance_show_chart.rb
+++ b/app/charts/good_job/performance_show_chart.rb
@@ -12,26 +12,28 @@ module GoodJob
       10**8 # About 3 years
     ].freeze
 
-    def initialize(job_class, range = GoodJob::PerformanceRange.new)
+    def initialize(job_class, range = GoodJob::PerformanceRange.new, metric = GoodJob::LatencyMetric.default)
       super()
       @job_class = job_class
       @range = range
+      @metric = metric
     end
 
     def data
       table_name = GoodJob::Execution.table_name
 
       interval_entries = BUCKET_INTERVALS.map { "interval '#{_1}'" }.join(",")
+      bucket_expression = "WIDTH_BUCKET(#{@metric.expression}, ARRAY[#{interval_entries}])"
       sum_query = <<~SQL.squish
         SELECT
-          WIDTH_BUCKET(duration, ARRAY[#{interval_entries}]) as bucket_index,
-          COUNT(WIDTH_BUCKET(duration, ARRAY[#{interval_entries}])) AS count
+          #{bucket_expression} as bucket_index,
+          COUNT(#{bucket_expression}) AS count
         FROM #{table_name} sources
         WHERE
           scheduled_at >= $1::timestamp
           AND scheduled_at < $2::timestamp
           AND job_class = $3
-          AND duration IS NOT NULL
+          AND #{@metric.presence_sql}
         GROUP BY bucket_index
       SQL
 
@@ -60,6 +62,12 @@ module GoodJob
           }],
         },
         options: {
+          plugins: {
+            title: {
+              display: true,
+              text: @metric.histogram_title,
+            },
+          },
           scales: {
             y: {
               beginAtZero: true,

--- a/app/controllers/good_job/performance_controller.rb
+++ b/app/controllers/good_job/performance_controller.rb
@@ -6,30 +6,20 @@ module GoodJob
 
     def index
       executions = @performance_range.apply(GoodJob::Execution)
+      aggregates = GoodJob::LatencyMetric.table_aggregates_sql
 
-      @performances = executions.group(:job_class).select("
-        job_class,
-        COUNT(*) AS executions_count,
-        AVG(duration) AS avg_duration,
-        MIN(duration) AS min_duration,
-        MAX(duration) AS max_duration
-      ").order(:job_class)
+      @performances = executions.group(:job_class).select("job_class, #{aggregates}").order(:job_class)
+      @queue_performances = executions.group(:queue_name).select("queue_name, #{aggregates}").order(:queue_name)
 
-      @queue_performances = executions.group(:queue_name).select("
-        queue_name,
-        COUNT(*) AS executions_count,
-        AVG(duration) AS avg_duration,
-        MIN(duration) AS min_duration,
-        MAX(duration) AS max_duration
-      ").order(:queue_name)
-
-      @chart_data = GoodJob::PerformanceIndexChart.new(@performance_range).data
+      @chart_data = GoodJob::PerformanceIndexChart.new(@performance_range, @chart_metric).data
     end
 
     def show
       representative_job = GoodJob::Job.find_by!(job_class: request.path_parameters.fetch(:id))
       @job_class = representative_job.job_class
-      @chart_data = GoodJob::PerformanceShowChart.new(@job_class, @performance_range).data
+      @charts = GoodJob::LatencyMetric.options.to_h do |metric|
+        [metric.key, GoodJob::PerformanceShowChart.new(@job_class, @performance_range, metric).data]
+      end
     end
 
     private
@@ -38,10 +28,14 @@ module GoodJob
       locale = request.query_parameters["locale"]
       @performance_range_context = locale.is_a?(String) ? { "locale" => locale } : {}
       @performance_range = GoodJob::PerformanceRange.new(params, query_string: request.query_string)
+      # Only the index chart is metric-switchable; show renders every metric.
+      @chart_metric = GoodJob::LatencyMetric.from_params(params)
+      @chart_metric_params = action_name == "index" ? @chart_metric.to_params : {}
       return if @performance_range.canonical_parameters?(request.query_parameters)
 
       canonical_query = @performance_range.to_params.symbolize_keys
       canonical_query[:locale] = @performance_range_context["locale"]
+      canonical_query.merge!(@chart_metric_params.symbolize_keys)
       canonical_path = if action_name == "show"
                          performance_path(request.path_parameters.fetch(:id), canonical_query)
                        else

--- a/app/frontend/good_job/style.css
+++ b/app/frontend/good_job/style.css
@@ -88,6 +88,11 @@
   min-width: 14rem;
 }
 
+/* Grid cells default to min-width:auto, so a wide header label would grow its column instead of wrapping. */
+.performance-row > * {
+  min-width: 0;
+}
+
 .performance-name {
   overflow-wrap: anywhere;
   white-space: normal;

--- a/app/views/good_job/performance/_latency.erb
+++ b/app/views/good_job/performance/_latency.erb
@@ -1,0 +1,6 @@
+<div class="col-6 col-lg performance-metric">
+  <div class="d-lg-none small text-muted mt-1"><%= label %></div>
+  <div><%= format_duration average %> <small class="text-body-secondary"><%= t ".average" %></small></div>
+  <div><%= format_duration minimum %> <small class="text-body-secondary"><%= t ".minimum" %></small></div>
+  <div><%= format_duration maximum %> <small class="text-body-secondary"><%= t ".maximum" %></small></div>
+</div>

--- a/app/views/good_job/performance/_metric.erb
+++ b/app/views/good_job/performance/_metric.erb
@@ -1,0 +1,8 @@
+<div class="btn-group btn-group-sm mb-3" role="group" aria-label="<%= t ".chart_metric" %>">
+  <% GoodJob::LatencyMetric.options.each do |metric| %>
+    <% active = metric.key == chart_metric.key %>
+    <% metric_query = range_context.merge(performance_range.to_params).merge(metric.to_params).to_query %>
+    <% option_path = metric_query.present? ? "#{metric_path}?#{metric_query}" : metric_path %>
+    <%= link_to t(".metric_options.#{metric.key}"), option_path, class: ["btn", "btn-outline-secondary", ("active" if active)], aria: { current: ("page" if active) } %>
+  <% end %>
+</div>

--- a/app/views/good_job/performance/_range.erb
+++ b/app/views/good_job/performance/_range.erb
@@ -28,8 +28,8 @@
       data: range_form_data
     ) do %>
   <span class="visually-hidden" id="performance-range-name"><%= t ".time_range" %></span>
-  <% if range_context["locale"] %>
-    <%= hidden_field_tag "locale", range_context["locale"] %>
+  <% range_context.each do |context_key, context_value| %>
+    <%= hidden_field_tag context_key, context_value %>
   <% end %>
   <%= hidden_field_tag "chart_start", performance_range.canonical_timestamp(performance_range.start_time), disabled: true, id: nil, data: { performance_range_target: "startCanonicalInput" } %>
   <%= hidden_field_tag "chart_end", performance_range.canonical_timestamp(performance_range.end_time), disabled: true, id: nil, data: { performance_range_target: "endCanonicalInput" } %>

--- a/app/views/good_job/performance/index.html.erb
+++ b/app/views/good_job/performance/index.html.erb
@@ -2,7 +2,9 @@
   <h2 class="pt-3 pb-2"><%= t ".title" %></h2>
 </div>
 
-<%= render "range", performance_range: @performance_range, drag_enabled: true, range_context: @performance_range_context, range_path: performance_index_path(locale: nil), bucket_size: format_performance_bucket_size(@performance_range.interval_seconds) %>
+<%= render "range", performance_range: @performance_range, drag_enabled: true, range_context: @performance_range_context.merge(@chart_metric_params), range_path: performance_index_path(locale: nil), bucket_size: format_performance_bucket_size(@performance_range.interval_seconds) %>
+
+<%= render "metric", chart_metric: @chart_metric, performance_range: @performance_range, range_context: @performance_range_context, metric_path: performance_index_path(locale: nil) %>
 
 <%= render 'good_job/shared/chart_container', chart_data: @chart_data %>
 
@@ -11,12 +13,13 @@
 <div class="my-3 card">
   <div class="list-group list-group-flush text-nowrap" role="table">
     <header class="list-group-item bg-body-tertiary">
-      <div class="row small text-muted text-uppercase align-items-center">
-        <div class="col-12 col-lg-4"><%= t ".job_class" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".executions" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".average_duration" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".minimum_duration" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".maximum_duration" %></div>
+      <div class="row performance-row small text-muted text-uppercase align-items-center">
+        <div class="col-12 col-lg-3"><%= t ".job_class" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".jobs" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".executions" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".queue_latency" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".execution_latency" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".total_latency" %></div>
       </div>
     </header>
 
@@ -26,28 +29,21 @@
 
     <% @performances.each do |performance| %>
       <div role="row" class="list-group-item py-3">
-        <div class="row align-items-center">
-          <div class="col-12 col-lg-4 performance-name">
-            <div class="d-flex gap-3 justify-content-between">
-              <%= link_to performance.job_class, "#{performance_path(performance.job_class, locale: nil)}?#{performance_range_query}" %>
-            </div>
+        <div class="row performance-row align-items-center">
+          <div class="col-12 col-lg-3 performance-name">
+            <%= link_to performance.job_class, "#{performance_path(performance.job_class, locale: nil)}?#{performance_range_query}" %>
           </div>
-          <div class="col-6 col-lg-2 text-wrap">
+          <div class="col-6 col-lg">
+            <div class="d-lg-none small text-muted mt-1"><%= t ".jobs" %></div>
+            <%= performance.jobs_count %>
+          </div>
+          <div class="col-6 col-lg">
             <div class="d-lg-none small text-muted mt-1"><%= t ".executions" %></div>
             <%= performance.executions_count %>
           </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".average_duration" %></div>
-            <%= format_duration performance.avg_duration %>
-          </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".minimum_duration" %></div>
-            <%= format_duration performance.min_duration %>
-          </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".maximum_duration" %></div>
-            <%= format_duration performance.max_duration %>
-          </div>
+          <%= render "latency", label: t(".queue_latency"), average: performance.avg_queue, minimum: performance.min_queue, maximum: performance.max_queue %>
+          <%= render "latency", label: t(".execution_latency"), average: performance.avg_execution, minimum: performance.min_execution, maximum: performance.max_execution %>
+          <%= render "latency", label: t(".total_latency"), average: performance.avg_total, minimum: performance.min_total, maximum: performance.max_total %>
         </div>
       </div>
     <% end %>
@@ -57,12 +53,13 @@
 <div class="my-3 card">
   <div class="list-group list-group-flush text-nowrap" role="table">
     <header class="list-group-item bg-body-tertiary">
-      <div class="row small text-muted text-uppercase align-items-center">
-        <div class="col-12 col-lg-4"><%= t ".queue_name" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".executions" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".average_duration" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".minimum_duration" %></div>
-        <div class="col-lg-2 d-none d-lg-block"><%= t ".maximum_duration" %></div>
+      <div class="row performance-row small text-muted text-uppercase align-items-center">
+        <div class="col-12 col-lg-3"><%= t ".queue_name" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".jobs" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".executions" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".queue_latency" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".execution_latency" %></div>
+        <div class="col-lg d-none d-lg-block text-wrap"><%= t ".total_latency" %></div>
       </div>
     </header>
 
@@ -72,28 +69,21 @@
 
     <% @queue_performances.each do |performance| %>
       <div role="row" class="list-group-item py-3">
-        <div class="row align-items-center">
-          <div class="col-12 col-lg-4 performance-name">
-            <div class="d-flex gap-3 justify-content-between">
-              <%= performance.queue_name %>
-            </div>
+        <div class="row performance-row align-items-center">
+          <div class="col-12 col-lg-3 performance-name">
+            <%= performance.queue_name %>
           </div>
-          <div class="col-6 col-lg-2 text-wrap">
+          <div class="col-6 col-lg">
+            <div class="d-lg-none small text-muted mt-1"><%= t ".jobs" %></div>
+            <%= performance.jobs_count %>
+          </div>
+          <div class="col-6 col-lg">
             <div class="d-lg-none small text-muted mt-1"><%= t ".executions" %></div>
             <%= performance.executions_count %>
           </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".average_duration" %></div>
-            <%= format_duration performance.avg_duration %>
-          </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".minimum_duration" %></div>
-            <%= format_duration performance.min_duration %>
-          </div>
-          <div class="col-6 col-lg-2 text-wrap">
-            <div class="d-lg-none small text-muted mt-1"><%= t ".maximum_duration" %></div>
-            <%= format_duration performance.max_duration %>
-          </div>
+          <%= render "latency", label: t(".queue_latency"), average: performance.avg_queue, minimum: performance.min_queue, maximum: performance.max_queue %>
+          <%= render "latency", label: t(".execution_latency"), average: performance.avg_execution, minimum: performance.min_execution, maximum: performance.max_execution %>
+          <%= render "latency", label: t(".total_latency"), average: performance.avg_total, minimum: performance.min_total, maximum: performance.max_total %>
         </div>
       </div>
     <% end %>

--- a/app/views/good_job/performance/show.html.erb
+++ b/app/views/good_job/performance/show.html.erb
@@ -4,4 +4,6 @@
 
 <%= render "range", performance_range: @performance_range, range_context: @performance_range_context, range_path: performance_path(@job_class, locale: nil) %>
 
-<%= render 'good_job/shared/chart_container', chart_data: @chart_data %>
+<% @charts.each do |metric_key, chart_data| %>
+  <%= render 'good_job/shared/chart_container', chart_data: chart_data, region: "#{metric_key.to_s.dasherize}-chart" %>
+<% end %>

--- a/app/views/good_job/shared/_chart_container.erb
+++ b/app/views/good_job/shared/_chart_container.erb
@@ -1,6 +1,8 @@
 <% vertical_legend = chart_data.dig(:options, :plugins, :legend, :vertical) %>
+<%# Live polling replaces regions by name, so pages with more than one chart must name each. %>
+<% region = local_assigns.fetch(:region, "chart") %>
 
-<div class="container-fluid" data-controller="chart" data-chart-config-value="<%= chart_data.to_json %>" data-live-poll-region="chart">
+<div class="container-fluid" data-controller="chart" data-chart-config-value="<%= chart_data.to_json %>" data-live-poll-region="<%= region %>">
   <div class="row d-flex">
     <% if vertical_legend %>
       <div class="row d-flex">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -234,15 +234,28 @@ de:
         value: Wert
     performance:
       index:
-        average_duration: Durchschnittliche Dauer
-        chart_title: Gesamtausführungszeit in Sekunden
+        chart_title: Gesamte Ausführungslatenz in Sekunden
+        chart_title_queue: Durchschnittliche Warteschlangenlatenz in Sekunden
+        chart_title_total: Durchschnittliche Gesamtlatenz in Sekunden
+        execution_latency: Ausführungslatenz
         executions: Ausführungen
         job_class: Job-Klasse
-        maximum_duration: Maximale Dauer
-        minimum_duration: Minimale Dauer
+        jobs: Jobs
         no_executions: Keine Ausführungen in diesem Zeitraum.
+        queue_latency: Warteschlangenlatenz
         queue_name: Warteschlangenname
         title: Leistung
+        total_latency: Gesamtlatenz
+      latency:
+        average: Ø
+        maximum: max
+        minimum: min
+      metric:
+        chart_metric: Diagramm-Metrik
+        metric_options:
+          execution: Ausführungslatenz
+          queue: Warteschlangenlatenz
+          total: Gesamtlatenz
       range:
         bucket_size:
           days: "%{count} T"
@@ -267,8 +280,11 @@ de:
         time_range: Leistungszeitraum
         time_zone: 'Zeitzone:'
       show:
+        execution_chart_title: Ausführungslatenz
+        queue_chart_title: Warteschlangenlatenz
         slow: Langsam
         title: Leistung
+        total_chart_title: Gesamtlatenz
     processes:
       index:
         cron_enabled: Cron aktiviert

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,15 +234,28 @@ en:
         value: Value
     performance:
       index:
-        average_duration: Average duration
-        chart_title: Total job execution time in seconds
+        chart_title: Total execution latency in seconds
+        chart_title_queue: Average queue latency in seconds
+        chart_title_total: Average total latency in seconds
+        execution_latency: Execution latency
         executions: Executions
         job_class: Job class
-        maximum_duration: Maximum duration
-        minimum_duration: Minimum duration
+        jobs: Jobs
         no_executions: No executions in this time range.
+        queue_latency: Queue latency
         queue_name: Queue name
         title: Performance
+        total_latency: Total latency
+      latency:
+        average: avg
+        maximum: max
+        minimum: min
+      metric:
+        chart_metric: Chart metric
+        metric_options:
+          execution: Execution latency
+          queue: Queue latency
+          total: Total latency
       range:
         bucket_size:
           days: "%{count}d"
@@ -267,8 +280,11 @@ en:
         time_range: Performance time range
         time_zone: 'Time zone:'
       show:
+        execution_chart_title: Execution latency
+        queue_chart_title: Queue latency
         slow: Slow
         title: Performance
+        total_chart_title: Total latency
     processes:
       index:
         cron_enabled: Cron enabled

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -234,15 +234,28 @@ es:
         value: Valor
     performance:
       index:
-        average_duration: Duración promedio
-        chart_title: Tiempo total de ejecución del trabajo en segundos
+        chart_title: Latencia de ejecución total en segundos
+        chart_title_queue: Latencia en cola promedio en segundos
+        chart_title_total: Latencia total promedio en segundos
+        execution_latency: Latencia de ejecución
         executions: Ejecuciones
         job_class: Clase de trabajo
-        maximum_duration: Duración máxima
-        minimum_duration: Duración mínima
+        jobs: Trabajos
         no_executions: No hay ejecuciones en este intervalo de tiempo.
+        queue_latency: Latencia en cola
         queue_name: Nombre de la cola
         title: Rendimiento
+        total_latency: Latencia total
+      latency:
+        average: prom
+        maximum: máx
+        minimum: mín
+      metric:
+        chart_metric: Métrica del gráfico
+        metric_options:
+          execution: Latencia de ejecución
+          queue: Latencia en cola
+          total: Latencia total
       range:
         bucket_size:
           days: "%{count}d"
@@ -267,8 +280,11 @@ es:
         time_range: Intervalo de tiempo de rendimiento
         time_zone: 'Zona horaria:'
       show:
+        execution_chart_title: Latencia de ejecución
+        queue_chart_title: Latencia en cola
         slow: Lento
         title: Rendimiento
+        total_chart_title: Latencia total
     processes:
       index:
         cron_enabled: Cron habilitado

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -234,15 +234,28 @@ fr:
         value: Valeur
     performance:
       index:
-        average_duration: Durée moyenne
-        chart_title: Temps total d'exécution des tâches en secondes
+        chart_title: Latence d'exécution totale en secondes
+        chart_title_queue: Latence d'attente moyenne en secondes
+        chart_title_total: Latence totale moyenne en secondes
+        execution_latency: Latence d'exécution
         executions: Exécutions
         job_class: Classe de tâche
-        maximum_duration: Durée maximale
-        minimum_duration: Durée minimale
+        jobs: Tâches
         no_executions: Aucune exécution dans cette plage horaire.
+        queue_latency: Latence d'attente
         queue_name: Nom de la file
         title: Performance
+        total_latency: Latence totale
+      latency:
+        average: moy
+        maximum: max
+        minimum: min
+      metric:
+        chart_metric: Métrique du graphique
+        metric_options:
+          execution: Latence d'exécution
+          queue: Latence d'attente
+          total: Latence totale
       range:
         bucket_size:
           days: "%{count}j"
@@ -267,8 +280,11 @@ fr:
         time_range: Plage horaire de performance
         time_zone: 'Fuseau horaire :'
       show:
+        execution_chart_title: Latence d'exécution
+        queue_chart_title: Latence d'attente
         slow: Lent
         title: Performance
+        total_chart_title: Latence totale
     processes:
       index:
         cron_enabled: Cron activé

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -234,15 +234,28 @@ it:
         value: Valore
     performance:
       index:
-        average_duration: Durata media
-        chart_title: Tempo totale di esecuzione in secondi
+        chart_title: Latenza di esecuzione totale in secondi
+        chart_title_queue: Latenza in coda media in secondi
+        chart_title_total: Latenza totale media in secondi
+        execution_latency: Latenza di esecuzione
         executions: Esecuzioni
         job_class: Classe del job
-        maximum_duration: Durata massima
-        minimum_duration: Durata minima
+        jobs: Job
         no_executions: Nessuna esecuzione in questo intervallo di tempo.
+        queue_latency: Latenza in coda
         queue_name: Nome della coda
         title: Prestazioni
+        total_latency: Latenza totale
+      latency:
+        average: media
+        maximum: max
+        minimum: min
+      metric:
+        chart_metric: Metrica del grafico
+        metric_options:
+          execution: Latenza di esecuzione
+          queue: Latenza in coda
+          total: Latenza totale
       range:
         bucket_size:
           days: "%{count}g"
@@ -267,8 +280,11 @@ it:
         time_range: Intervallo di tempo delle prestazioni
         time_zone: 'Fuso orario:'
       show:
+        execution_chart_title: Latenza di esecuzione
+        queue_chart_title: Latenza in coda
         slow: Lento
         title: Prestazioni
+        total_chart_title: Latenza totale
     processes:
       index:
         cron_enabled: Cron abilitato

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -234,15 +234,28 @@ ja:
         value: 値
     performance:
       index:
-        average_duration: 平均所要時間
-        chart_title: 合計実行時間（秒）
+        chart_title: 実行レイテンシの合計（秒）
+        chart_title_queue: 平均待機レイテンシ（秒）
+        chart_title_total: 平均合計レイテンシ（秒）
+        execution_latency: 実行レイテンシ
         executions: 実行回数
         job_class: ジョブクラス
-        maximum_duration: 最大所要時間
-        minimum_duration: 最小所要時間
+        jobs: ジョブ数
         no_executions: この時間範囲には実行がありません。
+        queue_latency: 待機レイテンシ
         queue_name: キュー名
         title: パフォーマンス
+        total_latency: 合計レイテンシ
+      latency:
+        average: 平均
+        maximum: 最大
+        minimum: 最小
+      metric:
+        chart_metric: グラフの指標
+        metric_options:
+          execution: 実行レイテンシ
+          queue: 待機レイテンシ
+          total: 合計レイテンシ
       range:
         bucket_size:
           days: "%{count}日"
@@ -267,8 +280,11 @@ ja:
         time_range: パフォーマンスの時間範囲
         time_zone: 'タイムゾーン:'
       show:
+        execution_chart_title: 実行レイテンシ
+        queue_chart_title: 待機レイテンシ
         slow: 遅い
         title: パフォーマンス
+        total_chart_title: 合計レイテンシ
     processes:
       index:
         cron_enabled: Cron が有効になっている

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -234,15 +234,28 @@ ko:
         value: 값
     performance:
       index:
-        average_duration: 평균 소요 시간
-        chart_title: 총 실행 시간(초)
+        chart_title: 총 실행 지연 시간(초)
+        chart_title_queue: 평균 대기 지연 시간(초)
+        chart_title_total: 평균 총 지연 시간(초)
+        execution_latency: 실행 지연 시간
         executions: 실행 횟수
         job_class: 작업 클래스
-        maximum_duration: 최대 소요 시간
-        minimum_duration: 최소 소요 시간
+        jobs: 작업 수
         no_executions: 이 시간 범위에 실행이 없습니다.
+        queue_latency: 대기 지연 시간
         queue_name: 큐 이름
         title: 성능
+        total_latency: 총 지연 시간
+      latency:
+        average: 평균
+        maximum: 최대
+        minimum: 최소
+      metric:
+        chart_metric: 차트 지표
+        metric_options:
+          execution: 실행 지연 시간
+          queue: 대기 지연 시간
+          total: 총 지연 시간
       range:
         bucket_size:
           days: "%{count}일"
@@ -267,8 +280,11 @@ ko:
         time_range: 성능 시간 범위
         time_zone: '시간대:'
       show:
+        execution_chart_title: 실행 지연 시간
+        queue_chart_title: 대기 지연 시간
         slow: 느림
         title: 성능
+        total_chart_title: 총 지연 시간
     processes:
       index:
         cron_enabled: Cron이 활성화되어 있음

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -234,15 +234,28 @@ nl:
         value: Waarde
     performance:
       index:
-        average_duration: Gemiddelde duur
-        chart_title: Totale uitvoeringstijd in seconden
+        chart_title: Totale uitvoeringslatentie in seconden
+        chart_title_queue: Gemiddelde wachtrijlatentie in seconden
+        chart_title_total: Gemiddelde totale latentie in seconden
+        execution_latency: Uitvoeringslatentie
         executions: Uitvoeringen
         job_class: Taakklasse
-        maximum_duration: Maximale duur
-        minimum_duration: Minimale duur
+        jobs: Taken
         no_executions: Geen uitvoeringen in dit tijdsbereik.
+        queue_latency: Wachtrijlatentie
         queue_name: Wachtrijnaam
         title: Prestaties
+        total_latency: Totale latentie
+      latency:
+        average: gem
+        maximum: max
+        minimum: min
+      metric:
+        chart_metric: Grafiekmetriek
+        metric_options:
+          execution: Uitvoeringslatentie
+          queue: Wachtrijlatentie
+          total: Totale latentie
       range:
         bucket_size:
           days: "%{count}d"
@@ -267,8 +280,11 @@ nl:
         time_range: Tijdsbereik voor prestaties
         time_zone: 'Tijdzone:'
       show:
+        execution_chart_title: Uitvoeringslatentie
+        queue_chart_title: Wachtrijlatentie
         slow: Traag
         title: Prestaties
+        total_chart_title: Totale latentie
     processes:
       index:
         cron_enabled: Cron ingeschakeld

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -234,15 +234,28 @@ pt-BR:
         value: Valor
     performance:
       index:
-        average_duration: Duração média
-        chart_title: Tempo total de execução em segundos
+        chart_title: Latência de execução total em segundos
+        chart_title_queue: Latência na fila média em segundos
+        chart_title_total: Latência total média em segundos
+        execution_latency: Latência de execução
         executions: Execuções
         job_class: Classe do trabalho
-        maximum_duration: Duração máxima
-        minimum_duration: Duração mínima
+        jobs: Trabalhos
         no_executions: Nenhuma execução neste intervalo de tempo.
+        queue_latency: Latência na fila
         queue_name: Nome da fila
         title: Desempenho
+        total_latency: Latência total
+      latency:
+        average: méd
+        maximum: máx
+        minimum: mín
+      metric:
+        chart_metric: Métrica do gráfico
+        metric_options:
+          execution: Latência de execução
+          queue: Latência na fila
+          total: Latência total
       range:
         bucket_size:
           days: "%{count}d"
@@ -267,8 +280,11 @@ pt-BR:
         time_range: Intervalo de tempo de desempenho
         time_zone: 'Fuso horário:'
       show:
+        execution_chart_title: Latência de execução
+        queue_chart_title: Latência na fila
         slow: Lento
         title: Desempenho
+        total_chart_title: Latência total
     processes:
       index:
         cron_enabled: Agendamento ativado

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -260,15 +260,28 @@ ru:
         value: Значение
     performance:
       index:
-        average_duration: Средняя продолжительность
-        chart_title: Общее время выполнения в секундах
+        chart_title: Суммарная задержка выполнения в секундах
+        chart_title_queue: Средняя задержка в очереди в секундах
+        chart_title_total: Средняя общая задержка в секундах
+        execution_latency: Задержка выполнения
         executions: Выполнения
         job_class: Класс задачи
-        maximum_duration: Максимальная продолжительность
-        minimum_duration: Минимальная продолжительность
+        jobs: Задачи
         no_executions: Нет выполнений за этот период.
+        queue_latency: Задержка в очереди
         queue_name: Название очереди
         title: Производительность
+        total_latency: Общая задержка
+      latency:
+        average: сред
+        maximum: макс
+        minimum: мин
+      metric:
+        chart_metric: Метрика графика
+        metric_options:
+          execution: Задержка выполнения
+          queue: Задержка в очереди
+          total: Общая задержка
       range:
         bucket_size:
           days: "%{count} д"
@@ -293,8 +306,11 @@ ru:
         time_range: Диапазон времени производительности
         time_zone: 'Часовой пояс:'
       show:
+        execution_chart_title: Задержка выполнения
+        queue_chart_title: Задержка в очереди
         slow: Медленно
         title: Производительность
+        total_chart_title: Общая задержка
     processes:
       index:
         cron_enabled: Cron включен

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -234,15 +234,28 @@ tr:
         value: Değer
     performance:
       index:
-        average_duration: Ortalama süre
-        chart_title: Toplam yürütme süresi (saniye)
+        chart_title: Toplam yürütme gecikmesi (saniye)
+        chart_title_queue: Ortalama kuyruk gecikmesi (saniye)
+        chart_title_total: Ortalama toplam gecikme (saniye)
+        execution_latency: Yürütme gecikmesi
         executions: Yürütmeler
         job_class: İş sınıfı
-        maximum_duration: Maksimum süre
-        minimum_duration: Minimum süre
+        jobs: İşler
         no_executions: Bu zaman aralığında yürütme yok.
+        queue_latency: Kuyruk gecikmesi
         queue_name: Kuyruk adı
         title: Performans
+        total_latency: Toplam gecikme
+      latency:
+        average: ort
+        maximum: maks
+        minimum: min
+      metric:
+        chart_metric: Grafik metriği
+        metric_options:
+          execution: Yürütme gecikmesi
+          queue: Kuyruk gecikmesi
+          total: Toplam gecikme
       range:
         bucket_size:
           days: "%{count}g"
@@ -267,8 +280,11 @@ tr:
         time_range: Performans zaman aralığı
         time_zone: 'Saat dilimi:'
       show:
+        execution_chart_title: Yürütme gecikmesi
+        queue_chart_title: Kuyruk gecikmesi
         slow: Yavaş
         title: Performans
+        total_chart_title: Toplam gecikme
     processes:
       index:
         cron_enabled: Cron etkin

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -260,15 +260,28 @@ uk:
         value: Значення
     performance:
       index:
-        average_duration: Середня тривалість
-        chart_title: Загальний час виконання в секундах
+        chart_title: Сумарна затримка виконання в секундах
+        chart_title_queue: Середня затримка в черзі в секундах
+        chart_title_total: Середня загальна затримка в секундах
+        execution_latency: Затримка виконання
         executions: Виконання
         job_class: Клас завдання
-        maximum_duration: Максимальна тривалість
-        minimum_duration: Мінімальна тривалість
+        jobs: Завдання
         no_executions: Немає виконань за цей період.
+        queue_latency: Затримка в черзі
         queue_name: Назва черги
         title: Продуктивність
+        total_latency: Загальна затримка
+      latency:
+        average: сер
+        maximum: макс
+        minimum: мін
+      metric:
+        chart_metric: Метрика графіка
+        metric_options:
+          execution: Затримка виконання
+          queue: Затримка в черзі
+          total: Загальна затримка
       range:
         bucket_size:
           days: "%{count} д"
@@ -293,8 +306,11 @@ uk:
         time_range: Часовий діапазон продуктивності
         time_zone: 'Часовий пояс:'
       show:
+        execution_chart_title: Затримка виконання
+        queue_chart_title: Затримка в черзі
         slow: Повільно
         title: Продуктивність
+        total_chart_title: Загальна затримка
     processes:
       index:
         cron_enabled: Cron увімкнено

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -234,15 +234,28 @@ zh-CN:
         value: 值
     performance:
       index:
-        average_duration: 平均时长
-        chart_title: 任务总执行时间（秒）
+        chart_title: 任务执行延迟总和（秒）
+        chart_title_queue: 任务平均排队延迟（秒）
+        chart_title_total: 任务平均总延迟（秒）
+        execution_latency: 执行延迟
         executions: 执行次数
         job_class: 任务 Class
-        maximum_duration: 最大时长
-        minimum_duration: 最小时长
+        jobs: 任务数
         no_executions: 此时间范围内没有执行记录。
+        queue_latency: 排队延迟
         queue_name: 队列名称
         title: 性能
+        total_latency: 总延迟
+      latency:
+        average: 平均
+        maximum: 最大
+        minimum: 最小
+      metric:
+        chart_metric: 图表指标
+        metric_options:
+          execution: 执行延迟
+          queue: 排队延迟
+          total: 总延迟
       range:
         bucket_size:
           days: "%{count}天"
@@ -267,8 +280,11 @@ zh-CN:
         time_range: 性能时间范围
         time_zone: 时区：
       show:
+        execution_chart_title: 执行延迟
+        queue_chart_title: 排队延迟
         slow: 慢
         title: 性能
+        total_chart_title: 总延迟
     processes:
       index:
         cron_enabled: 定时任务已启用

--- a/spec/app/charts/good_job/latency_metric_spec.rb
+++ b/spec/app/charts/good_job/latency_metric_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoodJob::LatencyMetric do
+  describe ".from_params" do
+    it "selects a metric by its key" do
+      expect(described_class.from_params(chart: "queue")).to be_a(described_class::Queue)
+      expect(described_class.from_params(chart: "execution")).to be_a(described_class::Execution)
+    end
+
+    it "reads the key out of request parameters, which arrive string-keyed" do
+      params = ActionController::Parameters.new("chart" => "queue")
+
+      expect(described_class.from_params(params)).to be_a(described_class::Queue)
+    end
+
+    it "falls back to the default for unrecognized, non-scalar, and blank input" do
+      [
+        { chart: "unknown" },
+        { chart: ["queue"] },
+        { chart: { value: "queue" } },
+        { chart: "" },
+        { chart: nil },
+        {},
+      ].each do |params|
+        expect(described_class.from_params(params)).to be_a(described_class::Execution)
+      end
+    end
+  end
+
+  describe ".options" do
+    it "lists every metric in toggle order, starting with the default" do
+      expect(described_class.options.map(&:key)).to eq(%i[execution queue total])
+      expect(described_class.options.map(&:key).first).to eq(described_class.default.key)
+    end
+  end
+
+  describe ".table_aggregates_sql" do
+    it "selects job and execution counts plus avg/min/max of queue, execution and total latency" do
+      expect(described_class.table_aggregates_sql).to eq(
+        "COUNT(DISTINCT active_job_id) AS jobs_count, COUNT(*) AS executions_count, " \
+        "AVG((created_at - scheduled_at)) AS avg_queue, MIN((created_at - scheduled_at)) AS min_queue, " \
+        "MAX((created_at - scheduled_at)) AS max_queue, " \
+        "AVG(duration) AS avg_execution, MIN(duration) AS min_execution, MAX(duration) AS max_execution, " \
+        "AVG(((created_at - scheduled_at) + duration)) AS avg_total, " \
+        "MIN(((created_at - scheduled_at) + duration)) AS min_total, " \
+        "MAX(((created_at - scheduled_at) + duration)) AS max_total"
+      )
+    end
+  end
+
+  describe described_class::Total do
+    subject(:metric) { described_class.new }
+
+    it "averages the queue wait plus the run time" do
+      expect(metric.key).to eq(:total)
+      expect(metric.expression).to eq("((created_at - scheduled_at) + duration)")
+      expect(metric.aggregate).to eq("AVG")
+      expect(metric.presence_sql).to eq("scheduled_at IS NOT NULL AND duration IS NOT NULL")
+    end
+
+    it "leaves an empty bucket as a spanned gap rather than claiming zero time" do
+      expect(metric.empty_value).to be_nil
+      expect(metric).to be_span_gaps
+    end
+
+    it "names itself in navigation URLs" do
+      expect(metric.to_params).to eq(chart: "total")
+    end
+
+    it "titles the charts for total time" do
+      expect(metric.chart_title).to eq("Average total latency in seconds")
+      expect(metric.histogram_title).to eq("Total latency")
+    end
+
+    it "measures Execution#queue_latency plus #runtime_latency, and nothing while still running" do
+      scheduled_at = Time.zone.parse("2024-01-01 10:00:00 UTC")
+      execution = GoodJob::Execution.create!(
+        active_job_id: SecureRandom.uuid,
+        created_at: scheduled_at + 30.seconds,
+        duration: 1.second,
+        job_class: "ExampleJob",
+        queue_name: "default",
+        scheduled_at: scheduled_at,
+        serialized_params: {},
+        updated_at: scheduled_at
+      )
+      measure = lambda do
+        GoodJob::Execution
+          .where(id: execution.id)
+          .pick(metric.to_arel.as("total"))
+      end
+
+      expect(measure.call).to eq(execution.queue_latency + execution.runtime_latency)
+      expect(measure.call).to eq(31.seconds)
+
+      execution.update!(duration: nil)
+
+      expect(measure.call).to be_nil
+    end
+  end
+
+  describe described_class::Execution do
+    subject(:metric) { described_class.new }
+
+    it "sums monotonic runtime" do
+      expect(metric.key).to eq(:execution)
+      expect(metric.expression).to eq("duration")
+      expect(metric.to_arel).to be_a(Arel::Nodes::SqlLiteral).and eq("duration")
+      expect(metric.aggregate).to eq("SUM")
+      expect(metric.presence_sql).to eq("duration IS NOT NULL")
+    end
+
+    it "treats an empty bucket as zero work and needs no gap spanning" do
+      expect(metric.empty_value).to eq(0)
+      expect(metric).not_to be_span_gaps
+    end
+
+    it "stays out of navigation URLs as the default metric" do
+      expect(metric.to_params).to eq({})
+    end
+
+    it "titles the charts for execution time" do
+      expect(metric.chart_title).to eq("Total execution latency in seconds")
+      expect(metric.histogram_title).to eq("Execution latency")
+    end
+  end
+
+  describe described_class::Queue do
+    subject(:metric) { described_class.new }
+
+    it "averages the wait between scheduling and performing" do
+      expect(metric.key).to eq(:queue)
+      expect(metric.expression).to eq("(created_at - scheduled_at)")
+      expect(metric.aggregate).to eq("AVG")
+      expect(metric.presence_sql).to eq("scheduled_at IS NOT NULL")
+    end
+
+    it "leaves an empty bucket as a spanned gap rather than claiming zero wait" do
+      expect(metric.empty_value).to be_nil
+      expect(metric).to be_span_gaps
+    end
+
+    it "names itself in navigation URLs" do
+      expect(metric.to_params).to eq(chart: "queue")
+    end
+
+    it "titles the charts for queue time" do
+      expect(metric.chart_title).to eq("Average queue latency in seconds")
+      expect(metric.histogram_title).to eq("Queue latency")
+    end
+
+    it "resolves titles in the request locale" do
+      I18n.with_locale(:de) do
+        expect(metric.chart_title).to eq("Durchschnittliche Warteschlangenlatenz in Sekunden")
+        expect(metric.histogram_title).to eq("Warteschlangenlatenz")
+      end
+    end
+
+    it "measures the same quantity as Execution#queue_latency" do
+      scheduled_at = Time.zone.parse("2024-01-01 10:00:00 UTC")
+      execution = GoodJob::Execution.create!(
+        active_job_id: SecureRandom.uuid,
+        created_at: scheduled_at + 30.seconds,
+        duration: 1.second,
+        job_class: "ExampleJob",
+        queue_name: "default",
+        scheduled_at: scheduled_at,
+        serialized_params: {},
+        updated_at: scheduled_at
+      )
+
+      measured = GoodJob::Execution
+                 .where(id: execution.id)
+                 .pick(metric.to_arel.as("queue"))
+
+      expect(measured).to eq(execution.queue_latency)
+      expect(measured).to eq(30.seconds)
+    end
+  end
+end

--- a/spec/app/charts/good_job/performance_index_chart_spec.rb
+++ b/spec/app/charts/good_job/performance_index_chart_spec.rb
@@ -3,10 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe GoodJob::PerformanceIndexChart do
-  subject(:chart) { described_class.new(range) }
+  subject(:chart) { described_class.new(range, metric) }
 
   let(:range) { GoodJob::PerformanceRange.new(params) }
   let(:params) { {} }
+  let(:metric) { GoodJob::LatencyMetric.default }
 
   describe "#data" do
     around do |example|
@@ -63,6 +64,58 @@ RSpec.describe GoodJob::PerformanceIndexChart do
         expect(data.dig(:goodJob, :timestamps).first).to eq("2024-01-01T10:00:00Z")
         expect(data.dig(:goodJob, :timestamps).last).to eq("2024-01-01T11:05:00Z")
         expect(data.dig(:data, :labels).count).to eq(14)
+      end
+    end
+
+    context "with the queue time metric" do
+      let(:params) do
+        {
+          chart_start: "2024-01-01T10:00:00Z",
+          chart_end: "2024-01-01T11:00:00Z",
+        }
+      end
+      let(:metric) { GoodJob::LatencyMetric::Queue.new }
+
+      before do
+        # Both land in the leading two-minute bucket, so the bucket averages to 15s.
+        create_execution(job_class: "ExampleJob", scheduled_at: range.start_time, queue_time: 10.seconds)
+        create_execution(job_class: "ExampleJob", scheduled_at: range.start_time + 1.minute, queue_time: 20.seconds)
+      end
+
+      it "averages the wait per bucket and leaves bucketless time as a gap" do
+        data = chart.data
+        series = data.dig(:data, :datasets, 0, :data)
+
+        expect(data.dig(:options, :plugins, :title, :text)).to eq("Average queue latency in seconds")
+        expect(series.first).to eq(15.0)
+        # nil rather than 0: no executions is not the same as no waiting.
+        expect(series.compact).to eq([15.0])
+        expect(series.drop(1)).to all(be_nil)
+      end
+
+      it "draws a continuous line across the gaps" do
+        expect(chart.data.dig(:data, :datasets, 0, :spanGaps)).to be(true)
+      end
+
+      it "averages wait plus runtime when the total latency metric is selected" do
+        data = described_class.new(range, GoodJob::LatencyMetric::Total.new).data
+        series = data.dig(:data, :datasets, 0, :data)
+
+        expect(data.dig(:options, :plugins, :title, :text)).to eq("Average total latency in seconds")
+        # The 15s average wait plus the 1s each execution ran.
+        expect(series.first).to eq(16.0)
+        expect(series.drop(1)).to all(be_nil)
+        expect(data.dig(:data, :datasets, 0, :spanGaps)).to be(true)
+      end
+
+      it "still sums seconds when the duration metric is selected" do
+        data = described_class.new(range, GoodJob::LatencyMetric::Execution.new).data
+        series = data.dig(:data, :datasets, 0, :data)
+
+        expect(series.first).to eq(2.0)
+        expect(series.drop(1)).to all(eq(0))
+        # A summed series has no gaps to span.
+        expect(data.dig(:data, :datasets, 0, :spanGaps)).to be(false)
       end
     end
 
@@ -163,10 +216,10 @@ RSpec.describe GoodJob::PerformanceIndexChart do
     end
   end
 
-  def create_execution(job_class:, scheduled_at:)
+  def create_execution(job_class:, scheduled_at:, queue_time: 0)
     GoodJob::Execution.create!(
       active_job_id: SecureRandom.uuid,
-      created_at: scheduled_at,
+      created_at: scheduled_at + queue_time,
       duration: 1.second,
       job_class: job_class,
       queue_name: "default",

--- a/spec/app/charts/good_job/performance_show_chart_spec.rb
+++ b/spec/app/charts/good_job/performance_show_chart_spec.rb
@@ -20,12 +20,34 @@ RSpec.describe GoodJob::PerformanceShowChart do
 
       expect(data.dig(:data, :datasets, 0, :data).sum).to eq(2)
     end
+
+    it "buckets each metric on its own measurement" do
+      range = GoodJob::PerformanceRange.new(
+        chart_start: "2024-01-01T10:03:17Z",
+        chart_end: "2024-01-01T11:07:42Z"
+      )
+
+      # 1s of runtime after a 12s wait: 1s, 12s and their 13s total each fall in a
+      # different bucket, so the three histograms cannot coincide.
+      create_execution(job_class: "ExampleJob", scheduled_at: range.start_time, queue_time: 12.seconds)
+
+      histograms = GoodJob::LatencyMetric.options.to_h do |metric|
+        [metric.key, described_class.new("ExampleJob", range, metric).data]
+      end
+      buckets = histograms.transform_values do |data|
+        data.dig(:data, :labels)[data.dig(:data, :datasets, 0, :data).index(1)]
+      end
+
+      expect(histograms.transform_values { |data| data.dig(:options, :plugins, :title, :text) })
+        .to eq(execution: "Execution latency", queue: "Queue latency", total: "Total latency")
+      expect(buckets).to eq(execution: "1.1s", queue: "13s", total: "20s")
+    end
   end
 
-  def create_execution(job_class:, scheduled_at:)
+  def create_execution(job_class:, scheduled_at:, queue_time: 0)
     GoodJob::Execution.create!(
       active_job_id: SecureRandom.uuid,
-      created_at: scheduled_at,
+      created_at: scheduled_at + queue_time,
       duration: 1.second,
       job_class: job_class,
       queue_name: "default",

--- a/spec/app/controllers/good_job/performance_controller_spec.rb
+++ b/spec/app/controllers/good_job/performance_controller_spec.rb
@@ -40,6 +40,101 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
       expect(chart_data.dig(:data, :datasets).pluck(:label)).to contain_exactly("AtStart", "BeforeEnd")
     end
 
+    it "reports jobs, executions, and queue, execution and total latency in both tables" do
+      scheduled_at = Time.zone.parse("2024-01-01 10:30:00 UTC")
+      # One job retried once: two waits so no two aggregates coincide by accident, and a
+      # shared job id so the distinct job count differs from the execution count.
+      active_job_id = SecureRandom.uuid
+      create_execution(job_class: "SlowStart", queue_name: "slow-start", scheduled_at: scheduled_at, queue_time: 10.seconds, active_job_id: active_job_id)
+      create_execution(job_class: "SlowStart", queue_name: "slow-start", scheduled_at: scheduled_at, queue_time: 30.seconds, active_job_id: active_job_id)
+
+      get :index, params: {
+        chart_start: "2024-01-01T10:03:17Z",
+        chart_end: "2024-01-01T11:07:42Z",
+      }
+
+      performance = controller.instance_variable_get(:@performances).find { |row| row.job_class == "SlowStart" }
+      queue_performance = controller.instance_variable_get(:@queue_performances).find { |row| row.queue_name == "slow-start" }
+
+      expect(response).to have_http_status(:ok)
+      [performance, queue_performance].each do |row|
+        expect([row.jobs_count, row.executions_count]).to eq([1, 2])
+        expect([row.avg_queue, row.min_queue, row.max_queue]).to eq([20.seconds, 10.seconds, 30.seconds])
+        expect([row.avg_execution, row.min_execution, row.max_execution]).to eq([1.second, 1.second, 1.second])
+        expect([row.avg_total, row.min_total, row.max_total]).to eq([21.seconds, 11.seconds, 31.seconds])
+      end
+
+      page = Capybara.string(response.body)
+      expect(page).to have_css("[role='table']", count: 2)
+      ["Jobs", "Executions", "Queue latency", "Execution latency", "Total latency"].each do |label|
+        expect(page).to have_css("[role='table'] header", text: label, count: 2)
+      end
+      expect(page).to have_css("[role='row']", text: "SlowStart", count: 1)
+      row = page.find("[role='row']", text: "SlowStart")
+      expect(row).to have_css(".performance-name a", text: "SlowStart")
+      # Each cell carries its narrow-viewport label ahead of its values.
+      expect(row.text(normalize_ws: true)).to eq(
+        "SlowStart Jobs 1 Executions 2 " \
+        "Queue latency 20s avg 10s min 30s max " \
+        "Execution latency 1s avg 1s min 1s max " \
+        "Total latency 21s avg 11s min 31s max"
+      )
+    end
+
+    it "switches the chart metric while keeping the selected range" do
+      get :index, params: { chart_range: "1h", chart: "queue" }
+
+      chart_data = controller.instance_variable_get(:@chart_data)
+      page = Capybara.string(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(chart_data.dig(:options, :plugins, :title, :text)).to eq("Average queue latency in seconds")
+      expect(page).to have_link("Queue latency", href: performance_index_path(chart_range: "1h", chart: "queue", locale: nil))
+      expect(page).to have_link("Execution latency", href: performance_index_path(chart_range: "1h", locale: nil))
+      expect(page).to have_link("Total latency", href: performance_index_path(chart_range: "1h", chart: "total", locale: nil))
+      expect(page).to have_css("a.btn.active", text: "Queue latency")
+      # The range toolbar has to carry the metric or switching presets silently resets it.
+      expect(page.find("a.performance-range-reload")[:href]).to eq(
+        performance_index_path(chart_range: "1h", chart: "queue", locale: nil)
+      )
+    end
+
+    it "renders the duration chart for an unrecognized metric without echoing it back" do
+      get :index, params: { chart: "bogus" }
+
+      chart_data = controller.instance_variable_get(:@chart_data)
+
+      expect(response).to have_http_status(:ok)
+      expect(chart_data.dig(:options, :plugins, :title, :text)).to eq("Total execution latency in seconds")
+      expect(response.body).not_to include("bogus")
+    end
+
+    it "preserves the chart metric through a canonical range redirect" do
+      get :index, params: {
+        chart_start: "2024-01-01T10:03:17",
+        chart_end: "2024-01-01T11:07:42",
+        chart: "queue",
+      }
+
+      expect(response).to have_http_status(:redirect)
+      expect(Rack::Utils.parse_query(URI.parse(response.location).query)).to eq(
+        "chart_start" => "2024-01-01T10:03:17Z",
+        "chart_end" => "2024-01-01T11:07:42Z",
+        "chart" => "queue"
+      )
+    end
+
+    it "keeps the chart metric out of the job class drilldown links" do
+      get :index, params: { chart_range: "1h", chart: "queue" }
+
+      drilldown_query = Rack::Utils.parse_query(
+        URI.parse(Capybara.string(response.body).find(".performance-name a")[:href]).query
+      )
+
+      expect(response).to have_http_status(:ok)
+      expect(drilldown_query.keys).to contain_exactly("chart_range", "chart_start", "chart_end")
+    end
+
     it "renders explicit empty states when the selected range has no executions" do
       get :index, params: {
         chart_start: "2020-01-01T10:03:17Z",
@@ -47,7 +142,7 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
       }
 
       expect(response).to have_http_status(:ok)
-      expect(response.body.scan("No executions in this time range.").count).to eq(2)
+      expect(Capybara.string(response.body)).to have_css("[role='row']", text: "No executions in this time range.", count: 2)
     end
 
     it "canonicalizes native local values in the page timezone and then renders" do
@@ -243,6 +338,30 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
       expect(response.body).to include('Performance - ExampleJob')
     end
 
+    it "renders a separately titled histogram for every metric" do
+      scheduled_at = Time.zone.parse("2024-01-01 10:30:00 UTC")
+      GoodJob::Execution.find_by!(job_class: "ExampleJob")
+                        .update!(scheduled_at: scheduled_at, created_at: scheduled_at + 10.seconds)
+
+      get :show, params: {
+        id: "ExampleJob",
+        chart_start: "2024-01-01T10:03:17Z",
+        chart_end: "2024-01-01T11:07:42Z",
+      }
+
+      histograms = controller.instance_variable_get(:@charts)
+      page = Capybara.string(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(histograms.transform_values { |chart| chart.dig(:options, :plugins, :title, :text) })
+        .to eq(execution: "Execution latency", queue: "Queue latency", total: "Total latency")
+      histograms.each_value { |chart| expect(chart.dig(:data, :datasets, 0, :data).sum).to eq(1) }
+      # Distinct regions, or live polling would refresh the first chart repeatedly and never the rest.
+      %w[execution-chart queue-chart total-chart].each do |region|
+        expect(page).to have_css("[data-live-poll-region='#{region}'][data-chart-config-value]")
+      end
+    end
+
     it "raises a 404 when the job doesn't exist" do
       expect do
         get :show, params: { id: "Missing" }
@@ -259,7 +378,7 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
         chart_end: "2024-01-01T11:07:42Z",
       }
 
-      chart_data = controller.instance_variable_get(:@chart_data)
+      chart_data = controller.instance_variable_get(:@charts).fetch(:execution)
 
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Performance time range")
@@ -284,7 +403,7 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
       }
 
       range = controller.instance_variable_get(:@performance_range)
-      chart_data = controller.instance_variable_get(:@chart_data)
+      chart_data = controller.instance_variable_get(:@charts).fetch(:execution)
 
       expect(response).to have_http_status(:ok)
       expect(range.key).to eq("1h")
@@ -295,10 +414,10 @@ RSpec.describe GoodJob::PerformanceController, type: :controller do
     end
   end
 
-  def create_execution(job_class:, queue_name:, scheduled_at:)
+  def create_execution(job_class:, queue_name:, scheduled_at:, queue_time: 0, active_job_id: SecureRandom.uuid)
     GoodJob::Execution.create!(
-      active_job_id: SecureRandom.uuid,
-      created_at: scheduled_at,
+      active_job_id: active_job_id,
+      created_at: scheduled_at + queue_time,
       duration: 1.second,
       job_class: job_class,
       queue_name: queue_name,

--- a/spec/requests/good_job/performance_controller_spec.rb
+++ b/spec/requests/good_job/performance_controller_spec.rb
@@ -92,6 +92,46 @@ RSpec.describe GoodJob::PerformanceController do
     end
   end
 
+  describe "chart metric navigation" do
+    it "carries the metric across every range control on the index" do
+      get good_job.performance_index_path, params: { chart_range: "1h", chart: "queue", locale: "de" }
+
+      page = Capybara.string(response.body)
+      preset_paths = page.all("a.performance-range-menu-item").pluck(:href)
+      form_metric = page.find("form[data-controller='performance-range'] input[name='chart']", visible: :all)
+
+      expect(response).to have_http_status(:ok)
+      expect(preset_paths).to include(
+        good_job.performance_index_path(chart_range: "6h", chart: "queue", locale: "de")
+      )
+      expect(page.find("a.performance-range-reload")[:href]).to eq(
+        good_job.performance_index_path(chart_range: "1h", chart: "queue", locale: "de")
+      )
+      expect(Rack::Utils.parse_query(URI.parse(page.find("a.performance-range-custom")[:href]).query).keys)
+        .to contain_exactly("chart_start", "chart_end", "chart", "locale")
+      expect(form_metric[:value]).to eq("queue")
+    end
+
+    it "does not leak the metric into show, which renders both metrics" do
+      get good_job.performance_index_path, params: { chart_range: "1h", chart: "queue" }
+
+      drilldown_uri = URI.parse(Capybara.string(response.body).find(".performance-name a")[:href])
+
+      expect(Rack::Utils.parse_query(drilldown_uri.query).keys)
+        .to contain_exactly("chart_range", "chart_start", "chart_end")
+
+      get good_job.performance_path("ExampleJob"), params: { chart: "queue" }
+
+      page = Capybara.string(response.body)
+
+      expect(response).to have_http_status(:ok)
+      expect(page).to have_css("[data-live-poll-region='execution-chart']")
+      expect(page).to have_css("[data-live-poll-region='queue-chart']")
+      expect(page).to have_css("[data-live-poll-region='total-chart']")
+      expect(page).to have_no_css("form[data-controller='performance-range'] input[name='chart']", visible: :all)
+    end
+  end
+
   describe "unsafe timestamp input" do
     it "canonicalizes repeated scalar parameters once and renders without a query exception" do
       query_string = URI.encode_www_form([

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -28,6 +28,73 @@ describe 'Performance Page', :js do
     expect(page).to have_content 'ExampleJob'
   end
 
+  it 'switches the index chart between execution, queue, and total time' do
+    ExampleJob.perform_later
+    GoodJob.perform_inline
+
+    visit good_job.performance_index_path
+
+    # The table headers are uppercased by CSS, so assert on the rendered text.
+    expect(page).to have_content 'QUEUE LATENCY'
+    expect(chart_titles).to eq(["Total execution latency in seconds"])
+
+    click_link "Queue latency"
+    wait_for_turbo_load
+
+    # Anchored on the separator: `chart` is a prefix of chart_range/chart_start/chart_end.
+    expect(page).to have_current_path(/[?&]chart=queue/)
+    expect(page).to have_css("a.btn.active", text: "Queue latency")
+    expect(chart_titles).to eq(["Average queue latency in seconds"])
+
+    click_link "Total latency"
+    wait_for_turbo_load
+
+    expect(page).to have_current_path(/[?&]chart=total/)
+    expect(page).to have_css("a.btn.active", text: "Total latency")
+    expect(chart_titles).to eq(["Average total latency in seconds"])
+
+    click_link "Execution latency"
+    wait_for_turbo_load
+
+    expect(page).to have_no_current_path(/[?&]chart=/)
+    expect(page).to have_css("a.btn.active", text: "Execution latency")
+    expect(chart_titles).to eq(["Total execution latency in seconds"])
+  end
+
+  it 'keeps every performance column aligned with its header and labels cells on narrow viewports' do
+    ExampleJob.perform_later
+    GoodJob.perform_inline
+
+    visit good_job.performance_index_path
+
+    # The table headers are uppercased by CSS, so assert on the rendered text.
+    expect(page).to have_content 'TOTAL LATENCY'
+    expect(page).to have_no_css("[role='row'] .d-lg-none", text: "Total latency")
+    # The rows set `text-nowrap`, so an added column pushes the header onto a second
+    # line unless its label can wrap. Compare real geometry, not the grid arithmetic.
+    expect(misaligned_tables).to eq([])
+
+    with_narrow_viewport do
+      visit good_job.performance_index_path
+
+      # Narrow rows swap the uppercased header for a stacked inline label per cell.
+      expect(page).to have_css("[role='row'] .d-lg-none", text: "Total latency")
+      expect(page.evaluate_script("document.documentElement.scrollWidth > window.innerWidth")).to be(false)
+    end
+  end
+
+  it 'renders a histogram per metric on the show page' do
+    ExampleJob.perform_later
+    GoodJob.perform_inline
+
+    visit good_job.performance_index_path
+    click_link 'ExampleJob'
+    wait_for_turbo_load
+
+    expect(page).to have_css 'h2', text: 'Performance - ExampleJob'
+    expect(chart_titles).to eq(["Execution latency", "Queue latency", "Total latency"])
+  end
+
   it 'can select and reload a chart range on the index' do
     initial_time = Time.zone.parse("2024-01-01 12:34:56 UTC")
 
@@ -74,7 +141,7 @@ describe 'Performance Page', :js do
       ].each do |path|
         visit path
         initial_dates = all(".performance-range-date").map(&:text)
-        initial_chart_config = find("[data-chart-config-value]")["data-chart-config-value"]
+        initial_chart_configs = all("[data-chart-config-value]").map { |chart| chart["data-chart-config-value"] }
 
         click_button "Leistungszeiträume öffnen"
         find("a.performance-range-custom").click
@@ -83,7 +150,7 @@ describe 'Performance Page', :js do
         expect(query).to eq(exact_range.stringify_keys)
         expect(page).to have_css(".performance-range-key", text: "Benutzerdefiniert")
         expect(all(".performance-range-date").map(&:text)).to eq(initial_dates)
-        expect(find("[data-chart-config-value]")["data-chart-config-value"]).to eq(initial_chart_config)
+        expect(all("[data-chart-config-value]").map { |chart| chart["data-chart-config-value"] }).to eq(initial_chart_configs)
       end
     end
   end
@@ -816,7 +883,7 @@ describe 'Performance Page', :js do
       click_link 'ExampleJob'
 
       show_query = Rack::Utils.parse_query(URI.parse(page.current_url).query)
-      show_config = JSON.parse(find("[data-chart-config-value]")["data-chart-config-value"])
+      show_config = JSON.parse(find("[data-live-poll-region='execution-chart']")["data-chart-config-value"])
 
       expect(page).to have_css 'h2', text: 'Performance - ExampleJob'
       expect(show_query).to eq(expected_navigation)
@@ -830,6 +897,29 @@ describe 'Performance Page', :js do
       expect(page).to have_css(".performance-range-key", text: "24h")
       expect(all(".performance-range-date").map(&:text)).not_to eq(index_dates)
     end
+  end
+
+  def chart_titles
+    all("[data-chart-config-value]").map do |element|
+      JSON.parse(element["data-chart-config-value"]).dig("options", "plugins", "title", "text")
+    end
+  end
+
+  # Tables whose header cells do not start at the same offsets as their first body row,
+  # which is what a header wrapping onto a second line looks like geometrically.
+  def misaligned_tables
+    page.evaluate_script(<<~JAVASCRIPT)
+      Array.from(document.querySelectorAll("[role='table']")).flatMap((table) => {
+        const header = table.querySelector("header .row")
+        const body = table.querySelector("[role='row'] .row")
+        if (!header || !body) return []
+        const offsets = (row) => Array.from(row.children)
+          .map((cell) => Math.round(cell.getBoundingClientRect().left)).join(",")
+        const headerOffsets = offsets(header)
+        const bodyOffsets = offsets(body)
+        return headerOffsets === bodyOffsets ? [] : [`header ${headerOffsets} vs body ${bodyOffsets}`]
+      })
+    JAVASCRIPT
   end
 
   def contrast_ratio(foreground, background)


### PR DESCRIPTION
First attempt at implementing what we talked about in https://github.com/bensheldon/good_job/discussions/1804.

The Performance index tables gain a distinct job count and group each latency metric (queue, execution, total) into one cell that stacks its avg/min/max. Metrics live in `LatencyMetric` classes (`Execution`, `Queue`, `Total`) that supply the SQL expression, per-bucket aggregate, empty-bucket value, and titles; the index chart toggles between them and the show page renders one histogram per metric.

<img width="2800" height="2288" alt="performance04" src="https://github.com/user-attachments/assets/7d87b665-7848-4fa7-ac2f-1a0d355882a6" />

<img width="2800" height="1999" alt="ExampleJob" src="https://github.com/user-attachments/assets/46c87258-0fa1-4e63-8c07-9c04adff8e72" />

---

Let me know what you think!